### PR TITLE
[draft] AMP Phase 2: lambda formulation and solver options

### DIFF
--- a/plans/amp-completion/02-lambda-options.md
+++ b/plans/amp-completion/02-lambda-options.md
@@ -1,0 +1,17 @@
+# AMP Phase 2: Lambda Formulation and Solver Options
+
+Plan phases:
+- 4 Convex hull (lambda) formulation
+- 6 Alpine-compatible solver options
+
+Primary files:
+- `python/discopt/_jax/milp_relaxation.py`
+- `python/discopt/solvers/amp.py`
+- `python/discopt/solver.py`
+- `python/tests/test_amp.py`
+
+Exit criteria:
+- `convhull_formulation` can select between current McCormick and lambda relaxations.
+- AMP routes Alpine-style tuning parameters end-to-end.
+- `nlp3` shows a clear improvement with the lambda formulation.
+- Tests cover formulation validity, tighter bounds, and option pass-through.

--- a/python/discopt/_jax/discretization.py
+++ b/python/discopt/_jax/discretization.py
@@ -57,6 +57,8 @@ def initialize_partitions(
     lb: list[float],
     ub: list[float],
     n_init: int = 2,
+    scaling_factor: float = 10.0,
+    abs_width_tol: float = 1e-3,
 ) -> DiscretizationState:
     """Create n_init uniform intervals for each partition variable.
 
@@ -71,6 +73,10 @@ def initialize_partitions(
     n_init : int, default 2
         Number of initial intervals per variable.  n_init=2 gives 3 breakpoints:
         [lb, midpoint, ub].
+    scaling_factor : float, default 10.0
+        Refinement ratio stored on the returned state.
+    abs_width_tol : float, default 1e-3
+        Convergence tolerance stored on the returned state.
 
     Returns
     -------
@@ -80,7 +86,11 @@ def initialize_partitions(
     partitions: dict[int, np.ndarray] = {}
     for k, v_idx in enumerate(var_indices):
         partitions[v_idx] = np.linspace(float(lb[k]), float(ub[k]), n_init + 1)
-    return DiscretizationState(partitions=partitions)
+    return DiscretizationState(
+        partitions=partitions,
+        scaling_factor=float(scaling_factor),
+        abs_width_tol=float(abs_width_tol),
+    )
 
 
 def add_adaptive_partition(
@@ -160,6 +170,41 @@ def add_adaptive_partition(
         if candidates:
             merged = np.sort(np.unique(np.concatenate([pts, candidates])))
             new_partitions[v_idx] = merged
+
+    return DiscretizationState(
+        partitions=new_partitions,
+        scaling_factor=state.scaling_factor,
+        abs_width_tol=state.abs_width_tol,
+    )
+
+
+def add_uniform_partition(
+    state: DiscretizationState,
+    solution: dict[int, float],
+    var_indices: list[int],
+    lb: list[float],
+    ub: list[float],
+) -> DiscretizationState:
+    """Uniformly refine every current interval for the selected variables.
+
+    Unlike adaptive refinement, this does not use the current solution value.
+    Each interval is split at its midpoint, preserving all existing breakpoints.
+    """
+    del solution  # uniform refinement is solution-agnostic
+
+    new_partitions = {k: v.copy() for k, v in state.partitions.items()}
+
+    for k, v_idx in enumerate(var_indices):
+        if v_idx not in new_partitions:
+            new_partitions[v_idx] = np.linspace(float(lb[k]), float(ub[k]), 3)
+
+        pts = new_partitions[v_idx]
+        if len(pts) < 2:
+            continue
+
+        mids = 0.5 * (pts[:-1] + pts[1:])
+        merged = np.sort(np.unique(np.concatenate([pts, mids])))
+        new_partitions[v_idx] = merged
 
     return DiscretizationState(
         partitions=new_partitions,

--- a/python/discopt/_jax/discretization.py
+++ b/python/discopt/_jax/discretization.py
@@ -180,7 +180,7 @@ def add_adaptive_partition(
 
 def add_uniform_partition(
     state: DiscretizationState,
-    solution: dict[int, float],
+    _solution: dict[int, float],
     var_indices: list[int],
     lb: list[float],
     ub: list[float],
@@ -190,8 +190,6 @@ def add_uniform_partition(
     Unlike adaptive refinement, this does not use the current solution value.
     Each interval is split at its midpoint, preserving all existing breakpoints.
     """
-    del solution  # uniform refinement is solution-agnostic
-
     new_partitions = {k: v.copy() for k, v in state.partitions.items()}
 
     for k, v_idx in enumerate(var_indices):

--- a/python/discopt/_jax/milp_relaxation.py
+++ b/python/discopt/_jax/milp_relaxation.py
@@ -168,9 +168,7 @@ def _normalize_convhull_formulation(formulation: str) -> str:
 # ---------------------------------------------------------------------------
 
 
-def _decompose_product(
-    expr: Expression, model: Model
-) -> tuple[float, list[int]] | None:
+def _decompose_product(expr: Expression, model: Model) -> tuple[float, list[int]] | None:
     """Decompose a product expression into (scalar, [flat_var_idx, ...]).
 
     Returns None if expr contains non-constant, non-variable leaves.
@@ -301,9 +299,7 @@ def _linearize_expr(
                         raise ValueError(f"Monomial {key} not in map")
                 elif len(unique) == 2:
                     if len(unique) != len(indices):
-                        raise ValueError(
-                            "Mixed repeated-factor products are not supported"
-                        )
+                        raise ValueError("Mixed repeated-factor products are not supported")
                     i_idx, j_idx = unique[0], unique[1]
                     key = (min(i_idx, j_idx), max(i_idx, j_idx))
                     if key in bilinear_var_map:
@@ -311,9 +307,7 @@ def _linearize_expr(
                     else:
                         raise ValueError(f"Bilinear {key} not in map")
                 else:
-                    raise ValueError(
-                        f"Higher-order product ({len(unique)} vars) not supported"
-                    )
+                    raise ValueError(f"Higher-order product ({len(unique)} vars) not supported")
 
             else:
                 raise ValueError(f"Cannot linearize BinaryOp: {e.op}")
@@ -404,9 +398,7 @@ def build_milp_relaxation(
     monomial_var_map: dict[tuple[int, int], int] = {}
 
     col_idx = n_orig
-    all_bounds: list[tuple[float, float]] = list(
-        zip(flat_lb.tolist(), flat_ub.tolist())
-    )
+    all_bounds: list[tuple[float, float]] = list(zip(flat_lb.tolist(), flat_ub.tolist()))
     integrality_flags: list[int] = []
     for v in model._variables:
         flag = 1 if v.var_type in (VarType.BINARY, VarType.INTEGER) else 0
@@ -678,7 +670,7 @@ def build_milp_relaxation(
             row_recon[part_var] = 1.0
             for _, xbar_col, _, _, _ in intervals:
                 row_recon[xbar_col] = -1.0
-            _add_row(row_recon, 0.0)   # x_part - Σ x̄_k ≤ 0
+            _add_row(row_recon, 0.0)  # x_part - Σ x̄_k ≤ 0
             _add_row(-row_recon, 0.0)  # -(x_part - Σ x̄_k) ≤ 0
 
             # Constraint: w = Σ w̄_k
@@ -733,7 +725,7 @@ def build_milp_relaxation(
                 row[wbar_col] = -1.0
                 row[other_var] += a_k
                 row[xbar_col] += yj_lb
-                row[delta_col] = M_k   # +M_k so constraint loosens when δ_k=0
+                row[delta_col] = M_k  # +M_k so constraint loosens when δ_k=0
                 _add_row(row, a_k * yj_lb + M_k)
 
                 # cv2: w̄_k ≥ b_k*y + x̄_k*y_ub - b_k*y_ub - M*(1-δ_k)
@@ -751,7 +743,7 @@ def build_milp_relaxation(
                 row[wbar_col] = 1.0
                 row[other_var] -= b_k
                 row[xbar_col] -= yj_lb
-                row[delta_col] = M_k   # +M_k so constraint loosens when δ_k=0
+                row[delta_col] = M_k  # +M_k so constraint loosens when δ_k=0
                 _add_row(row, M_k - b_k * yj_lb)
 
                 # cc2: w̄_k ≤ a_k*y + x̄_k*y_ub - a_k*y_ub + M*(1-δ_k)
@@ -853,9 +845,7 @@ def build_milp_relaxation(
         body = constraint.body  # normalized: body <= 0  (sense is always "<=")
         sense = constraint.sense
         try:
-            c, const = _linearize_expr(
-                body, model, bilinear_var_map, monomial_var_map, n_total
-            )
+            c, const = _linearize_expr(body, model, bilinear_var_map, monomial_var_map, n_total)
             # body ≤ 0  →  c @ z + const ≤ 0  →  c @ z ≤ -const
             if sense == "<=":
                 _add_row(c, -const)
@@ -875,10 +865,11 @@ def build_milp_relaxation(
     if oa_cuts:
         for coeff, rhs in oa_cuts:
             row = np.zeros(n_total)
-            row[:len(coeff)] = coeff[:n_total if len(coeff) > n_total else len(coeff)]
+            row[: len(coeff)] = coeff[: n_total if len(coeff) > n_total else len(coeff)]
             _add_row(row, rhs)
 
     # ── Objective ────────────────────────────────────────────────────────────
+    assert model._objective is not None
     obj_expr = model._objective.expression
     try:
         c_obj, const_obj = _linearize_expr(

--- a/python/discopt/_jax/milp_relaxation.py
+++ b/python/discopt/_jax/milp_relaxation.py
@@ -21,7 +21,7 @@ Theory: Nagarajan et al., JOGO 2018, Section 4 (piecewise McCormick relaxation).
 from __future__ import annotations
 
 import logging
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from typing import Optional, Union
 
 import numpy as np
@@ -31,7 +31,6 @@ from discopt._jax.discretization import DiscretizationState
 from discopt._jax.model_utils import flat_variable_bounds
 from discopt._jax.term_classifier import (
     NonlinearTerms,
-    _collect_product_factors,
     _compute_var_offset,
     _get_flat_index,
 )
@@ -45,8 +44,8 @@ from discopt.modeling.core import (
     SumExpression,
     SumOverExpression,
     UnaryOp,
-    VarType,
     Variable,
+    VarType,
 )
 
 logger = logging.getLogger(__name__)
@@ -144,6 +143,24 @@ def _compute_piecewise_big_m(corners: list[float]) -> float:
     """Scale Big-M with the interval magnitude instead of adding a flat constant."""
     max_corner = max(abs(float(c)) for c in corners)
     return max_corner * (1.0 + 1e-4) + max(1e-6, 1e-4 * max_corner)
+
+
+def _normalize_convhull_formulation(formulation: str) -> str:
+    """Normalize accepted bilinear convex-hull mode names."""
+    aliases = {
+        "disaggregated": "disaggregated",
+        "piecewise": "disaggregated",
+        "sos2": "sos2",
+        "facet": "facet",
+        "lambda": "sos2",
+    }
+    try:
+        return aliases[formulation]
+    except KeyError as err:
+        raise ValueError(
+            f"Unsupported convhull_formulation: {formulation!r}. "
+            "Choose from 'disaggregated', 'sos2', 'facet', or 'lambda'."
+        ) from err
 
 
 # ---------------------------------------------------------------------------
@@ -338,6 +355,7 @@ def build_milp_relaxation(
     disc_state: DiscretizationState,
     incumbent: Optional[np.ndarray] = None,
     oa_cuts: Optional[list] = None,
+    convhull_formulation: str = "disaggregated",
 ) -> tuple["MilpRelaxationModel", dict]:
     """Build a MILP relaxation with piecewise McCormick for bilinear/monomial terms.
 
