### PR TITLE
[draft] AMP Phase 4: trilinear and monomial coverage

### DIFF
--- a/plans/amp-completion/04-relaxation-coverage.md
+++ b/plans/amp-completion/04-relaxation-coverage.md
@@ -1,0 +1,15 @@
+# AMP Phase 4: Trilinear and Higher-Order Monomial Coverage
+
+Plan phases:
+- 3 Trilinear decomposition
+- 5 Monomial `n > 2` piecewise relaxation
+
+Primary files:
+- `python/discopt/_jax/milp_relaxation.py`
+- `python/discopt/_jax/term_classifier.py`
+- `python/tests/test_amp.py`
+
+Exit criteria:
+- Trilinear terms are decomposed into valid nested bilinear relaxations.
+- Higher-order monomials get piecewise relaxations rather than single-point tangents.
+- Tests prove valid lower bounds and end-to-end convergence on targeted models.

--- a/python/discopt/_jax/milp_relaxation.py
+++ b/python/discopt/_jax/milp_relaxation.py
@@ -163,6 +163,92 @@ def _normalize_convhull_formulation(formulation: str) -> str:
         ) from err
 
 
+def _sorted_unique_points(points: list[float]) -> list[float]:
+    """Return sorted points with near-duplicates removed."""
+    unique: list[float] = []
+    for point in sorted(float(p) for p in points):
+        if not unique or abs(point - unique[-1]) > 1e-12:
+            unique.append(point)
+    return unique
+
+
+def _power_tangent_line(t: float, n: int) -> tuple[float, float]:
+    """Return slope/intercept for the tangent to x**n at x=t."""
+    slope = float(n * (t ** (n - 1)))
+    intercept = float((t**n) - slope * t)
+    return slope, intercept
+
+
+def _power_secant_line(lb: float, ub: float, n: int) -> tuple[float, float]:
+    """Return slope/intercept for the secant through (lb, lb**n) and (ub, ub**n)."""
+    if abs(ub - lb) <= 1e-12:
+        return 0.0, float(lb**n)
+    slope = float((ub**n - lb**n) / (ub - lb))
+    intercept = float(lb**n - slope * lb)
+    return slope, intercept
+
+
+def _monomial_breakpoints(
+    var_idx: int,
+    lb_i: float,
+    ub_i: float,
+    disc_state: DiscretizationState,
+) -> list[float]:
+    """Return refinement-aware monomial cut points, including zero when needed."""
+    if var_idx in disc_state.partitions and len(disc_state.partitions[var_idx]) >= 2:
+        points = [float(p) for p in disc_state.partitions[var_idx]]
+    else:
+        points = [lb_i, ub_i]
+    if lb_i < 0.0 < ub_i:
+        points.append(0.0)
+    return _sorted_unique_points(points)
+
+
+def _odd_mixed_tangent_is_valid(
+    t: float,
+    lb: float,
+    ub: float,
+    n: int,
+    kind: str,
+) -> bool:
+    """Check whether the tangent at t is a global under/over-estimator on [lb, ub]."""
+    slope, intercept = _power_tangent_line(t, n)
+    critical_points = [lb, ub, t]
+    mirrored = -t
+    if lb <= mirrored <= ub:
+        critical_points.append(mirrored)
+
+    diffs = [float(x**n - (slope * x + intercept)) for x in _sorted_unique_points(critical_points)]
+    tol = 1e-10
+    if kind == "under":
+        return all(diff >= -tol for diff in diffs)
+    if kind == "over":
+        return all(diff <= tol for diff in diffs)
+    raise ValueError(f"Unknown tangent validity kind: {kind}")
+
+
+def _choose_trilinear_pair(
+    term: tuple[int, int, int],
+    partitioned_vars: set[int],
+) -> tuple[tuple[int, int], int]:
+    """Choose a deterministic trilinear decomposition pair.
+
+    Prefer a pair that includes as many currently partitioned original variables as
+    possible so the first or second lifted bilinear term can reuse the stronger
+    piecewise relaxation machinery already present for bilinear terms.
+    """
+    i, j, k = tuple(sorted(term))
+    candidates = [((i, j), k), ((i, k), j), ((j, k), i)]
+    candidates.sort()
+    return max(
+        candidates,
+        key=lambda item: (
+            sum(v in partitioned_vars for v in item[0]),
+            item[0][0] in partitioned_vars or item[0][1] in partitioned_vars,
+        ),
+    )
+
+
 # ---------------------------------------------------------------------------
 # Helpers: expression decomposition
 # ---------------------------------------------------------------------------
