### PR TITLE
[draft] AMP Phase 5: advanced formulations and adaptive partitioning

### DIFF
--- a/plans/amp-completion/05-advanced-formulations.md
+++ b/plans/amp-completion/05-advanced-formulations.md
@@ -1,0 +1,18 @@
+# AMP Phase 5: Advanced Formulations and Adaptive Partitioning
+
+Plan phases:
+- 7 Facet formulation and embedded binary encoding
+- 8 Adaptive variable selection
+
+Primary files:
+- `python/discopt/_jax/milp_relaxation.py`
+- `python/discopt/_jax/embedding.py`
+- `python/discopt/_jax/partition_selection.py`
+- `python/discopt/solvers/amp.py`
+- `python/tests/test_amp.py`
+
+Exit criteria:
+- Facet and embedded-binary variants are available behind explicit options.
+- Binary growth scales like `O(log K)` where expected.
+- Variable selection can change across AMP iterations based on bound contribution.
+- Tests cover correctness and expected model-size reductions.

--- a/python/discopt/_jax/embedding.py
+++ b/python/discopt/_jax/embedding.py
@@ -62,8 +62,10 @@ def build_embedding_map(
     lambda_count : int
         Number of lambda variables, equal to the number of breakpoints.
     encoding : str, default ``"gray"``
-        Interval encoding scheme. Only encodings whose adjacent intervals differ
-        in one bit are accepted.
+        Interval encoding scheme. ``"gray"`` is SOS2-compatible for arbitrary
+        partition counts. ``"binary"`` is only SOS2-compatible for exactly two
+        partitions (``lambda_count == 3``) and is mainly kept to exercise the
+        validation path.
     """
     if lambda_count < 2:
         raise ValueError("lambda_count must be at least 2")
@@ -81,6 +83,13 @@ def build_embedding_map(
         )
 
     if not _is_sos2_compatible(codes):
+        if encoding == "binary":
+            raise ValueError(
+                "Embedding encoding 'binary' is not SOS2-compatible for "
+                f"{partition_count} partitions; it only works for exactly 2 "
+                "partitions (lambda_count=3). Use 'gray' for larger partition "
+                "counts."
+            )
         raise ValueError(
             f"Embedding encoding {encoding!r} is not SOS2-compatible for "
             f"{partition_count} partitions."

--- a/python/discopt/_jax/embedding.py
+++ b/python/discopt/_jax/embedding.py
@@ -1,0 +1,111 @@
+"""Embedded-binary helpers for SOS2-compatible convex-hull formulations.
+
+The helper here mirrors the Gray-code embedding idea used in Alpine.jl for
+piecewise convex-hull relaxations: replace one binary per interval with a
+logarithmic number of selector binaries while preserving the SOS2 adjacency
+pattern on the lambda variables.
+"""
+
+from __future__ import annotations
+
+import math
+from typing import TypedDict
+
+
+class EmbeddingMap(TypedDict):
+    """Structured SOS2 embedding metadata."""
+
+    encoding: str
+    bit_count: int
+    codes: tuple[tuple[int, ...], ...]
+    positive_sets: tuple[tuple[int, ...], ...]
+    negative_sets: tuple[tuple[int, ...], ...]
+
+
+def _binary_code(index: int, width: int) -> tuple[int, ...]:
+    """Return the fixed-width binary representation of ``index``."""
+    return tuple((index >> shift) & 1 for shift in range(width - 1, -1, -1))
+
+
+def _gray_code(index: int, width: int) -> tuple[int, ...]:
+    """Return the fixed-width Gray-code representation of ``index``."""
+    return _binary_code(index ^ (index >> 1), width)
+
+
+def _adjacent_intervals(lambda_idx: int, lambda_count: int) -> list[int]:
+    """Return the interval indices adjacent to breakpoint ``lambda_idx``."""
+    partition_count = lambda_count - 1
+    adjacent: list[int] = []
+    if lambda_idx > 0:
+        adjacent.append(lambda_idx - 1)
+    if lambda_idx < partition_count:
+        adjacent.append(lambda_idx)
+    return adjacent
+
+
+def _is_sos2_compatible(codes: list[tuple[int, ...]]) -> bool:
+    """Return True when adjacent interval codes differ in exactly one bit."""
+    for first, second in zip(codes, codes[1:]):
+        if sum(abs(a - b) for a, b in zip(first, second)) != 1:
+            return False
+    return True
+
+
+def build_embedding_map(
+    lambda_count: int,
+    encoding: str = "gray",
+) -> EmbeddingMap:
+    """Build an SOS2-compatible embedding map for ``lambda_count`` breakpoints.
+
+    Parameters
+    ----------
+    lambda_count : int
+        Number of lambda variables, equal to the number of breakpoints.
+    encoding : str, default ``"gray"``
+        Interval encoding scheme. Only encodings whose adjacent intervals differ
+        in one bit are accepted.
+    """
+    if lambda_count < 2:
+        raise ValueError("lambda_count must be at least 2")
+
+    partition_count = lambda_count - 1
+    bit_count = max(1, int(math.ceil(math.log2(max(1, partition_count)))))
+
+    if encoding == "gray":
+        codes = [_gray_code(i, bit_count) for i in range(partition_count)]
+    elif encoding == "binary":
+        codes = [_binary_code(i, bit_count) for i in range(partition_count)]
+    else:
+        raise ValueError(
+            f"Unsupported embedding encoding: {encoding!r}. Choose from 'gray' or 'binary'."
+        )
+
+    if not _is_sos2_compatible(codes):
+        raise ValueError(
+            f"Embedding encoding {encoding!r} is not SOS2-compatible for "
+            f"{partition_count} partitions."
+        )
+
+    positive_sets: list[tuple[int, ...]] = []
+    negative_sets: list[tuple[int, ...]] = []
+
+    for bit_idx in range(bit_count):
+        positive: list[int] = []
+        negative: list[int] = []
+        for lambda_idx in range(lambda_count):
+            adjacent = _adjacent_intervals(lambda_idx, lambda_count)
+            adjacent_codes = [codes[idx] for idx in adjacent]
+            if all(code[bit_idx] == 1 for code in adjacent_codes):
+                positive.append(lambda_idx)
+            if all(code[bit_idx] == 0 for code in adjacent_codes):
+                negative.append(lambda_idx)
+        positive_sets.append(tuple(positive))
+        negative_sets.append(tuple(negative))
+
+    return {
+        "encoding": encoding,
+        "bit_count": bit_count,
+        "codes": tuple(codes),
+        "positive_sets": tuple(positive_sets),
+        "negative_sets": tuple(negative_sets),
+    }

--- a/python/discopt/_jax/milp_relaxation.py
+++ b/python/discopt/_jax/milp_relaxation.py
@@ -483,7 +483,9 @@ def build_milp_relaxation(
         Replace SOS2 interval binaries with a logarithmic embedded encoding.
         Only supported with ``convhull_formulation="sos2"`` or ``"lambda"``.
     convhull_ebd_encoding : str, default "gray"
-        Embedded encoding scheme. ``"gray"`` is the Alpine-style default.
+        Embedded encoding scheme. ``"gray"`` is the Alpine-style default and
+        the only option that remains SOS2-compatible for arbitrary partition
+        counts. ``"binary"`` is only valid for two partitions.
 
     Returns
     -------
@@ -738,6 +740,11 @@ def build_milp_relaxation(
                 row_w[theta_col] -= float(p_j)
             _add_row(row_w, 0.0)
             _add_row(-row_w, 0.0)
+
+            if mode == "sos2":
+                assert alpha_cols or embedding_cols, (
+                    "Expected either alpha or embedding columns for SOS2 linking"
+                )
 
             if mode == "sos2" and embedding_info is not None:
                 for bit_col, positive_set, negative_set in zip(

--- a/python/discopt/_jax/milp_relaxation.py
+++ b/python/discopt/_jax/milp_relaxation.py
@@ -28,6 +28,7 @@ import numpy as np
 import scipy.sparse as sp
 
 from discopt._jax.discretization import DiscretizationState
+from discopt._jax.embedding import EmbeddingMap, build_embedding_map
 from discopt._jax.model_utils import flat_variable_bounds
 from discopt._jax.term_classifier import (
     NonlinearTerms,
@@ -446,6 +447,8 @@ def build_milp_relaxation(
     incumbent: Optional[np.ndarray] = None,
     oa_cuts: Optional[list] = None,
     convhull_formulation: str = "disaggregated",
+    convhull_ebd: bool = False,
+    convhull_ebd_encoding: str = "gray",
 ) -> tuple["MilpRelaxationModel", dict]:
     """Build a MILP relaxation with piecewise McCormick for bilinear/monomial terms.
 
@@ -476,6 +479,11 @@ def build_milp_relaxation(
         Piecewise bilinear formulation. ``"disaggregated"`` keeps the existing
         xbar/wbar construction; ``"sos2"`` and ``"facet"`` use a λ-based
         convex-hull reformulation similar to Alpine.jl.
+    convhull_ebd : bool, default False
+        Replace SOS2 interval binaries with a logarithmic embedded encoding.
+        Only supported with ``convhull_formulation="sos2"`` or ``"lambda"``.
+    convhull_ebd_encoding : str, default "gray"
+        Embedded encoding scheme. ``"gray"`` is the Alpine-style default.
 
     Returns
     -------
@@ -486,6 +494,10 @@ def build_milp_relaxation(
     flat_lb, flat_ub = flat_variable_bounds(model)
     n_orig = len(flat_lb)
     convhull_mode = _normalize_convhull_formulation(convhull_formulation)
+    if convhull_ebd and convhull_mode != "sos2":
+        raise ValueError(
+            "convhull_ebd is only supported with convhull_formulation='sos2' or its 'lambda' alias."
+        )
 
     # ── Assign MILP column indices ──────────────────────────────────────────
     # Original variables keep columns 0..n_orig-1. Additional columns are created
@@ -611,6 +623,8 @@ def build_milp_relaxation(
             lambda_cols: list[int] = []
             alpha_cols: list[int] = []
             theta_cols: list[int] = []
+            embedding_cols: list[int] = []
+            embedding_info: Optional[EmbeddingMap] = None
             theta_lb = min(0.0, float(other_lb), float(other_ub))
             theta_ub = max(0.0, float(other_lb), float(other_ub))
 
@@ -620,11 +634,22 @@ def build_milp_relaxation(
                 integrality_flags.append(0)
                 col_idx += 1
 
-            for _ in range(len(breakpoints) - 1):
-                alpha_cols.append(col_idx)
-                all_bounds.append((0.0, 1.0))
-                integrality_flags.append(1)
-                col_idx += 1
+            if convhull_mode == "sos2" and convhull_ebd and len(breakpoints) > 2:
+                embedding_info = build_embedding_map(
+                    len(breakpoints),
+                    encoding=convhull_ebd_encoding,
+                )
+                for _ in range(embedding_info["bit_count"]):
+                    embedding_cols.append(col_idx)
+                    all_bounds.append((0.0, 1.0))
+                    integrality_flags.append(1)
+                    col_idx += 1
+            else:
+                for _ in range(len(breakpoints) - 1):
+                    alpha_cols.append(col_idx)
+                    all_bounds.append((0.0, 1.0))
+                    integrality_flags.append(1)
+                    col_idx += 1
 
             for _ in breakpoints:
                 theta_cols.append(col_idx)
@@ -639,6 +664,8 @@ def build_milp_relaxation(
                 "lambda_cols": lambda_cols,
                 "alpha_cols": alpha_cols,
                 "theta_cols": theta_cols,
+                "embedding_cols": embedding_cols,
+                "embedding_info": embedding_info,
                 "mode": convhull_mode,
             }
 
@@ -673,6 +700,8 @@ def build_milp_relaxation(
             lambda_cols = list(lambda_info["lambda_cols"])
             alpha_cols = list(lambda_info["alpha_cols"])
             theta_cols = list(lambda_info["theta_cols"])
+            embedding_cols = list(lambda_info.get("embedding_cols", []))
+            embedding_info = lambda_info.get("embedding_info")
             mode = str(lambda_info["mode"])
             yj_lb, yj_ub = [float(v) for v in all_bounds[other_var]]
 
@@ -682,11 +711,12 @@ def build_milp_relaxation(
             _add_row(row_sum_lambda, -1.0)
             _add_row(-row_sum_lambda, 1.0)
 
-            row_sum_alpha = np.zeros(n_total)
-            for alpha_col in alpha_cols:
-                row_sum_alpha[alpha_col] = -1.0
-            _add_row(row_sum_alpha, -1.0)
-            _add_row(-row_sum_alpha, 1.0)
+            if alpha_cols:
+                row_sum_alpha = np.zeros(n_total)
+                for alpha_col in alpha_cols:
+                    row_sum_alpha[alpha_col] = -1.0
+                _add_row(row_sum_alpha, -1.0)
+                _add_row(-row_sum_alpha, 1.0)
 
             row_x = np.zeros(n_total)
             row_x[part_var] = 1.0
@@ -709,7 +739,24 @@ def build_milp_relaxation(
             _add_row(row_w, 0.0)
             _add_row(-row_w, 0.0)
 
-            if mode == "sos2":
+            if mode == "sos2" and embedding_info is not None:
+                for bit_col, positive_set, negative_set in zip(
+                    embedding_cols,
+                    embedding_info["positive_sets"],
+                    embedding_info["negative_sets"],
+                ):
+                    row = np.zeros(n_total)
+                    for lambda_idx in positive_set:
+                        row[lambda_cols[lambda_idx]] = 1.0
+                    row[bit_col] = -1.0
+                    _add_row(row, 0.0)
+
+                    row = np.zeros(n_total)
+                    for lambda_idx in negative_set:
+                        row[lambda_cols[lambda_idx]] = 1.0
+                    row[bit_col] = 1.0
+                    _add_row(row, 1.0)
+            elif mode == "sos2":
                 for idx, lambda_col in enumerate(lambda_cols):
                     row = np.zeros(n_total)
                     row[lambda_col] = 1.0
@@ -1046,6 +1093,8 @@ def build_milp_relaxation(
         "bilinear_pw": bilinear_pw_map,
         "bilinear_lambda": bilinear_lambda_map,
         "convhull_formulation": convhull_mode,
+        "convhull_ebd": convhull_ebd,
+        "convhull_ebd_encoding": convhull_ebd_encoding,
     }
 
     return milp_model, varmap

--- a/python/discopt/solver.py
+++ b/python/discopt/solver.py
@@ -1120,6 +1120,8 @@ def solve_model(
             "disc_add_partition_method",
             "disc_abs_width_tol",
             "convhull_formulation",
+            "convhull_ebd",
+            "convhull_ebd_encoding",
         ):
             if key in kwargs:
                 amp_kwargs[key] = kwargs.pop(key)

--- a/python/discopt/solvers/amp.py
+++ b/python/discopt/solvers/amp.py
@@ -263,6 +263,8 @@ def _solve_milp_with_oa_recovery(
     time_limit: Optional[float],
     gap_tolerance: float,
     convhull_formulation: str,
+    convhull_ebd: bool,
+    convhull_ebd_encoding: str,
 ):
     """Retry MILP solves after dropping the oldest half of OA cuts on infeasibility."""
     from discopt._jax.milp_relaxation import build_milp_relaxation
@@ -280,6 +282,8 @@ def _solve_milp_with_oa_recovery(
             incumbent,
             oa_cuts=active_oa_cuts,
             convhull_formulation=convhull_formulation,
+            convhull_ebd=convhull_ebd,
+            convhull_ebd_encoding=convhull_ebd_encoding,
         )
         milp_result = milp_model.solve(
             time_limit=time_limit,
@@ -438,6 +442,8 @@ def solve_amp(
     disc_add_partition_method: str = "adaptive",
     disc_abs_width_tol: float = 1e-3,
     convhull_formulation: str = "disaggregated",
+    convhull_ebd: bool = False,
+    convhull_ebd_encoding: str = "gray",
     presolve_bt: bool = True,
 ) -> SolveResult:
     """Solve MINLP globally using Adaptive Multivariate Partitioning (AMP).
@@ -483,6 +489,10 @@ def solve_amp(
     convhull_formulation : str
         Piecewise bilinear formulation: ``"disaggregated"``, ``"sos2"``,
         ``"facet"``, or ``"lambda"`` (alias for ``"sos2"``).
+    convhull_ebd : bool
+        Replace SOS2 interval binaries with an embedded logarithmic encoding.
+    convhull_ebd_encoding : str
+        Embedded encoding scheme for the SOS2 formulation.
     presolve_bt : bool
         Run LP-based OBBT before the AMP loop to tighten variable bounds.
 
@@ -516,6 +526,8 @@ def solve_amp(
 
     partition_mode = _normalize_partition_method(partition_method, disc_var_pick)
     convhull_mode = _normalize_convhull_formulation(convhull_formulation)
+    if convhull_ebd and convhull_mode != "sos2":
+        raise ValueError("convhull_ebd requires convhull_formulation='sos2' or the 'lambda' alias.")
 
     def _to_minimization_space(value: float) -> float:
         return -float(value) if maximize else float(value)
@@ -636,6 +648,8 @@ def solve_amp(
                 time_limit=milp_tl,
                 gap_tolerance=_milp_gap_tol,
                 convhull_formulation=convhull_mode,
+                convhull_ebd=convhull_ebd,
+                convhull_ebd_encoding=convhull_ebd_encoding,
             )
             oa_cuts = active_oa_cuts
         except Exception as e:

--- a/python/discopt/solvers/amp.py
+++ b/python/discopt/solvers/amp.py
@@ -492,7 +492,9 @@ def solve_amp(
     convhull_ebd : bool
         Replace SOS2 interval binaries with an embedded logarithmic encoding.
     convhull_ebd_encoding : str
-        Embedded encoding scheme for the SOS2 formulation.
+        Embedded encoding scheme for the SOS2 formulation. ``"gray"`` is the
+        only option that stays SOS2-compatible for arbitrary partition counts;
+        ``"binary"`` is only valid for two partitions.
     presolve_bt : bool
         Run LP-based OBBT before the AMP loop to tighten variable bounds.
 

--- a/python/tests/test_amp.py
+++ b/python/tests/test_amp.py
@@ -983,7 +983,7 @@ class TestMilpRelaxation:
         """Binary counting codes are invalid for SOS2 once adjacency breaks."""
         from discopt._jax.embedding import build_embedding_map
 
-        with pytest.raises(ValueError, match="not SOS2-compatible"):
+        with pytest.raises(ValueError, match="only works for exactly 2 partitions"):
             build_embedding_map(5, encoding="binary")
 
     def test_embedding_requires_sos2_formulation(self):
@@ -999,6 +999,36 @@ class TestMilpRelaxation:
                 state,
                 incumbent=None,
                 convhull_formulation="facet",
+                convhull_ebd=True,
+            )
+
+    def test_sos2_embedding_requires_selector_columns(self, monkeypatch):
+        """SOS2 linking must keep either alpha or embedded selector columns."""
+        m = _make_nlp1()
+        terms = self.classify(m)
+        state = self.init_partitions([0], lb=[1.0], ub=[4.0], n_init=4)
+
+        monkeypatch.setattr(
+            "discopt._jax.milp_relaxation.build_embedding_map",
+            lambda lambda_count, encoding="gray": {
+                "encoding": encoding,
+                "bit_count": 0,
+                "codes": tuple(),
+                "positive_sets": tuple(),
+                "negative_sets": tuple(),
+            },
+        )
+
+        with pytest.raises(
+            AssertionError,
+            match="Expected either alpha or embedding columns for SOS2 linking",
+        ):
+            self.build_milp(
+                m,
+                terms,
+                state,
+                incumbent=None,
+                convhull_formulation="sos2",
                 convhull_ebd=True,
             )
 
@@ -1133,6 +1163,45 @@ class TestAmpEndToEnd:
         assert result.objective is not None
         assert abs(result.objective - CIRCLE_OPTIMUM) <= 1e-3, (
             f"Objective {result.objective:.6f} too far from √2={CIRCLE_OPTIMUM}"
+        )
+
+    def test_amp_embedding_rebuilds_across_refinement_iterations(self, monkeypatch):
+        """Embedded SOS2 should stay consistent as AMP refines the partitions."""
+        import discopt._jax.milp_relaxation as milp_mod
+
+        orig_build = milp_mod.build_milp_relaxation
+        lambda_counts = []
+        bit_counts = []
+
+        def spy_build(*args, **kwargs):
+            milp_model, varmap = orig_build(*args, **kwargs)
+            info = next(iter(varmap["bilinear_lambda"].values()))
+            lambda_counts.append(len(info["lambda_cols"]))
+            bit_counts.append(len(info["embedding_cols"]))
+            return milp_model, varmap
+
+        monkeypatch.setattr(milp_mod, "build_milp_relaxation", spy_build)
+
+        m = _make_nlp1()
+        result = m.solve(
+            solver="amp",
+            convhull_formulation="sos2",
+            convhull_ebd=True,
+            rel_gap=1e-6,
+            max_iter=4,
+            time_limit=30,
+        )
+
+        assert result.status in ("optimal", "feasible")
+        assert result.objective is not None
+        assert abs(result.objective - NLP1_OPTIMUM) <= 0.15
+        assert len(bit_counts) >= 2
+        assert bit_counts[0] == 1
+        assert bit_counts[0] < max(bit_counts)
+        assert lambda_counts[0] < max(lambda_counts)
+        assert all(
+            bit_count == max(1, int(np.ceil(np.log2(max(1, lambda_count - 1)))))
+            for bit_count, lambda_count in zip(bit_counts, lambda_counts)
         )
 
     @pytest.mark.smoke

--- a/python/tests/test_amp.py
+++ b/python/tests/test_amp.py
@@ -849,6 +849,73 @@ class TestMilpRelaxation:
         assert len(info["alpha_cols"]) == 2
         assert len(info["theta_cols"]) == 3
 
+    def test_sos2_embedding_uses_logarithmic_selector_count(self):
+        """Embedded SOS2 should replace interval binaries with O(log K) selectors."""
+        m = _make_nlp1()
+        terms = self.classify(m)
+        state = self.init_partitions([0], lb=[1.0], ub=[4.0], n_init=8)
+
+        _, plain_varmap = self.build_milp(
+            m,
+            terms,
+            state,
+            incumbent=None,
+            convhull_formulation="sos2",
+        )
+        _, embedded_varmap = self.build_milp(
+            m,
+            terms,
+            state,
+            incumbent=None,
+            convhull_formulation="sos2",
+            convhull_ebd=True,
+            convhull_ebd_encoding="gray",
+        )
+
+        plain_info = plain_varmap["bilinear_lambda"][(0, 1)]
+        embedded_info = embedded_varmap["bilinear_lambda"][(0, 1)]
+        assert len(plain_info["alpha_cols"]) == 8
+        assert len(embedded_info["alpha_cols"]) == 0
+        assert len(embedded_info["embedding_cols"]) == 3
+        assert embedded_varmap["convhull_ebd"] is True
+        assert embedded_varmap["convhull_ebd_encoding"] == "gray"
+
+    def test_sos2_embedding_matches_plain_sos2_relaxation_value(self):
+        """Embedded SOS2 should preserve the λ-relaxation bound on a simple model."""
+        m = Model("embedding_compare")
+        x = m.continuous("x", lb=0, ub=2, shape=(2,))
+        m.subject_to(x[0] * x[1] >= 1.0)
+        m.minimize(x[0] + x[1])
+
+        terms = self.classify(m)
+        state = self.init_partitions([0], lb=[0.0], ub=[2.0], n_init=4)
+
+        plain_model, _ = self.build_milp(
+            m,
+            terms,
+            state,
+            incumbent=None,
+            convhull_formulation="sos2",
+        )
+        embedded_model, _ = self.build_milp(
+            m,
+            terms,
+            state,
+            incumbent=None,
+            convhull_formulation="sos2",
+            convhull_ebd=True,
+            convhull_ebd_encoding="gray",
+        )
+
+        plain_result = plain_model.solve()
+        embedded_result = embedded_model.solve()
+
+        assert plain_result.status == "optimal"
+        assert embedded_result.status == "optimal"
+        assert plain_result.objective is not None
+        assert embedded_result.objective is not None
+        assert embedded_result.objective == pytest.approx(plain_result.objective, abs=1e-6)
+
     def test_sos2_and_facet_convhull_match_on_simple_bilinear_relaxation(self):
         """SOS2 and facet λ-linking should dominate the disaggregated relaxation."""
         m = Model("lambda_compare")
@@ -910,6 +977,29 @@ class TestMilpRelaxation:
                 state,
                 incumbent=None,
                 convhull_formulation="bogus",
+            )
+
+    def test_embedding_helper_rejects_non_sos2_compatible_encoding(self):
+        """Binary counting codes are invalid for SOS2 once adjacency breaks."""
+        from discopt._jax.embedding import build_embedding_map
+
+        with pytest.raises(ValueError, match="not SOS2-compatible"):
+            build_embedding_map(5, encoding="binary")
+
+    def test_embedding_requires_sos2_formulation(self):
+        """Embedded binaries should be rejected for non-SOS2 formulations."""
+        m = _make_nlp1()
+        terms = self.classify(m)
+        state = self.init_partitions([0], lb=[1.0], ub=[4.0], n_init=2)
+
+        with pytest.raises(ValueError, match="convhull_ebd is only supported"):
+            self.build_milp(
+                m,
+                terms,
+                state,
+                incumbent=None,
+                convhull_formulation="facet",
+                convhull_ebd=True,
             )
 
 
@@ -1318,6 +1408,8 @@ class TestCurrentCodeWeaknesses:
             disc_add_partition_method="uniform",
             disc_abs_width_tol=1e-2,
             convhull_formulation="sos2",
+            convhull_ebd=True,
+            convhull_ebd_encoding="gray",
         )
 
         assert captured["rel_gap"] == pytest.approx(1e-3)
@@ -1327,6 +1419,8 @@ class TestCurrentCodeWeaknesses:
         assert captured["disc_add_partition_method"] == "uniform"
         assert captured["disc_abs_width_tol"] == pytest.approx(1e-2)
         assert captured["convhull_formulation"] == "sos2"
+        assert captured["convhull_ebd"] is True
+        assert captured["convhull_ebd_encoding"] == "gray"
 
     def test_integer_rounding_candidates_include_floor_and_ceil(self):
         """Nearest-integer rounding fallback must try floor and ceil alternatives."""
@@ -1491,8 +1585,12 @@ class TestCurrentCodeWeaknesses:
             incumbent,
             oa_cuts=None,
             convhull_formulation="disaggregated",
+            convhull_ebd=False,
+            convhull_ebd_encoding="gray",
         ):
             assert convhull_formulation == "disaggregated"
+            assert convhull_ebd is False
+            assert convhull_ebd_encoding == "gray"
             size = len(oa_cuts or [])
             call_sizes.append(size)
             status = "infeasible" if size >= 4 else "optimal"
@@ -1512,6 +1610,8 @@ class TestCurrentCodeWeaknesses:
             time_limit=1.0,
             gap_tolerance=1e-4,
             convhull_formulation="disaggregated",
+            convhull_ebd=False,
+            convhull_ebd_encoding="gray",
         )
 
         assert call_sizes == [4, 2]


### PR DESCRIPTION
## What changed
Adds the scoped checklist for the advanced formulation and adaptive variable-selection slice.

## Why
These items both sit on top of the tighter formulation work and materially change the partitioning model size and selection strategy.

## Implementation plan
- add facet and embedded-binary options
- add adaptive `disc_var_pick=3` behavior across iterations
- validate correctness and model-size reductions with targeted tests

## Validation
- Reviewed the staged tracking doc locally
- Branch is pushed and ready for follow-up commits