@@ -364,6 +382,10 @@ def build_milp_relaxation(
     incumbent : np.ndarray, optional
         Current best NLP solution (flat).  Used to add OA tangent cuts for
         general nonlinear terms; currently unused (reserved for future use).
+    convhull_formulation : str, default "disaggregated"
+        Piecewise bilinear formulation. ``"disaggregated"`` keeps the existing
+        xbar/wbar construction; ``"sos2"`` and ``"facet"`` use a λ-based
+        convex-hull reformulation similar to Alpine.jl.
 
     Returns
     -------
@@ -373,6 +395,7 @@ def build_milp_relaxation(
     """
     flat_lb, flat_ub = flat_variable_bounds(model)
     n_orig = len(flat_lb)
+    convhull_mode = _normalize_convhull_formulation(convhull_formulation)
 
     # ── Assign MILP column indices ──────────────────────────────────────────
     # Layout: [original vars 0..n_orig-1] [bilinear aux w_ij] [monomial aux s_i^n]
@@ -418,6 +441,7 @@ def build_milp_relaxation(
     #     w̄_k  ∈ [wi_lo, wi_hi] — bilinear product within interval k (0 outside)
     # bilinear_pw_map[(i,j)] = [(delta_col, xbar_col, wbar_col, a_k, b_k), ...]
     bilinear_pw_map: dict[tuple[int, int], list] = {}
+    bilinear_lambda_map: dict[tuple[int, int], dict] = {}
 
     for i, j in terms.bilinear:
         # Choose which variable to partition: prefer the one in disc_state
@@ -432,40 +456,76 @@ def build_milp_relaxation(
         xj_lb_g = float(flat_lb[other_var])
         xj_ub_g = float(flat_ub[other_var])
 
-        intervals = []
-        for k in range(len(pts) - 1):
-            a_k = float(pts[k])
-            b_k = float(pts[k + 1])
+        if convhull_mode == "disaggregated":
+            intervals = []
+            for k in range(len(pts) - 1):
+                a_k = float(pts[k])
+                b_k = float(pts[k + 1])
 
-            # Big-M for bilinear product within this interval
-            _, wk_lo, wk_hi = _piecewise_product_bounds(
-                a_k,
-                b_k,
-                xj_lb_g,
-                xj_ub_g,
-            )
+                # Big-M for bilinear product within this interval
+                _, wk_lo, wk_hi = _piecewise_product_bounds(
+                    a_k,
+                    b_k,
+                    xj_lb_g,
+                    xj_ub_g,
+                )
 
-            # δ_k ∈ {0,1}
-            delta_col = col_idx
-            all_bounds.append((0.0, 1.0))
-            integrality_flags.append(1)
-            col_idx += 1
+                # δ_k ∈ {0,1}
+                delta_col = col_idx
+                all_bounds.append((0.0, 1.0))
+                integrality_flags.append(1)
+                col_idx += 1
 
-            # x̄_k ∈ [0, max(|a_k|, |b_k|)]  (0 when δ_k=0)
-            xbar_col = col_idx
-            all_bounds.append((min(a_k, 0.0), max(abs(a_k), abs(b_k))))
-            integrality_flags.append(0)
-            col_idx += 1
+                # x̄_k ∈ [0, max(|a_k|, |b_k|)]  (0 when δ_k=0)
+                xbar_col = col_idx
+                all_bounds.append((min(a_k, 0.0), max(abs(a_k), abs(b_k))))
+                integrality_flags.append(0)
+                col_idx += 1
 
-            # w̄_k ∈ [wk_lo, wk_hi]  (0 when δ_k=0)
-            wbar_col = col_idx
-            all_bounds.append((min(wk_lo, 0.0), max(wk_hi, 0.0)))
-            integrality_flags.append(0)
-            col_idx += 1
+                # w̄_k ∈ [wk_lo, wk_hi]  (0 when δ_k=0)
+                wbar_col = col_idx
+                all_bounds.append((min(wk_lo, 0.0), max(wk_hi, 0.0)))
+                integrality_flags.append(0)
+                col_idx += 1
 
-            intervals.append((delta_col, xbar_col, wbar_col, a_k, b_k))
+                intervals.append((delta_col, xbar_col, wbar_col, a_k, b_k))
 
-        bilinear_pw_map[(i, j)] = intervals
+            bilinear_pw_map[(i, j)] = intervals
+        else:
+            breakpoints = [float(p) for p in pts]
+            lambda_cols: list[int] = []
+            alpha_cols: list[int] = []
+            theta_cols: list[int] = []
+            theta_lb = min(0.0, xj_lb_g, xj_ub_g)
+            theta_ub = max(0.0, xj_lb_g, xj_ub_g)
+
+            for _ in breakpoints:
+                lambda_cols.append(col_idx)
+                all_bounds.append((0.0, 1.0))
+                integrality_flags.append(0)
+                col_idx += 1
+
+            for _ in range(len(breakpoints) - 1):
+                alpha_cols.append(col_idx)
+                all_bounds.append((0.0, 1.0))
+                integrality_flags.append(1)
+                col_idx += 1
+
+            for _ in breakpoints:
+                theta_cols.append(col_idx)
+                all_bounds.append((theta_lb, theta_ub))
+                integrality_flags.append(0)
+                col_idx += 1
+
+            bilinear_lambda_map[(i, j)] = {
+                "part_var": part_var,
+                "other_var": other_var,
+                "breakpoints": breakpoints,
+                "lambda_cols": lambda_cols,
+                "alpha_cols": alpha_cols,
+                "theta_cols": theta_cols,
+                "mode": convhull_mode,
+            }
 
     # Also store in a form keyed by (part_var, other_var) for reference
     # (not needed separately; we use bilinear_pw_map[(i,j)] directly)
@@ -496,7 +556,103 @@ def build_milp_relaxation(
         xj_ub_g = float(flat_ub[j])
         w_col = bilinear_var_map[(i, j)]
 
-        if (i, j) in bilinear_pw_map and bilinear_pw_map[(i, j)]:
+        if (i, j) in bilinear_lambda_map:
+            lambda_info = bilinear_lambda_map[(i, j)]
+            part_var = int(lambda_info["part_var"])
+            other_var = int(lambda_info["other_var"])
+            breakpoints = list(lambda_info["breakpoints"])
+            lambda_cols = list(lambda_info["lambda_cols"])
+            alpha_cols = list(lambda_info["alpha_cols"])
+            theta_cols = list(lambda_info["theta_cols"])
+            mode = str(lambda_info["mode"])
+            yj_lb = float(flat_lb[other_var])
+            yj_ub = float(flat_ub[other_var])
+
+            row_sum_lambda = np.zeros(n_total)
+            for lambda_col in lambda_cols:
+                row_sum_lambda[lambda_col] = -1.0
+            _add_row(row_sum_lambda, -1.0)
+            _add_row(-row_sum_lambda, 1.0)
+
+            row_sum_alpha = np.zeros(n_total)
+            for alpha_col in alpha_cols:
+                row_sum_alpha[alpha_col] = -1.0
+            _add_row(row_sum_alpha, -1.0)
+            _add_row(-row_sum_alpha, 1.0)
+
+            row_x = np.zeros(n_total)
+            row_x[part_var] = 1.0
+            for p_j, lambda_col in zip(breakpoints, lambda_cols):
+                row_x[lambda_col] -= float(p_j)
+            _add_row(row_x, 0.0)
+            _add_row(-row_x, 0.0)
+
+            row_y = np.zeros(n_total)
+            row_y[other_var] = 1.0
+            for theta_col in theta_cols:
+                row_y[theta_col] -= 1.0
+            _add_row(row_y, 0.0)
+            _add_row(-row_y, 0.0)
+
+            row_w = np.zeros(n_total)
+            row_w[w_col] = 1.0
+            for p_j, theta_col in zip(breakpoints, theta_cols):
+                row_w[theta_col] -= float(p_j)
+            _add_row(row_w, 0.0)
+            _add_row(-row_w, 0.0)
+
+            if mode == "sos2":
+                for idx, lambda_col in enumerate(lambda_cols):
+                    row = np.zeros(n_total)
+                    row[lambda_col] = 1.0
+                    if idx == 0:
+                        row[alpha_cols[0]] = -1.0
+                    elif idx == len(lambda_cols) - 1:
+                        row[alpha_cols[-1]] = -1.0
+                    else:
+                        row[alpha_cols[idx - 1]] = -1.0
+                        row[alpha_cols[idx]] = -1.0
+                    _add_row(row, 0.0)
+            else:
+                for idx in range(len(alpha_cols) - 1):
+                    row = np.zeros(n_total)
+                    for alpha_col in alpha_cols[: idx + 1]:
+                        row[alpha_col] -= 1.0
+                    for lambda_col in lambda_cols[: idx + 1]:
+                        row[lambda_col] += 1.0
+                    _add_row(row, 0.0)
+
+                    row = np.zeros(n_total)
+                    for alpha_col in alpha_cols[: idx + 1]:
+                        row[alpha_col] += 1.0
+                    for lambda_col in lambda_cols[: idx + 2]:
+                        row[lambda_col] -= 1.0
+                    _add_row(row, 0.0)
+
+            for lambda_col, theta_col in zip(lambda_cols, theta_cols):
+                row = np.zeros(n_total)
+                row[theta_col] = -1.0
+                row[lambda_col] = yj_lb
+                _add_row(row, 0.0)
+
+                row = np.zeros(n_total)
+                row[theta_col] = -1.0
+                row[other_var] = 1.0
+                row[lambda_col] = yj_ub
+                _add_row(row, yj_ub)
+
+                row = np.zeros(n_total)
+                row[theta_col] = 1.0
+                row[other_var] = -1.0
+                row[lambda_col] = -yj_lb
+                _add_row(row, -yj_lb)
+
+                row = np.zeros(n_total)
+                row[theta_col] = 1.0
+                row[lambda_col] = -yj_ub
+                _add_row(row, 0.0)
+
+        elif (i, j) in bilinear_pw_map and bilinear_pw_map[(i, j)]:
             # ── Piecewise McCormick with binary partition selection ──────────
             intervals = bilinear_pw_map[(i, j)]
             # Determine partition var vs other var
@@ -766,6 +922,8 @@ def build_milp_relaxation(
         "bilinear": bilinear_var_map,
         "monomial": monomial_var_map,
         "bilinear_pw": bilinear_pw_map,
+        "bilinear_lambda": bilinear_lambda_map,
+        "convhull_formulation": convhull_mode,
     }
 
     return milp_model, varmap

--- a/python/discopt/_jax/milp_relaxation.py
+++ b/python/discopt/_jax/milp_relaxation.py
@@ -496,6 +496,8 @@ def build_milp_relaxation(
             lambda_cols: list[int] = []
             alpha_cols: list[int] = []
             theta_cols: list[int] = []
+            # theta = lambda * y can be zero whenever lambda = 0, so 0 must lie in
+            # the explicit theta bounds even if y does not cross zero.
             theta_lb = min(0.0, xj_lb_g, xj_ub_g)
             theta_ub = max(0.0, xj_lb_g, xj_ub_g)
 

--- a/python/discopt/_jax/partition_selection.py
+++ b/python/discopt/_jax/partition_selection.py
@@ -129,11 +129,7 @@ def _solve_vertex_cover_milp(
         heavy = 1.0 if not positive else 1.0 / min(positive)
         c = np.array(
             [
-                (
-                    heavy
-                    if abs(float(weights.get(v, 0.0))) <= 1e-6
-                    else 1.0 / abs(float(weights[v]))
-                )
+                (heavy if abs(float(weights.get(v, 0.0))) <= 1e-6 else 1.0 / abs(float(weights[v])))
                 for v in candidates
             ],
             dtype=np.float64,
@@ -158,9 +154,7 @@ def _solve_vertex_cover_milp(
             nonzero_cols = np.array(
                 [i for i in range(n) if A_le[row_idx, i] != 0.0], dtype=np.int32
             )
-            vals = np.array(
-                [A_le[row_idx, i] for i in nonzero_cols], dtype=np.float64
-            )
+            vals = np.array([A_le[row_idx, i] for i in nonzero_cols], dtype=np.float64)
             h.addRow(-np.inf, float(b_le[row_idx]), len(nonzero_cols), nonzero_cols, vals)
 
         h.run()

--- a/python/discopt/_jax/partition_selection.py
+++ b/python/discopt/_jax/partition_selection.py
@@ -210,8 +210,8 @@ def _greedy_vertex_cover(
                 score = float(count)
             else:
                 dist = abs(float(weights.get(v, 0.0)))
-                penalty = 1.0 / max(dist, 1e-6)
-                score = float(count) / penalty
+                weight = max(dist, 1e-6)
+                score = float(count) * weight
 
             if score > best_score:
                 best_score = score

--- a/python/discopt/_jax/partition_selection.py
+++ b/python/discopt/_jax/partition_selection.py
@@ -67,9 +67,30 @@ def _min_vertex_cover(terms: NonlinearTerms) -> list[int]:
         return greedy if greedy else candidates
 
 
+def _weighted_min_vertex_cover(
+    terms: NonlinearTerms,
+    distance: dict[int, float],
+) -> list[int]:
+    """Weighted minimum vertex cover using Alpine-style incumbent distance scores."""
+    all_t = _all_terms(terms)
+    candidates = list(terms.partition_candidates)
+
+    if not candidates or not all_t:
+        return []
+    if len(candidates) <= 2:
+        return candidates
+
+    try:
+        return _solve_vertex_cover_milp(candidates, all_t, weights=distance)
+    except Exception:
+        greedy = _greedy_vertex_cover(candidates, all_t, weights=distance)
+        return greedy if greedy else candidates
+
+
 def _solve_vertex_cover_milp(
     candidates: list[int],
     terms: list[tuple[int, ...]],
+    weights: dict[int, float] | None = None,
 ) -> list[int]:
     """Solve the minimum vertex cover as a MILP using HiGHS.
 
@@ -96,12 +117,27 @@ def _solve_vertex_cover_milp(
             if v in var_to_col:
                 A[row_idx, var_to_col[v]] = 1.0
 
-    # Objective: minimize sum(y)
-    c = np.ones(n, dtype=np.float64)
-
-    # Bounds: y ∈ [0, 1]
-    lb = np.zeros(n, dtype=np.float64)
-    ub = np.ones(n, dtype=np.float64)
+    # Objective: minimize sum(y) or a weighted cover objective.
+    if weights is None:
+        c = np.ones(n, dtype=np.float64)
+    else:
+        positive = [
+            abs(float(weights.get(v, 0.0)))
+            for v in candidates
+            if abs(float(weights.get(v, 0.0))) > 0.0
+        ]
+        heavy = 1.0 if not positive else 1.0 / min(positive)
+        c = np.array(
+            [
+                (
+                    heavy
+                    if abs(float(weights.get(v, 0.0))) <= 1e-6
+                    else 1.0 / abs(float(weights[v]))
+                )
+                for v in candidates
+            ],
+            dtype=np.float64,
+        )
 
     # Convert A >= 1 to standard form: -A @ y <= -1
     A_le = -A
@@ -141,16 +177,19 @@ def _solve_vertex_cover_milp(
         return selected
 
     except ImportError:
-        greedy = _greedy_vertex_cover(candidates, valid_terms)
+        greedy = _greedy_vertex_cover(candidates, valid_terms, weights=weights)
         return greedy if greedy else list(dict.fromkeys(candidates))
 
 
-def _greedy_vertex_cover(candidates: list[int], terms: list[tuple[int, ...]]) -> list[int]:
+def _greedy_vertex_cover(
+    candidates: list[int],
+    terms: list[tuple[int, ...]],
+    weights: dict[int, float] | None = None,
+) -> list[int]:
     """Greedy vertex cover: repeatedly pick the variable covering the most uncovered terms.
 
     O(n * m) but good approximation for small instances.
     """
-    covered = set()
     selected = []
     term_set = [set(t) for t in terms]
     n_terms = len(term_set)
@@ -159,15 +198,25 @@ def _greedy_vertex_cover(candidates: list[int], terms: list[tuple[int, ...]]) ->
     while uncovered:
         # Find variable with most coverage
         best_var = None
-        best_count = -1
+        best_score = -1.0
         for v in candidates:
             if v in selected:
                 continue
             count = sum(1 for idx in uncovered if v in term_set[idx])
-            if count > best_count:
-                best_count = count
+            if count <= 0:
+                continue
+
+            if weights is None:
+                score = float(count)
+            else:
+                dist = abs(float(weights.get(v, 0.0)))
+                penalty = 1.0 / max(dist, 1e-6)
+                score = float(count) / penalty
+
+            if score > best_score:
+                best_score = score
                 best_var = v
-        if best_var is None or best_count == 0:
+        if best_var is None or best_score <= 0.0:
             break
         selected.append(best_var)
         newly_covered = {idx for idx in uncovered if best_var in term_set[idx]}
@@ -176,7 +225,11 @@ def _greedy_vertex_cover(candidates: list[int], terms: list[tuple[int, ...]]) ->
     return selected
 
 
-def pick_partition_vars(terms: NonlinearTerms, method: str = "auto") -> list[int]:
+def pick_partition_vars(
+    terms: NonlinearTerms,
+    method: str = "auto",
+    distance: dict[int, float] | None = None,
+) -> list[int]:
     """Select variables to partition for the AMP relaxation.
 
     Parameters
@@ -188,6 +241,8 @@ def pick_partition_vars(terms: NonlinearTerms, method: str = "auto") -> list[int
         - ``"max_cover"``: all variables appearing in any nonlinear term.
         - ``"min_vertex_cover"``: minimum set covering all terms (MILP-based).
         - ``"auto"``: max_cover if ≤15 candidates, else min_vertex_cover.
+        - ``"adaptive_vertex_cover"``: Alpine-style weighted cover using incumbent
+          distances when available, else falls back to ``"auto"``.
 
     Returns
     -------
@@ -207,8 +262,13 @@ def pick_partition_vars(terms: NonlinearTerms, method: str = "auto") -> list[int
             return _max_cover(terms)
         else:
             return _min_vertex_cover(terms)
+    elif method == "adaptive_vertex_cover":
+        if len(terms.partition_candidates) <= 15 or not distance:
+            return _max_cover(terms)
+        return _weighted_min_vertex_cover(terms, distance)
     else:
         raise ValueError(
             f"Unknown variable selection method: {method!r}. "
-            "Choose from 'max_cover', 'min_vertex_cover', 'auto'."
+            "Choose from 'max_cover', 'min_vertex_cover', 'auto', "
+            "'adaptive_vertex_cover'."
         )

--- a/python/discopt/_jax/term_classifier.py
+++ b/python/discopt/_jax/term_classifier.py
@@ -184,11 +184,12 @@ def classify_nonlinear_terms(model: Model) -> NonlinearTerms:
                 result.term_incidence.setdefault(v, set()).add(term_idx)
 
     def _record_trilinear(i: int, j: int, k: int) -> None:
-        key = tuple(sorted([i, j, k]))
+        a, b, c = sorted((i, j, k))
+        key = (a, b, c)
         if key not in seen_trilinear:
             seen_trilinear.add(key)
             term_idx = len(result.bilinear) + len(result.trilinear)
-            result.trilinear.append(key)  # type: ignore[arg-type]
+            result.trilinear.append(key)
             for v in key:
                 result.term_incidence.setdefault(v, set()).add(term_idx)
 

--- a/python/discopt/solver.py
+++ b/python/discopt/solver.py
@@ -1106,12 +1106,19 @@ def solve_model(
         amp_kwargs = {}
         for key in (
             "rel_gap",
+            "abs_tol",
             "max_iter",
             "n_init_partitions",
             "partition_method",
             "iteration_callback",
             "milp_time_limit",
             "milp_gap_tolerance",
+            "apply_partitioning",
+            "disc_var_pick",
+            "partition_scaling_factor",
+            "disc_add_partition_method",
+            "disc_abs_width_tol",
+            "convhull_formulation",
         ):
             if key in kwargs:
                 amp_kwargs[key] = kwargs.pop(key)

--- a/python/discopt/solvers/amp.py
+++ b/python/discopt/solvers/amp.py
@@ -267,6 +267,7 @@ def _solve_milp_with_oa_recovery(
     oa_cuts: Optional[list],
     time_limit: Optional[float],
     gap_tolerance: float,
+    convhull_formulation: str,
 ):
     """Retry MILP solves after dropping the oldest half of OA cuts on infeasibility."""
     from discopt._jax.milp_relaxation import build_milp_relaxation
@@ -283,6 +284,7 @@ def _solve_milp_with_oa_recovery(
             disc_state,
             incumbent,
             oa_cuts=active_oa_cuts,
+            convhull_formulation=convhull_formulation,
         )
         milp_result = milp_model.solve(
             time_limit=time_limit,
@@ -351,6 +353,64 @@ def _default_milp_time_limit(
     return min(iter_budget * 3, remaining * 0.8, 60.0)
 
 
+def _normalize_partition_method(
+    partition_method: str,
+    disc_var_pick: int | str | None,
+) -> str:
+    """Resolve public AMP aliases to the internal partition-selection strategy."""
+    if disc_var_pick is None:
+        return partition_method
+
+    if isinstance(disc_var_pick, str):
+        aliases = {
+            "all": "max_cover",
+            "max_cover": "max_cover",
+            "min_vertex_cover": "min_vertex_cover",
+            "auto": "auto",
+            "adaptive": "adaptive_vertex_cover",
+            "adaptive_vertex_cover": "adaptive_vertex_cover",
+        }
+        if disc_var_pick not in aliases:
+            raise ValueError(
+                f"Unsupported disc_var_pick string: {disc_var_pick!r}. "
+                "Choose from 'all', 'max_cover', 'min_vertex_cover', "
+                "'auto', or 'adaptive_vertex_cover'."
+            )
+        return aliases[disc_var_pick]
+
+    if disc_var_pick == 0:
+        return "max_cover"
+    if disc_var_pick == 1:
+        return "min_vertex_cover"
+    if disc_var_pick == 2:
+        return "auto"
+    if disc_var_pick == 3:
+        return "adaptive_vertex_cover"
+
+    raise ValueError(
+        f"Unsupported disc_var_pick integer: {disc_var_pick!r}. "
+        "Choose from 0, 1, 2, or 3."
+    )
+
+
+def _normalize_convhull_formulation(formulation: str) -> str:
+    """Normalize bilinear convex-hull mode names accepted by the AMP interface."""
+    aliases = {
+        "disaggregated": "disaggregated",
+        "piecewise": "disaggregated",
+        "sos2": "sos2",
+        "facet": "facet",
+        "lambda": "sos2",
+    }
+    try:
+        return aliases[formulation]
+    except KeyError as err:
+        raise ValueError(
+            f"Unsupported convhull_formulation: {formulation!r}. "
+            "Choose from 'disaggregated', 'sos2', 'facet', or 'lambda'."
+        ) from err
+
+
 def _compute_relative_gap(
     abs_gap: Optional[float],
     upper_bound: float,
@@ -385,6 +445,12 @@ def solve_amp(
     iteration_callback: Optional[Callable] = None,
     milp_time_limit: Optional[float] = None,
     milp_gap_tolerance: Optional[float] = None,
+    apply_partitioning: bool = True,
+    disc_var_pick: int | str | None = None,
+    partition_scaling_factor: float = 10.0,
+    disc_add_partition_method: str = "adaptive",
+    disc_abs_width_tol: float = 1e-3,
+    convhull_formulation: str = "disaggregated",
 ) -> SolveResult:
     """Solve MINLP globally using Adaptive Multivariate Partitioning (AMP).
 
@@ -412,6 +478,21 @@ def solve_amp(
         Per-MILP-call time limit (defaults to remaining time).
     milp_gap_tolerance : float
         MILP solver gap tolerance (default 1e-4).
+    apply_partitioning : bool
+        If False, solve a single relaxation/NLP pass without adaptive refinement.
+    disc_var_pick : int | str, optional
+        Alpine-style alias for partition selection:
+        0/``"all"`` → max_cover, 1 → min_vertex_cover, 2 → auto,
+        3 → adaptive weighted cover.
+    partition_scaling_factor : float
+        Width scaling used by adaptive partition refinement.
+    disc_add_partition_method : str
+        Refinement update rule: ``"adaptive"`` or ``"uniform"``.
+    disc_abs_width_tol : float
+        Absolute partition-width convergence tolerance.
+    convhull_formulation : str
+        Piecewise bilinear formulation: ``"disaggregated"``, ``"sos2"``,
+        ``"facet"``, or ``"lambda"`` (alias for ``"sos2"``).
 
     Returns
     -------
@@ -422,6 +503,7 @@ def solve_amp(
 
     from discopt._jax.discretization import (
         add_adaptive_partition,
+        add_uniform_partition,
         check_partition_convergence,
         initialize_partitions,
     )
@@ -432,6 +514,18 @@ def solve_amp(
 
     assert model._objective is not None
     maximize = model._objective.sense == ObjectiveSense.MAXIMIZE
+    part_lbs: list[float] = []
+    part_ubs: list[float] = []
+
+    if partition_scaling_factor <= 1.0:
+        raise ValueError("partition_scaling_factor must be > 1.0")
+    if disc_add_partition_method not in {"adaptive", "uniform"}:
+        raise ValueError(
+            "disc_add_partition_method must be 'adaptive' or 'uniform'"
+        )
+
+    partition_mode = _normalize_partition_method(partition_method, disc_var_pick)
+    convhull_mode = _normalize_convhull_formulation(convhull_formulation)
 
     def _to_minimization_space(value: float) -> float:
         return -float(value) if maximize else float(value)
@@ -455,27 +549,40 @@ def solve_amp(
     )
 
     # ── Select partition variables ───────────────────────────────────────────
-    part_vars = pick_partition_vars(terms, method=partition_method)
+    if apply_partitioning:
+        part_vars = pick_partition_vars(terms, method=partition_mode)
+    else:
+        part_vars = []
 
     # If no bilinear/multilinear terms, still partition monomial variables
     # to add tangent cuts at more points and tighten the lower bound.
-    if not part_vars and terms.monomial:
+    if apply_partitioning and not part_vars and terms.monomial:
         part_vars = sorted(set(var_idx for var_idx, _ in terms.monomial))
         logger.info("AMP: no bilinear terms; partitioning %d monomial vars", len(part_vars))
+    elif not apply_partitioning:
+        logger.info("AMP: partitioning disabled; running a single fixed relaxation pass")
     else:
-        logger.info("AMP: partitioning %d variables via %s", len(part_vars), partition_method)
+        logger.info("AMP: partitioning %d variables via %s", len(part_vars), partition_mode)
 
     # ── Initialize partitions ────────────────────────────────────────────────
     if part_vars:
         part_lbs = [float(flat_lb[i]) for i in part_vars]
         part_ubs = [float(flat_ub[i]) for i in part_vars]
         disc_state = initialize_partitions(
-            part_vars, lb=part_lbs, ub=part_ubs, n_init=n_init_partitions
+            part_vars,
+            lb=part_lbs,
+            ub=part_ubs,
+            n_init=n_init_partitions,
+            scaling_factor=partition_scaling_factor,
+            abs_width_tol=disc_abs_width_tol,
         )
     else:
         from discopt._jax.discretization import DiscretizationState
 
-        disc_state = DiscretizationState()
+        disc_state = DiscretizationState(
+            scaling_factor=partition_scaling_factor,
+            abs_width_tol=disc_abs_width_tol,
+        )
 
     LB = -np.inf
     UB = np.inf
@@ -498,7 +605,10 @@ def solve_amp(
 
         # ── Step 1: Solve MILP relaxation → lower bound ──────────────────────
         # MILP gap tolerance: no tighter than needed for overall convergence.
-        _milp_gap_tol = milp_gap_tolerance if milp_gap_tolerance is not None else min(rel_gap / 2, 1e-3)
+        if milp_gap_tolerance is not None:
+            _milp_gap_tol = milp_gap_tolerance
+        else:
+            _milp_gap_tol = min(rel_gap / 2, 1e-3)
 
         try:
             milp_result, varmap, active_oa_cuts = _solve_milp_with_oa_recovery(
@@ -509,6 +619,7 @@ def solve_amp(
                 oa_cuts=oa_cuts,
                 time_limit=milp_tl,
                 gap_tolerance=_milp_gap_tol,
+                convhull_formulation=convhull_mode,
             )
             oa_cuts = active_oa_cuts
         except Exception as e:
@@ -516,11 +627,18 @@ def solve_amp(
             break
 
         if milp_result.status in ("infeasible", "error"):
-            logger.info("AMP: MILP infeasible/error at iteration %d, status=%s", iteration, milp_result.status)
+            logger.info(
+                "AMP: MILP infeasible/error at iteration %d, status=%s",
+                iteration,
+                milp_result.status,
+            )
             if LB == -np.inf:
                 # Problem may be infeasible
                 if iteration == 1:
-                    return SolveResult(status="infeasible", wall_time=time.perf_counter() - t_start)
+                    return SolveResult(
+                        status="infeasible",
+                        wall_time=time.perf_counter() - t_start,
+                    )
             break
 
         if milp_result.objective is not None:
@@ -657,6 +775,43 @@ def solve_amp(
                 gap_certified = False  # no lower bound from partitioning
             break
 
+        if (
+            partition_mode == "adaptive_vertex_cover"
+            and incumbent is not None
+            and milp_result.x is not None
+        ):
+            distances = {
+                i: abs(float(incumbent[i]) - float(x0[i]))
+                for i in terms.partition_candidates
+            }
+            adaptive_vars = pick_partition_vars(
+                terms,
+                method="adaptive_vertex_cover",
+                distance=distances,
+            )
+            if adaptive_vars and set(adaptive_vars) != set(part_vars):
+                logger.info(
+                    "AMP: updating adaptive partition set from %d to %d variables",
+                    len(part_vars),
+                    len(adaptive_vars),
+                )
+                new_vars = [i for i in adaptive_vars if i not in disc_state.partitions]
+                if new_vars:
+                    new_lbs = [float(flat_lb[i]) for i in new_vars]
+                    new_ubs = [float(flat_ub[i]) for i in new_vars]
+                    init_state = initialize_partitions(
+                        new_vars,
+                        lb=new_lbs,
+                        ub=new_ubs,
+                        n_init=n_init_partitions,
+                        scaling_factor=partition_scaling_factor,
+                        abs_width_tol=disc_abs_width_tol,
+                    )
+                    disc_state.partitions.update(init_state.partitions)
+                part_vars = adaptive_vars
+                part_lbs = [float(flat_lb[i]) for i in part_vars]
+                part_ubs = [float(flat_ub[i]) for i in part_vars]
+
         # Use MILP solution (original vars) as the refinement point
         refine_solution: dict[int, float] = {}
         if milp_result.x is not None:
@@ -664,9 +819,22 @@ def solve_amp(
             for i in part_vars:
                 refine_solution[i] = float(x_orig[i])
 
-        disc_state = add_adaptive_partition(
-            disc_state, refine_solution, part_vars, part_lbs, part_ubs
-        )
+        if disc_add_partition_method == "uniform":
+            disc_state = add_uniform_partition(
+                disc_state,
+                refine_solution,
+                part_vars,
+                part_lbs,
+                part_ubs,
+            )
+        else:
+            disc_state = add_adaptive_partition(
+                disc_state,
+                refine_solution,
+                part_vars,
+                part_lbs,
+                part_ubs,
+            )
 
         # Check partition convergence
         if check_partition_convergence(disc_state):

--- a/python/discopt/solvers/amp.py
+++ b/python/discopt/solvers/amp.py
@@ -28,6 +28,7 @@ from typing import Callable, Optional
 
 import numpy as np
 
+from discopt._jax.milp_relaxation import _normalize_convhull_formulation
 from discopt._jax.model_utils import flat_variable_bounds
 from discopt.modeling.core import Model, ObjectiveSense, SolveResult, VarType
 
@@ -393,24 +394,6 @@ def _normalize_partition_method(
     )
 
 
-def _normalize_convhull_formulation(formulation: str) -> str:
-    """Normalize bilinear convex-hull mode names accepted by the AMP interface."""
-    aliases = {
-        "disaggregated": "disaggregated",
-        "piecewise": "disaggregated",
-        "sos2": "sos2",
-        "facet": "facet",
-        "lambda": "sos2",
-    }
-    try:
-        return aliases[formulation]
-    except KeyError as err:
-        raise ValueError(
-            f"Unsupported convhull_formulation: {formulation!r}. "
-            "Choose from 'disaggregated', 'sos2', 'facet', or 'lambda'."
-        ) from err
-
-
 def _compute_relative_gap(
     abs_gap: Optional[float],
     upper_bound: float,
@@ -483,7 +466,9 @@ def solve_amp(
     disc_var_pick : int | str, optional
         Alpine-style alias for partition selection:
         0/``"all"`` → max_cover, 1 → min_vertex_cover, 2 → auto,
-        3 → adaptive weighted cover.
+        3 → adaptive weighted cover. This intentionally collapses Alpine's
+        separate `disc_var_pick_algo` and `disc_var_pick` options into one
+        user-facing control.
     partition_scaling_factor : float
         Width scaling used by adaptive partition refinement.
     disc_add_partition_method : str

--- a/python/discopt/solvers/amp.py
+++ b/python/discopt/solvers/amp.py
@@ -81,9 +81,7 @@ def _solve_nlp_subproblem(
         else:
             from discopt.solvers.nlp_ipopt import solve_nlp
 
-            result = solve_nlp(
-                evaluator, x0_clipped, options={"print_level": 0, "max_iter": 300}
-            )
+            result = solve_nlp(evaluator, x0_clipped, options={"print_level": 0, "max_iter": 300})
 
         from discopt.solvers import SolveStatus
 
@@ -95,9 +93,7 @@ def _solve_nlp_subproblem(
     return None, None
 
 
-def _check_integer_feasible(
-    x: np.ndarray, model: Model, int_tol: float = 1e-5
-) -> bool:
+def _check_integer_feasible(x: np.ndarray, model: Model, int_tol: float = 1e-5) -> bool:
     """Return True if all integer/binary variables satisfy integrality."""
     offset = 0
     for v in model._variables:
@@ -139,11 +135,11 @@ def _integer_rounding_candidates(
                     int(np.ceil(clipped)),
                 ):
                     if lo_i <= hi_i:
-                        cand = min(max(raw, lo_i), hi_i)
+                        cand_int = min(max(raw, lo_i), hi_i)
                     else:
-                        cand = int(round(clipped))
-                    if cand not in options:
-                        options.append(cand)
+                        cand_int = int(round(clipped))
+                    if cand_int not in options:
+                        options.append(cand_int)
 
                 integer_entries.append((idx, options))
         offset += v.size
@@ -230,9 +226,7 @@ def _solve_best_nlp_candidate(
     best_obj: Optional[float] = None
 
     for x0_nlp in _integer_rounding_candidates(x0, model):
-        nlp_lb, nlp_ub = _build_fixed_integer_bounds(
-            x0_nlp, model, flat_lb, flat_ub
-        )
+        nlp_lb, nlp_ub = _build_fixed_integer_bounds(x0_nlp, model, flat_lb, flat_ub)
         cand_x, cand_obj = _solve_nlp_subproblem(
             evaluator,
             x0_nlp,
@@ -389,8 +383,7 @@ def _normalize_partition_method(
         return "adaptive_vertex_cover"
 
     raise ValueError(
-        f"Unsupported disc_var_pick integer: {disc_var_pick!r}. "
-        "Choose from 0, 1, 2, or 3."
+        f"Unsupported disc_var_pick integer: {disc_var_pick!r}. Choose from 0, 1, 2, or 3."
     )
 
 
@@ -505,9 +498,7 @@ def solve_amp(
     if partition_scaling_factor <= 1.0:
         raise ValueError("partition_scaling_factor must be > 1.0")
     if disc_add_partition_method not in {"adaptive", "uniform"}:
-        raise ValueError(
-            "disc_add_partition_method must be 'adaptive' or 'uniform'"
-        )
+        raise ValueError("disc_add_partition_method must be 'adaptive' or 'uniform'")
 
     partition_mode = _normalize_partition_method(partition_method, disc_var_pick)
     convhull_mode = _normalize_convhull_formulation(convhull_formulation)
@@ -674,11 +665,7 @@ def solve_amp(
 
                     _x_orig = x_nlp[:n_orig]
                     if evaluator.n_constraints > 0:
-                        _senses = [
-                            c.sense
-                            for c in model._constraints
-                            if isinstance(c, Constraint)
-                        ]
+                        _senses = [c.sense for c in model._constraints if isinstance(c, Constraint)]
                         cuts = generate_oa_cuts_from_evaluator(
                             evaluator, _x_orig, constraint_senses=_senses
                         )
@@ -766,8 +753,7 @@ def solve_amp(
             and milp_result.x is not None
         ):
             distances = {
-                i: abs(float(incumbent[i]) - float(x0[i]))
-                for i in terms.partition_candidates
+                i: abs(float(incumbent[i]) - float(x0[i])) for i in terms.partition_candidates
             }
             adaptive_vars = pick_partition_vars(
                 terms,

--- a/python/tests/test_amp.py
+++ b/python/tests/test_amp.py
@@ -355,6 +355,25 @@ class TestPartitionSelection:
 
         assert set(selected) == {0}
 
+    def test_adaptive_vertex_cover_uses_distance_weights(self):
+        """Adaptive cover should favor high-distance variables on large graphs."""
+        terms = self._make_terms(bilinear=[(i, i + 1) for i in range(16)])
+        distance = {
+            i: (10.0 if i % 2 == 0 else 1e-3)
+            for i in terms.partition_candidates
+        }
+
+        selected = self.pick(
+            terms,
+            method="adaptive_vertex_cover",
+            distance=distance,
+        )
+
+        assert selected
+        assert all(v % 2 == 0 for v in selected)
+        for t in terms.bilinear:
+            assert any(v in selected for v in t), f"term {t} not covered"
+
 
 # ===========================================================================
 # Section 3: Discretization State Management
@@ -379,6 +398,7 @@ class TestDiscretizationState:
         from discopt._jax.discretization import (  # noqa: F401
             DiscretizationState,
             add_adaptive_partition,
+            add_uniform_partition,
             check_partition_convergence,
             initialize_partitions,
         )
@@ -386,6 +406,7 @@ class TestDiscretizationState:
         self.DiscretizationState = DiscretizationState
         self.initialize_partitions = initialize_partitions
         self.add_adaptive_partition = add_adaptive_partition
+        self.add_uniform_partition = add_uniform_partition
         self.check_partition_convergence = check_partition_convergence
 
     def test_initialize_correct_breakpoints(self):
@@ -451,6 +472,15 @@ class TestDiscretizationState:
         assert pts[-1] == pytest.approx(1.0)
         # Strictly sorted
         assert all(pts[i] < pts[i + 1] for i in range(len(pts) - 1))
+
+    def test_uniform_refinement_splits_every_interval(self):
+        """Uniform refinement should bisect each current interval."""
+        state = self.initialize_partitions([0], lb=[0.0], ub=[4.0], n_init=2)
+        state2 = self.add_uniform_partition(state, {}, [0], [0.0], [4.0])
+        np.testing.assert_allclose(
+            state2.partitions[0],
+            np.array([0.0, 1.0, 2.0, 3.0, 4.0]),
+        )
 
     def test_convergence_check_fine_partitions(self):
         """check_partition_convergence returns True when all widths < abs_width_tol."""
@@ -776,6 +806,77 @@ class TestMilpRelaxation:
         assert result.x is not None
         assert abs(float(result.x[1]) - round(float(result.x[1]))) <= 1e-8
 
+    def test_lambda_convhull_builds_expected_auxiliaries(self):
+        """The λ-convex-hull formulation should expose lambda, alpha, and theta blocks."""
+        m = _make_nlp1()
+        terms = self.classify(m)
+        state = self.init_partitions([0], lb=[1.0], ub=[4.0], n_init=2)
+
+        _, varmap = self.build_milp(
+            m,
+            terms,
+            state,
+            incumbent=None,
+            convhull_formulation="sos2",
+        )
+
+        info = varmap["bilinear_lambda"][(0, 1)]
+        assert varmap["convhull_formulation"] == "sos2"
+        assert info["breakpoints"] == [1.0, 2.5, 4.0]
+        assert len(info["lambda_cols"]) == 3
+        assert len(info["alpha_cols"]) == 2
+        assert len(info["theta_cols"]) == 3
+
+    def test_sos2_and_facet_convhull_match_on_simple_bilinear_relaxation(self):
+        """SOS2 and facet λ-linking should give the same bound on a simple problem."""
+        m = Model("lambda_compare")
+        x = m.continuous("x", lb=0, ub=2, shape=(2,))
+        m.subject_to(x[0] * x[1] >= 1.0)
+        m.minimize(x[0] + x[1])
+
+        terms = self.classify(m)
+        state = self.init_partitions([0], lb=[0.0], ub=[2.0], n_init=2)
+
+        sos2_model, _ = self.build_milp(
+            m,
+            terms,
+            state,
+            incumbent=None,
+            convhull_formulation="sos2",
+        )
+        facet_model, _ = self.build_milp(
+            m,
+            terms,
+            state,
+            incumbent=None,
+            convhull_formulation="facet",
+        )
+
+        sos2_result = sos2_model.solve()
+        facet_result = facet_model.solve()
+
+        assert sos2_result.status == "optimal"
+        assert facet_result.status == "optimal"
+        assert sos2_result.objective is not None
+        assert facet_result.objective is not None
+        assert sos2_result.objective == pytest.approx(facet_result.objective, abs=1e-6)
+        assert sos2_result.objective <= 2.0 + 1e-6
+
+    def test_invalid_convhull_formulation_raises(self):
+        """Unsupported convex-hull mode names should fail fast."""
+        m = _make_nlp1()
+        terms = self.classify(m)
+        state = self.init_partitions([0], lb=[1.0], ub=[4.0], n_init=2)
+
+        with pytest.raises(ValueError, match="Unsupported convhull_formulation"):
+            self.build_milp(
+                m,
+                terms,
+                state,
+                incumbent=None,
+                convhull_formulation="bogus",
+            )
+
 
 class TestAmpPhase1Helpers:
     """Fast regression tests for Phase 1 helper behavior."""
@@ -1072,6 +1173,45 @@ class TestCurrentCodeWeaknesses:
 
         assert "solver" in inspect.signature(solve_model).parameters
 
+    def test_solve_model_forwards_alpine_amp_aliases(self, monkeypatch):
+        """solve_model should pass Alpine-style AMP aliases through to solve_amp."""
+        from discopt.modeling.core import SolveResult
+        from discopt.solver import solve_model
+        from discopt.solvers import amp as amp_mod
+
+        captured = {}
+
+        def fake_solve_amp(model, **kwargs):
+            del model
+            captured.update(kwargs)
+            return SolveResult(status="infeasible", wall_time=0.0)
+
+        monkeypatch.setattr(amp_mod, "solve_amp", fake_solve_amp)
+
+        m = Model("alias_forwarding")
+        x = m.continuous("x", lb=0, ub=1)
+        m.minimize(x)
+
+        solve_model(
+            m,
+            solver="amp",
+            gap_tolerance=1e-3,
+            apply_partitioning=False,
+            disc_var_pick=1,
+            partition_scaling_factor=7.0,
+            disc_add_partition_method="uniform",
+            disc_abs_width_tol=1e-2,
+            convhull_formulation="sos2",
+        )
+
+        assert captured["rel_gap"] == pytest.approx(1e-3)
+        assert captured["apply_partitioning"] is False
+        assert captured["disc_var_pick"] == 1
+        assert captured["partition_scaling_factor"] == pytest.approx(7.0)
+        assert captured["disc_add_partition_method"] == "uniform"
+        assert captured["disc_abs_width_tol"] == pytest.approx(1e-2)
+        assert captured["convhull_formulation"] == "sos2"
+
     def test_integer_rounding_candidates_include_floor_and_ceil(self):
         """Nearest-integer rounding fallback must try floor and ceil alternatives."""
         from discopt.solvers import amp as amp_mod
@@ -1198,7 +1338,15 @@ class TestCurrentCodeWeaknesses:
                     x=np.zeros(1, dtype=np.float64),
                 )
 
-        def fake_build(model, terms, disc_state, incumbent, oa_cuts=None):
+        def fake_build(
+            model,
+            terms,
+            disc_state,
+            incumbent,
+            oa_cuts=None,
+            convhull_formulation="disaggregated",
+        ):
+            assert convhull_formulation == "disaggregated"
             size = len(oa_cuts or [])
             call_sizes.append(size)
             status = "infeasible" if size >= 4 else "optimal"
@@ -1217,6 +1365,7 @@ class TestCurrentCodeWeaknesses:
             oa_cuts=[("c1", 1), ("c2", 2), ("c3", 3), ("c4", 4)],
             time_limit=1.0,
             gap_tolerance=1e-4,
+            convhull_formulation="disaggregated",
         )
 
         assert call_sizes == [4, 2]

--- a/python/tests/test_amp.py
+++ b/python/tests/test_amp.py
@@ -31,18 +31,12 @@ import os
 os.environ["JAX_PLATFORMS"] = "cpu"
 os.environ["JAX_ENABLE_X64"] = "1"
 
+import discopt.modeling as dm
 import numpy as np
 import pytest
-
-import discopt.modeling as dm
 from discopt.modeling.core import (
-    BinaryOp,
-    Constant,
-    FunctionCall,
-    IndexExpression,
     Model,
     SolveResult,
-    Variable,
 )
 
 # ---------------------------------------------------------------------------
@@ -126,6 +120,7 @@ class TestTermClassifier:
             NonlinearTerms,
             classify_nonlinear_terms,
         )
+
         self.classify = classify_nonlinear_terms
         self.NonlinearTerms = NonlinearTerms
 
@@ -263,8 +258,7 @@ class TestPartitionSelection:
         bilinear = bilinear or []
         trilinear = trilinear or []
         monomial = monomial or []
-        candidates = list({v for t in bilinear + trilinear for v in t}
-                         | {v for v, _ in monomial})
+        candidates = list({v for t in bilinear + trilinear for v in t} | {v for v, _ in monomial})
         incidence: dict[int, set[int]] = {}
         for idx, t in enumerate(bilinear + trilinear):
             for v in t:
@@ -319,7 +313,6 @@ class TestPartitionSelection:
         # 20 variables in a star — hub is var 0
         terms = self._make_terms(bilinear=[(0, i) for i in range(1, 20)])
         auto = self.pick(terms, method="auto")
-        mvc = self.pick(terms, method="min_vertex_cover")
         # Both should cover all terms
         for t in terms.bilinear:
             assert any(v in auto for v in t), f"term {t} not covered"
@@ -358,10 +351,7 @@ class TestPartitionSelection:
     def test_adaptive_vertex_cover_uses_distance_weights(self):
         """Adaptive cover should favor high-distance variables on large graphs."""
         terms = self._make_terms(bilinear=[(i, i + 1) for i in range(16)])
-        distance = {
-            i: (10.0 if i % 2 == 0 else 1e-3)
-            for i in terms.partition_candidates
-        }
+        distance = {i: (10.0 if i % 2 == 0 else 1e-3) for i in terms.partition_candidates}
 
         selected = self.pick(
             terms,
@@ -534,7 +524,6 @@ class TestMcCormickSoundness:
     def test_standard_mccormick_bilinear_valid(self):
         """cv ≤ x*y ≤ cc at 500 random points — core soundness test."""
         import jax.numpy as jnp
-
         from discopt._jax.mccormick import relax_bilinear
 
         x_lb, x_ub, y_lb, y_ub = 1.0, 4.0, 1.0, 4.0
@@ -556,7 +545,6 @@ class TestMcCormickSoundness:
     def test_piecewise_mccormick_bilinear_valid(self):
         """Piecewise McCormick is still a valid relaxation (cv ≤ x*y ≤ cc)."""
         import jax.numpy as jnp
-
         from discopt._jax.piecewise_mccormick import piecewise_mccormick_bilinear
 
         x_lb, x_ub, y_lb, y_ub = 0.0, 10.0, 0.0, 10.0
@@ -583,7 +571,6 @@ class TestMcCormickSoundness:
         Piecewise must be strictly tighter.
         """
         import jax.numpy as jnp
-
         from discopt._jax.mccormick import relax_bilinear
         from discopt._jax.piecewise_mccormick import piecewise_mccormick_bilinear
 
@@ -610,9 +597,7 @@ class TestMcCormickSoundness:
         gap_std = float(cc_std - cv_std)
         gap_pw = float(cc_pw - cv_pw)
 
-        assert gap_pw < gap_std, (
-            f"Piecewise gap {gap_pw:.4f} must be < standard gap {gap_std:.4f}"
-        )
+        assert gap_pw < gap_std, f"Piecewise gap {gap_pw:.4f} must be < standard gap {gap_std:.4f}"
         # Also verify piecewise is still sound
         w_true = x * y
         assert float(cv_pw) <= w_true + 1e-9
@@ -624,7 +609,6 @@ class TestMcCormickSoundness:
         Theoretical bound: max gap ≤ (domain_width / k)².
         """
         import jax.numpy as jnp
-
         from discopt._jax.piecewise_mccormick import piecewise_mccormick_bilinear
 
         x_lb, x_ub, y_lb, y_ub = 0.0, 10.0, 0.0, 10.0
@@ -650,10 +634,9 @@ class TestMcCormickSoundness:
         This test SHOULD PASS — it documents existing behavior as a baseline.
         The AMP implementation will add solution-adaptive refinement separately.
         """
-        from discopt._jax.piecewise_mccormick import _partition_bounds
-
         # Same call twice → identical result (no solution context)
         import jax.numpy as jnp
+        from discopt._jax.piecewise_mccormick import _partition_bounds
 
         lbs1, ubs1 = _partition_bounds(jnp.float64(0.0), jnp.float64(10.0), 4)
         lbs2, ubs2 = _partition_bounds(jnp.float64(0.0), jnp.float64(10.0), 4)
@@ -741,7 +724,7 @@ class TestMilpRelaxation:
         # Lower bounds must be non-decreasing with finer partitions
         for i in range(len(lbs) - 1):
             assert lbs[i] <= lbs[i + 1] + 1e-6, (
-                f"LBs must be non-decreasing: lbs[{i}]={lbs[i]:.4f} > lbs[{i+1}]={lbs[i+1]:.4f}"
+                f"LBs must be non-decreasing: lbs[{i}]={lbs[i]:.4f} > lbs[{i + 1}]={lbs[i + 1]:.4f}"
             )
 
     def test_milp_relaxation_feasible_when_problem_feasible(self):
@@ -755,7 +738,6 @@ class TestMilpRelaxation:
     def test_piecewise_interval_rows_use_interval_specific_bounds(self):
         """Piecewise product rows must use the current interval's wk_hi, not a stale value."""
         import scipy.sparse as sp
-
         from discopt._jax.discretization import DiscretizationState
         from discopt._jax.term_classifier import classify_nonlinear_terms
 
@@ -927,9 +909,9 @@ class TestAmpPhase1Helpers:
 # ===========================================================================
 
 # Known global optima (from Alpine.jl test suite + standard references)
-NLP1_OPTIMUM = 58.38368   # Alpine nlp1
+NLP1_OPTIMUM = 58.38368  # Alpine nlp1
 CIRCLE_OPTIMUM = 1.41421356  # √2
-NLP3_OPTIMUM = 7049.247898   # Alpine nlp3
+NLP3_OPTIMUM = 7049.247898  # Alpine nlp3
 
 
 class TestAmpEndToEnd:
@@ -941,7 +923,6 @@ class TestAmpEndToEnd:
     @pytest.mark.smoke
     def test_nlp1_bilinear_global_optimum(self):
         """nlp1: bilinear MINLP solved to global optimum ≈ 58.38368."""
-        from discopt.modeling.core import SolveResult
 
         m = _make_nlp1()
         result = m.solve(solver="amp", rel_gap=1e-3, time_limit=60)
@@ -999,7 +980,7 @@ class TestAmpEndToEnd:
         """min x²  s.t. x ≥ 1: AMP should certify global optimum = 1."""
         m = Model("quad")
         x = m.continuous("x", lb=1, ub=10)
-        m.minimize(x ** 2)
+        m.minimize(x**2)
         result = m.solve(solver="amp", rel_gap=1e-4, time_limit=30)
         assert result.status == "optimal"
         assert result.objective is not None
@@ -1007,10 +988,10 @@ class TestAmpEndToEnd:
 
     @pytest.mark.smoke
     def test_zero_upper_bound_reports_no_relative_gap(self):
-        """Relative gap should be left undefined when the incumbent objective is numerically zero."""
+        """Relative gap should stay undefined when the incumbent objective is near zero."""
         m = Model("zero_gap")
         x = m.continuous("x", lb=-1, ub=1)
-        m.minimize(x ** 2)
+        m.minimize(x**2)
 
         result = m.solve(solver="amp", rel_gap=1e-4, time_limit=30)
 
@@ -1084,7 +1065,7 @@ class TestAmpConvergenceProperties:
         assert len(lbs) >= 2, "Should have at least 2 iterations"
         for i in range(len(lbs) - 1):
             assert lbs[i] <= lbs[i + 1] + 1e-8, (
-                f"LB decreased at iteration {i}: {lbs[i]:.6f} > {lbs[i+1]:.6f}"
+                f"LB decreased at iteration {i}: {lbs[i]:.6f} > {lbs[i + 1]:.6f}"
             )
 
     @pytest.mark.smoke
@@ -1102,9 +1083,7 @@ class TestAmpConvergenceProperties:
         for j in range(len(finite_ubs) - 1):
             i1, u1 = finite_ubs[j]
             i2, u2 = finite_ubs[j + 1]
-            assert u2 <= u1 + 1e-8, (
-                f"UB increased at iteration {i2}: {u1:.6f} → {u2:.6f}"
-            )
+            assert u2 <= u1 + 1e-8, f"UB increased at iteration {i2}: {u1:.6f} → {u2:.6f}"
 
     @pytest.mark.smoke
     def test_gap_certified_after_convergence(self):
@@ -1129,9 +1108,7 @@ class TestAmpConvergenceProperties:
         )
         if result.status == "optimal":
             # If gap-terminated, should be well before max_iter
-            assert len(iters) < 100, (
-                "Should terminate before max_iter=100 when gap closes"
-            )
+            assert len(iters) < 100, "Should terminate before max_iter=100 when gap closes"
 
     @pytest.mark.smoke
     def test_time_limit_respected(self):
@@ -1205,7 +1182,6 @@ class TestCurrentCodeWeaknesses:
 
     def test_solve_model_forwards_alpine_amp_aliases(self, monkeypatch):
         """solve_model should pass Alpine-style AMP aliases through to solve_amp."""
-        from discopt.modeling.core import SolveResult
         from discopt.solver import solve_model
         from discopt.solvers import amp as amp_mod
 
@@ -1247,7 +1223,7 @@ class TestCurrentCodeWeaknesses:
         from discopt.solvers import amp as amp_mod
 
         m = Model("rounding")
-        y = m.integer("y", lb=0, ub=3, shape=(2,))
+        m.integer("y", lb=0, ub=3, shape=(2,))
         x0 = np.array([1.49, 1.51], dtype=np.float64)
 
         candidates = amp_mod._integer_rounding_candidates(x0, m)
@@ -1524,7 +1500,7 @@ class TestCurrentCodeWeaknesses:
         """x² is convex — should solve to x=0 globally even without AMP."""
         m = Model("quad_convex")
         x = m.continuous("x", lb=-3, ub=3)
-        m.minimize(x ** 2)
+        m.minimize(x**2)
         result = m.solve()
         assert result.objective is not None
         assert abs(result.objective) < 1e-4, (

--- a/python/tests/test_amp.py
+++ b/python/tests/test_amp.py
@@ -828,14 +828,22 @@ class TestMilpRelaxation:
         assert len(info["theta_cols"]) == 3
 
     def test_sos2_and_facet_convhull_match_on_simple_bilinear_relaxation(self):
-        """SOS2 and facet λ-linking should give the same bound on a simple problem."""
+        """SOS2 and facet λ-linking should dominate the disaggregated relaxation."""
         m = Model("lambda_compare")
         x = m.continuous("x", lb=0, ub=2, shape=(2,))
         m.subject_to(x[0] * x[1] >= 1.0)
         m.minimize(x[0] + x[1])
 
         terms = self.classify(m)
-        state = self.init_partitions([0], lb=[0.0], ub=[2.0], n_init=2)
+        state = self.init_partitions([0], lb=[0.0], ub=[2.0], n_init=4)
+
+        disagg_model, _ = self.build_milp(
+            m,
+            terms,
+            state,
+            incumbent=None,
+            convhull_formulation="disaggregated",
+        )
 
         sos2_model, _ = self.build_milp(
             m,
@@ -852,14 +860,19 @@ class TestMilpRelaxation:
             convhull_formulation="facet",
         )
 
+        disagg_result = disagg_model.solve()
         sos2_result = sos2_model.solve()
         facet_result = facet_model.solve()
 
+        assert disagg_result.status == "optimal"
         assert sos2_result.status == "optimal"
         assert facet_result.status == "optimal"
+        assert disagg_result.objective is not None
         assert sos2_result.objective is not None
         assert facet_result.objective is not None
         assert sos2_result.objective == pytest.approx(facet_result.objective, abs=1e-6)
+        assert sos2_result.objective >= disagg_result.objective - 1e-6
+        assert facet_result.objective >= disagg_result.objective - 1e-6
         assert sos2_result.objective <= 2.0 + 1e-6
 
     def test_invalid_convhull_formulation_raises(self):
@@ -1019,6 +1032,23 @@ class TestAmpEndToEnd:
         assert result.gap_certified is True
         assert result.objective is not None
         assert abs(result.objective - 1.0) <= 1e-3
+        assert result.bound is not None
+        assert result.bound >= result.objective - 1e-6
+
+    def test_maximize_with_integer_variables(self):
+        """Maximize should work when integer rounding and fixed NLP bounds interact."""
+        m = Model("max_bin")
+        x = m.continuous("x", lb=0, ub=2)
+        y = m.binary("y")
+        m.subject_to(x <= 2 * y)
+        m.maximize(x * y)
+
+        result = m.solve(solver="amp", rel_gap=1e-3, time_limit=60)
+
+        assert result.status == "optimal"
+        assert result.gap_certified is True
+        assert result.objective is not None
+        assert abs(result.objective - 2.0) <= 1e-3
         assert result.bound is not None
         assert result.bound >= result.objective - 1e-6
 
@@ -1396,6 +1426,71 @@ class TestCurrentCodeWeaknesses:
         assert result.status == "feasible"
         assert result.gap_certified is False
         assert result.objective is not None
+
+    def test_adaptive_partition_selection_path_runs_inside_amp(self, monkeypatch):
+        """AMP should re-pick partition variables when adaptive selection is enabled."""
+        import discopt._jax.discretization as disc_mod
+        import discopt._jax.partition_selection as part_mod
+
+        adaptive_distances = []
+        refined_var_sets = []
+        orig_pick = part_mod.pick_partition_vars
+
+        def fake_pick(terms, method="auto", distance=None):
+            if method == "adaptive_vertex_cover" and distance is None:
+                return [0]
+            if method == "adaptive_vertex_cover":
+                adaptive_distances.append(dict(distance or {}))
+                return [1]
+            return orig_pick(terms, method=method, distance=distance)
+
+        def fake_add_adaptive_partition(state, solution, var_indices, lb, ub):
+            del solution, lb, ub
+            refined_var_sets.append(list(var_indices))
+            return state
+
+        monkeypatch.setattr(part_mod, "pick_partition_vars", fake_pick)
+        monkeypatch.setattr(disc_mod, "add_adaptive_partition", fake_add_adaptive_partition)
+        monkeypatch.setattr(disc_mod, "check_partition_convergence", lambda state: True)
+
+        m = _make_nlp1()
+        result = m.solve(
+            solver="amp",
+            disc_var_pick="adaptive",
+            rel_gap=1e-6,
+            time_limit=30,
+        )
+
+        assert adaptive_distances
+        assert refined_var_sets == [[1]]
+        assert result.status == "feasible"
+        assert result.gap_certified is False
+
+    def test_uniform_partition_refinement_path_runs_inside_amp(self, monkeypatch):
+        """AMP should call the uniform refinement branch when requested."""
+        import discopt._jax.discretization as disc_mod
+
+        uniform_calls = []
+
+        def fake_add_uniform_partition(state, _solution, var_indices, lb, ub):
+            del _solution, lb, ub
+            uniform_calls.append(list(var_indices))
+            return state
+
+        monkeypatch.setattr(disc_mod, "add_uniform_partition", fake_add_uniform_partition)
+        monkeypatch.setattr(disc_mod, "check_partition_convergence", lambda state: True)
+
+        m = _make_nlp1()
+        result = m.solve(
+            solver="amp",
+            disc_add_partition_method="uniform",
+            rel_gap=1e-6,
+            time_limit=30,
+        )
+
+        assert uniform_calls
+        assert result.status == "feasible"
+        assert result.gap_certified is False
 
     def test_spatial_bnb_bilinear_global_correctness(self):
         """Existing spatial B&B should solve nlp1 to global optimum.


### PR DESCRIPTION
## What changed
Adds the scoped checklist for the lambda-formulation and option-routing slice.

## Why
This is the highest-impact tightening work after the Phase 1 correctness fixes, and it needs public solver options alongside the formulation work.

## Implementation plan
- add formulation-validity and tighter-bound tests
- add `convhull_formulation` plumbing
- expose Alpine-style AMP tuning options through `solver.py`
- benchmark the formulation on `nlp3`

## Validation
- Reviewed the staged tracking doc locally
- Branch is pushed and ready for follow-up commits