@@ -204,6 +290,7 @@ def _linearize_expr(
     expr: Expression,
     model: Model,
     bilinear_var_map: dict[tuple[int, int], int],
+    trilinear_var_map: dict[tuple[int, int, int], int],
     monomial_var_map: dict[tuple[int, int], int],
     n_total_vars: int,
 ) -> tuple[np.ndarray, float]:
@@ -306,6 +393,15 @@ def _linearize_expr(
                         coeff[bilinear_var_map[key]] += scale * c
                     else:
                         raise ValueError(f"Bilinear {key} not in map")
+                elif len(unique) == 3:
+                    if len(unique) != len(indices):
+                        raise ValueError("Mixed repeated-factor products are not supported")
+                    ordered = sorted(unique)
+                    tri_key = (ordered[0], ordered[1], ordered[2])
+                    if tri_key in trilinear_var_map:
+                        coeff[trilinear_var_map[tri_key]] += scale * c
+                    else:
+                        raise ValueError(f"Trilinear {tri_key} not in map")
                 else:
                     raise ValueError(f"Higher-order product ({len(unique)} vars) not supported")
 
@@ -392,9 +488,11 @@ def build_milp_relaxation(
     convhull_mode = _normalize_convhull_formulation(convhull_formulation)
 
     # ── Assign MILP column indices ──────────────────────────────────────────
-    # Layout: [original vars 0..n_orig-1] [bilinear aux w_ij] [monomial aux s_i^n]
-    # For partitioned bilinear terms: also [δ_k, x̄_k, w̄_k per partition k]
+    # Original variables keep columns 0..n_orig-1. Additional columns are created
+    # for lifted bilinear, trilinear, and monomial terms plus any piecewise binaries.
     bilinear_var_map: dict[tuple[int, int], int] = {}
+    trilinear_var_map: dict[tuple[int, int, int], int] = {}
+    trilinear_stage_map: dict[tuple[int, int, int], dict[str, object]] = {}
     monomial_var_map: dict[tuple[int, int], int] = {}
 
     col_idx = n_orig
@@ -404,15 +502,51 @@ def build_milp_relaxation(
         flag = 1 if v.var_type in (VarType.BINARY, VarType.INTEGER) else 0
         integrality_flags.extend([flag] * v.size)
 
-    # Pre-compute bilinear auxiliary variable slots
-    for i, j in terms.bilinear:
-        xi_lb, xi_ub = float(flat_lb[i]), float(flat_ub[i])
-        xj_lb, xj_ub = float(flat_lb[j]), float(flat_ub[j])
-        corners = [xi_lb * xj_lb, xi_lb * xj_ub, xi_ub * xj_lb, xi_ub * xj_ub]
-        bilinear_var_map[(i, j)] = col_idx
+    bilinear_relation_map: dict[tuple[int, int], int] = {}
+
+    def _ensure_bilinear_aux(lhs_col: int, rhs_col: int) -> int:
+        nonlocal col_idx
+        key = (min(lhs_col, rhs_col), max(lhs_col, rhs_col))
+        if key in bilinear_relation_map:
+            return bilinear_relation_map[key]
+
+        lhs_lb, lhs_ub = all_bounds[key[0]]
+        rhs_lb, rhs_ub = all_bounds[key[1]]
+        corners = [
+            lhs_lb * rhs_lb,
+            lhs_lb * rhs_ub,
+            lhs_ub * rhs_lb,
+            lhs_ub * rhs_ub,
+        ]
+        bilinear_relation_map[key] = col_idx
         all_bounds.append((min(corners), max(corners)))
         integrality_flags.append(0)
         col_idx += 1
+        return bilinear_relation_map[key]
+
+    original_bilinear_keys = sorted({(min(i, j), max(i, j)) for i, j in terms.bilinear})
+    for key in original_bilinear_keys:
+        bilinear_var_map[key] = _ensure_bilinear_aux(*key)
+
+    partitioned_vars = set(disc_state.partitions)
+    trilinear_terms: list[tuple[int, int, int]] = []
+    for term in terms.trilinear:
+        ordered = sorted(term)
+        canonical = (ordered[0], ordered[1], ordered[2])
+        if canonical not in trilinear_terms:
+            trilinear_terms.append(canonical)
+
+    for term in sorted(trilinear_terms):
+        pair, remaining = _choose_trilinear_pair(term, partitioned_vars)
+        pair_col = _ensure_bilinear_aux(*pair)
+        final_col = _ensure_bilinear_aux(pair_col, remaining)
+        trilinear_var_map[term] = final_col
+        trilinear_stage_map[term] = {
+            "pair": pair,
+            "pair_col": pair_col,
+            "remaining_var": remaining,
+            "product_col": final_col,
+        }
 
     for var_idx, n in terms.monomial:
         lb_i = float(flat_lb[var_idx])
@@ -425,56 +559,45 @@ def build_milp_relaxation(
         integrality_flags.append(0)
         col_idx += 1
 
-    # Piecewise McCormick: per-partition auxiliary variables for bilinear terms.
-    # For each bilinear (i,j) where i ∈ disc_state.partitions:
-    #   For each partition interval k:
-    #     δ_k  ∈ {0,1}       — binary selector (col)
-    #     x̄_k  ∈ [a_k, b_k]  — x_i value within interval k (0 outside)
-    #     w̄_k  ∈ [wi_lo, wi_hi] — bilinear product within interval k (0 outside)
-    # bilinear_pw_map[(i,j)] = [(delta_col, xbar_col, wbar_col, a_k, b_k), ...]
     bilinear_pw_map: dict[tuple[int, int], list] = {}
     bilinear_lambda_map: dict[tuple[int, int], dict] = {}
 
-    for i, j in terms.bilinear:
-        # Choose which variable to partition: prefer the one in disc_state
-        if i in disc_state.partitions:
-            part_var, other_var = i, j
-        elif j in disc_state.partitions:
-            part_var, other_var = j, i
+    for (lhs_col, rhs_col), _w_col in bilinear_relation_map.items():
+        part_var: Optional[int] = None
+        if lhs_col < n_orig and lhs_col in disc_state.partitions:
+            part_var = lhs_col
+            other_var = rhs_col
+        elif rhs_col < n_orig and rhs_col in disc_state.partitions:
+            part_var = rhs_col
+            other_var = lhs_col
         else:
-            continue  # no partitioning for this term
+            continue
 
         pts = disc_state.partitions[part_var]
-        xj_lb_g = float(flat_lb[other_var])
-        xj_ub_g = float(flat_ub[other_var])
+        other_lb, other_ub = all_bounds[other_var]
 
         if convhull_mode == "disaggregated":
             intervals = []
             for k in range(len(pts) - 1):
                 a_k = float(pts[k])
                 b_k = float(pts[k + 1])
-
-                # Big-M for bilinear product within this interval
                 _, wk_lo, wk_hi = _piecewise_product_bounds(
                     a_k,
                     b_k,
-                    xj_lb_g,
-                    xj_ub_g,
+                    float(other_lb),
+                    float(other_ub),
                 )
 
-                # δ_k ∈ {0,1}
                 delta_col = col_idx
                 all_bounds.append((0.0, 1.0))
                 integrality_flags.append(1)
                 col_idx += 1
 
-                # x̄_k ∈ [0, max(|a_k|, |b_k|)]  (0 when δ_k=0)
                 xbar_col = col_idx
                 all_bounds.append((min(a_k, 0.0), max(abs(a_k), abs(b_k))))
                 integrality_flags.append(0)
                 col_idx += 1
 
-                # w̄_k ∈ [wk_lo, wk_hi]  (0 when δ_k=0)
                 wbar_col = col_idx
                 all_bounds.append((min(wk_lo, 0.0), max(wk_hi, 0.0)))
                 integrality_flags.append(0)
@@ -482,16 +605,14 @@ def build_milp_relaxation(
 
                 intervals.append((delta_col, xbar_col, wbar_col, a_k, b_k))
 
-            bilinear_pw_map[(i, j)] = intervals
+            bilinear_pw_map[(lhs_col, rhs_col)] = intervals
         else:
             breakpoints = [float(p) for p in pts]
             lambda_cols: list[int] = []
             alpha_cols: list[int] = []
             theta_cols: list[int] = []
-            # theta = lambda * y can be zero whenever lambda = 0, so 0 must lie in
-            # the explicit theta bounds even if y does not cross zero.
-            theta_lb = min(0.0, xj_lb_g, xj_ub_g)
-            theta_ub = max(0.0, xj_lb_g, xj_ub_g)
+            theta_lb = min(0.0, float(other_lb), float(other_ub))
+            theta_ub = max(0.0, float(other_lb), float(other_ub))
 
             for _ in breakpoints:
                 lambda_cols.append(col_idx)
@@ -511,7 +632,7 @@ def build_milp_relaxation(
                 integrality_flags.append(0)
                 col_idx += 1
 
-            bilinear_lambda_map[(i, j)] = {
+            bilinear_lambda_map[(lhs_col, rhs_col)] = {
                 "part_var": part_var,
                 "other_var": other_var,
                 "breakpoints": breakpoints,
@@ -520,9 +641,6 @@ def build_milp_relaxation(
                 "theta_cols": theta_cols,
                 "mode": convhull_mode,
             }
-
-    # Also store in a form keyed by (part_var, other_var) for reference
-    # (not needed separately; we use bilinear_pw_map[(i,j)] directly)
 
     n_total = col_idx
 
@@ -542,13 +660,10 @@ def build_milp_relaxation(
             A_data.extend(coeff_arr[nz].tolist())
         b_rows.append(float(rhs))
 
-    # McCormick constraints for each bilinear term
-    for i, j in terms.bilinear:
-        xi_lb_g = float(flat_lb[i])
-        xi_ub_g = float(flat_ub[i])
-        xj_lb_g = float(flat_lb[j])
-        xj_ub_g = float(flat_ub[j])
-        w_col = bilinear_var_map[(i, j)]
+    # McCormick constraints for each lifted bilinear relation
+    for (i, j), w_col in bilinear_relation_map.items():
+        xi_lb_g, xi_ub_g = [float(v) for v in all_bounds[i]]
+        xj_lb_g, xj_ub_g = [float(v) for v in all_bounds[j]]
 
         if (i, j) in bilinear_lambda_map:
             lambda_info = bilinear_lambda_map[(i, j)]
@@ -559,8 +674,7 @@ def build_milp_relaxation(
             alpha_cols = list(lambda_info["alpha_cols"])
             theta_cols = list(lambda_info["theta_cols"])
             mode = str(lambda_info["mode"])
-            yj_lb = float(flat_lb[other_var])
-            yj_ub = float(flat_ub[other_var])
+            yj_lb, yj_ub = [float(v) for v in all_bounds[other_var]]
 
             row_sum_lambda = np.zeros(n_total)
             for lambda_col in lambda_cols:
@@ -649,14 +763,12 @@ def build_milp_relaxation(
         elif (i, j) in bilinear_pw_map and bilinear_pw_map[(i, j)]:
             # ── Piecewise McCormick with binary partition selection ──────────
             intervals = bilinear_pw_map[(i, j)]
-            # Determine partition var vs other var
-            if i in disc_state.partitions:
+            if i < n_orig and i in disc_state.partitions:
                 part_var, other_var = i, j
             else:
                 part_var, other_var = j, i
 
-            yj_lb = float(flat_lb[other_var])
-            yj_ub = float(flat_ub[other_var])
+            yj_lb, yj_ub = [float(v) for v in all_bounds[other_var]]
 
             # Constraint: Σ δ_k = 1 (select exactly one partition)
             row_sum = np.zeros(n_total)
@@ -791,61 +903,71 @@ def build_milp_relaxation(
         lb_i = float(flat_lb[var_idx])
         ub_i = float(flat_ub[var_idx])
         s_col = monomial_var_map[(var_idx, n)]
+        breakpoints = _monomial_breakpoints(var_idx, lb_i, ub_i, disc_state)
 
-        if n == 2:
-            # Piecewise tangent underestimators: s ≥ 2*t*x - t^2  for tangent point t.
-            # → -s + 2*t*x ≤ t^2
-            #
-            # KEY monotonicity requirement: as partitions get finer, the set of tangent
-            # points must grow (never shrink).  Using ALL BREAKPOINTS achieves this:
-            # linspace(lb,ub,k+1) breakpoints are a superset of linspace(lb,ub,k) for
-            # the test sequence n_init=1,2,4,8 (each is a refinement of the previous).
-            # Using midpoints would fail because n_init=1's midpoint (2.5) gives a
-            # tighter cut than n_init=2's midpoints (1.75, 3.25) at the LP optimum.
-            if var_idx in disc_state.partitions and len(disc_state.partitions[var_idx]) >= 2:
-                pts = disc_state.partitions[var_idx]
-                tangent_pts = [float(p) for p in pts]  # breakpoints as tangent points
-            else:
-                tangent_pts = [lb_i, ub_i]
-
-            for t in tangent_pts:
-                row = np.zeros(n_total)
-                row[s_col] = -1.0
-                row[var_idx] = 2.0 * t
-                _add_row(row, t * t)
-
-            # Global secant overestimator: s ≤ (lb+ub)*x - lb*ub
-            # → s - (lb+ub)*x ≤ -lb*ub
-            row = np.zeros(n_total)
-            row[s_col] = 1.0
-            row[var_idx] = -(lb_i + ub_i)
-            _add_row(row, -lb_i * ub_i)
-
-        else:
-            # General n: secant overestimator
-            if abs(ub_i - lb_i) > 1e-12:
-                slope = (ub_i**n - lb_i**n) / (ub_i - lb_i)
-                intercept = lb_i**n - slope * lb_i
-                row = np.zeros(n_total)
-                row[s_col] = 1.0
-                row[var_idx] = -slope
-                _add_row(row, intercept)
-
-            # Tangent at midpoint
-            mid = 0.5 * (lb_i + ub_i)
-            t_slope = n * (mid ** (n - 1))
-            t_intercept = -(n - 1) * (mid**n)
+        def _add_under_tangent(t: float) -> None:
+            slope, intercept = _power_tangent_line(t, n)
             row = np.zeros(n_total)
             row[s_col] = -1.0
-            row[var_idx] = t_slope
-            _add_row(row, -t_intercept)
+            row[var_idx] = slope
+            _add_row(row, -intercept)
+
+        def _add_over_tangent(t: float) -> None:
+            slope, intercept = _power_tangent_line(t, n)
+            row = np.zeros(n_total)
+            row[s_col] = 1.0
+            row[var_idx] = -slope
+            _add_row(row, intercept)
+
+        def _add_under_secant(a: float, b: float) -> None:
+            slope, intercept = _power_secant_line(a, b, n)
+            row = np.zeros(n_total)
+            row[s_col] = -1.0
+            row[var_idx] = slope
+            _add_row(row, -intercept)
+
+        def _add_over_secant(a: float, b: float) -> None:
+            slope, intercept = _power_secant_line(a, b, n)
+            row = np.zeros(n_total)
+            row[s_col] = 1.0
+            row[var_idx] = -slope
+            _add_row(row, intercept)
+
+        if n % 2 == 0 or lb_i >= 0.0:
+            # Convex on the full domain: tangents underestimate and the secant
+            # overestimates. Using all breakpoints makes the relaxation tighten
+            # monotonically as the partition is refined.
+            for t in breakpoints:
+                _add_under_tangent(t)
+            _add_over_secant(lb_i, ub_i)
+        elif ub_i <= 0.0:
+            # Concave on the full domain: the secant underestimates and tangents
+            # overestimate.
+            _add_under_secant(lb_i, ub_i)
+            for t in breakpoints:
+                _add_over_tangent(t)
+        else:
+            # Mixed-sign odd powers change curvature at zero. Keep only tangents that
+            # are globally valid on the current box so the relaxation remains sound.
+            for t in breakpoints:
+                if _odd_mixed_tangent_is_valid(t, lb_i, ub_i, n, "under"):
+                    _add_under_tangent(t)
+                if _odd_mixed_tangent_is_valid(t, lb_i, ub_i, n, "over"):
+                    _add_over_tangent(t)
 
     # Model constraints
     for constraint in model._constraints:
         body = constraint.body  # normalized: body <= 0  (sense is always "<=")
         sense = constraint.sense
         try:
-            c, const = _linearize_expr(body, model, bilinear_var_map, monomial_var_map, n_total)
+            c, const = _linearize_expr(
+                body,
+                model,
+                bilinear_var_map,
+                trilinear_var_map,
+                monomial_var_map,
+                n_total,
+            )
             # body ≤ 0  →  c @ z + const ≤ 0  →  c @ z ≤ -const
             if sense == "<=":
                 _add_row(c, -const)
@@ -873,7 +995,12 @@ def build_milp_relaxation(
     obj_expr = model._objective.expression
     try:
         c_obj, const_obj = _linearize_expr(
-            obj_expr, model, bilinear_var_map, monomial_var_map, n_total
+            obj_expr,
+            model,
+            bilinear_var_map,
+            trilinear_var_map,
+            monomial_var_map,
+            n_total,
         )
     except ValueError:
         # Fallback: trivial objective (LP gives ‑∞ lower bound — acceptable for soundness)
@@ -913,6 +1040,8 @@ def build_milp_relaxation(
     varmap: dict = {
         "original": {k: k for k in range(n_orig)},
         "bilinear": bilinear_var_map,
+        "trilinear": trilinear_var_map,
+        "trilinear_stages": trilinear_stage_map,
         "monomial": monomial_var_map,
         "bilinear_pw": bilinear_pw_map,
         "bilinear_lambda": bilinear_lambda_map,

--- a/python/tests/test_amp.py
+++ b/python/tests/test_amp.py
@@ -121,6 +121,24 @@ def _make_obbt_ineq_demo() -> Model:
     return m
 
 
+def _make_trilinear_cover() -> Model:
+    """Simple trilinear problem with a known AM-GM optimum of 3."""
+    m = Model("trilinear_cover")
+    x = m.continuous("x", lb=0, ub=2, shape=(3,))
+    m.subject_to(x[0] * x[1] * x[2] >= 1.0)
+    m.minimize(x[0] + x[1] + x[2])
+    return m
+
+
+def _make_quartic_objective_demo() -> Model:
+    """Univariate quartic objective whose MILP lower bound should tighten with refinement."""
+    m = Model("quartic_objective")
+    x = m.continuous("x", lb=0, ub=2)
+    m.subject_to(x >= 1.0)
+    m.minimize(x**4)
+    return m
+
+
 # ===========================================================================
 # Section 1: Nonlinear Term Classifier
 #
@@ -895,6 +913,66 @@ class TestMilpRelaxation:
             )
 
 
+class TestAmpPhase4Coverage:
+    """Regression coverage for trilinear and higher-order monomial relaxations."""
+
+    @pytest.fixture(autouse=True)
+    def _import(self):
+        from discopt._jax.discretization import initialize_partitions
+        from discopt._jax.milp_relaxation import (
+            _odd_mixed_tangent_is_valid,
+            build_milp_relaxation,
+        )
+        from discopt._jax.term_classifier import classify_nonlinear_terms
+
+        self.build_milp = build_milp_relaxation
+        self.classify = classify_nonlinear_terms
+        self.init_partitions = initialize_partitions
+        self.is_valid_odd_tangent = _odd_mixed_tangent_is_valid
+
+    def test_trilinear_milp_builds_nested_auxiliaries(self):
+        """Trilinear terms should be modeled through explicit lifted auxiliaries."""
+        m = _make_trilinear_cover()
+        terms = self.classify(m)
+        state = self.init_partitions([0, 1, 2], lb=[0.0, 0.0, 0.0], ub=[2.0, 2.0, 2.0], n_init=2)
+
+        milp_model, varmap = self.build_milp(m, terms, state, incumbent=None)
+        result = milp_model.solve()
+
+        assert (0, 1, 2) in varmap["trilinear"]
+        stage = varmap["trilinear_stages"][(0, 1, 2)]
+        assert stage["product_col"] == varmap["trilinear"][(0, 1, 2)]
+        assert result.status == "optimal"
+        assert result.objective is not None
+        assert 0.0 < result.objective <= 3.0 + 1e-6
+
+    def test_quartic_relaxation_tightens_with_finer_partitions(self):
+        """Breakpoint tangents should tighten n>2 monomial objectives as partitions refine."""
+        m = _make_quartic_objective_demo()
+        terms = self.classify(m)
+        lbs = []
+
+        for n_init in [1, 2, 4, 8]:
+            state = self.init_partitions([0], lb=[0.0], ub=[2.0], n_init=n_init)
+            milp_model, _ = self.build_milp(m, terms, state, incumbent=None)
+            result = milp_model.solve()
+            assert result.status == "optimal"
+            assert result.objective is not None
+            lbs.append(float(result.objective))
+
+        for i in range(len(lbs) - 1):
+            assert lbs[i] <= lbs[i + 1] + 1e-8
+        assert lbs[0] < 0.2
+        assert lbs[-1] >= 0.999
+
+    def test_mixed_sign_odd_tangent_filter_keeps_only_global_supporting_lines(self):
+        """Only tangents that stay valid on the full mixed-sign box should be used."""
+        assert self.is_valid_odd_tangent(0.5, -0.5, 0.5, 5, "under") is True
+        assert self.is_valid_odd_tangent(-0.5, -0.5, 0.5, 5, "over") is True
+        assert self.is_valid_odd_tangent(0.1, -1.0, 0.1, 5, "under") is False
+        assert self.is_valid_odd_tangent(-0.1, -0.1, 1.0, 5, "over") is False
+
+
 class TestAmpPhase1Helpers:
     """Fast regression tests for Phase 1 helper behavior."""
 
@@ -966,6 +1044,16 @@ class TestAmpEndToEnd:
         assert abs(result.objective - CIRCLE_OPTIMUM) <= 1e-3, (
             f"Objective {result.objective:.6f} too far from √2={CIRCLE_OPTIMUM}"
         )
+
+    @pytest.mark.smoke
+    def test_trilinear_global_optimum(self):
+        """A simple AM-GM trilinear instance should converge to the global optimum 3."""
+        m = _make_trilinear_cover()
+        result = m.solve(solver="amp", rel_gap=1e-3, time_limit=60)
+        assert result.status == "optimal"
+        assert result.gap_certified is True
+        assert result.objective is not None
+        assert abs(result.objective - 3.0) <= 1e-3
 
     @pytest.mark.slow
     @pytest.mark.timeout(300)


### PR DESCRIPTION
## What changed
Adds the scoped checklist for the trilinear and higher-order monomial relaxation slice.

## Why
These features both expand the set of nonlinear structures that the AMP MILP relaxation can cover soundly, and they are concentrated in the same implementation area.

## Implementation plan
- decompose trilinear terms into nested bilinear auxiliaries
- improve monomial `n > 2` relaxations from single-point to piecewise constructions
- add lower-bound validity and convergence tests for both paths

## Validation
- Reviewed the staged tracking doc locally
- Branch is pushed and ready for follow-up commits
