### PR TITLE
Add shared nonlinear bound tightening

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ The release procedure that produces these entries is documented in
 
 ### Fixed
 
+- Large-bound warnings now remain conservative when nonlinear tightening can
+  infer a smaller box but that tightened box is not applied to every solve path.
+
 ## [0.3.0] - 2026-04-24
 
 This release skips the never-tagged `0.2.6` and folds its draft entries into `0.3.0` along with the post-`0.2.6` feature and infrastructure work.

--- a/python/discopt/_jax/nonlinear_bound_tightening.py
+++ b/python/discopt/_jax/nonlinear_bound_tightening.py
@@ -9,7 +9,7 @@ future rules can be added without changing solver-side plumbing.
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Optional, Sequence
+from typing import NoReturn, Optional, Sequence
 
 import numpy as np
 
@@ -79,6 +79,12 @@ class NonlinearBoundTighteningStats:
 
     n_tightened: int
     applied_rules: tuple[str, ...]
+    infeasible: bool = False
+    infeasibility_reason: Optional[str] = None
+
+
+class NonlinearBoundTighteningInfeasible(ValueError):
+    """Raised internally when a sound tightening rule proves infeasibility."""
 
 
 class NonlinearBoundTighteningRule:
@@ -188,6 +194,17 @@ def _apply_integrality(
     return lb, ub
 
 
+def _constraint_label(constraint) -> str:
+    name = getattr(constraint, "name", None)
+    return str(name) if name else repr(constraint)
+
+
+def _prove_infeasible(rule_name: str, constraint, reason: str) -> NoReturn:
+    raise NonlinearBoundTighteningInfeasible(
+        f"{rule_name} proved infeasibility for {_constraint_label(constraint)}: {reason}"
+    )
+
+
 def _tighten_affine_argument_interval(
     tightened_lb: np.ndarray,
     tightened_ub: np.ndarray,
@@ -227,6 +244,11 @@ def _tighten_affine_argument_interval(
     if new_lb <= new_ub:
         tightened_lb[flat_idx] = new_lb
         tightened_ub[flat_idx] = new_ub
+        return
+
+    raise NonlinearBoundTighteningInfeasible(
+        f"tightened interval is empty for flat variable {flat_idx}: [{new_lb}, {new_ub}]"
+    )
 
 
 def _flatten_sum(expr, scale: float, out: list[tuple[float, object]]) -> None:
@@ -324,7 +346,7 @@ class SumOfSquaresUpperBoundRule(NonlinearBoundTighteningRule):
         tightened_ub = flat_ub.copy()
 
         for constraint in model._constraints:
-            if getattr(constraint, "sense", None) != "<=":
+            if getattr(constraint, "sense", None) not in ("<=", "=="):
                 continue
 
             terms: list[tuple[float, object]] = []
@@ -354,7 +376,14 @@ class SumOfSquaresUpperBoundRule(NonlinearBoundTighteningRule):
             if not matches_pattern or not square_coeffs:
                 continue
 
-            rhs = max(0.0, -constant_term)
+            rhs = -constant_term
+            if rhs < -1e-12:
+                _prove_infeasible(
+                    self.name,
+                    constraint,
+                    "nonnegative sum of squares has a negative upper bound",
+                )
+            rhs = max(0.0, rhs)
             for flat_idx, coeff in square_coeffs.items():
                 if coeff <= 0.0:
                     continue
@@ -374,6 +403,12 @@ class SumOfSquaresUpperBoundRule(NonlinearBoundTighteningRule):
                 if new_lb <= new_ub:
                     tightened_lb[flat_idx] = new_lb
                     tightened_ub[flat_idx] = new_ub
+                else:
+                    _prove_infeasible(
+                        self.name,
+                        constraint,
+                        f"required interval for flat variable {flat_idx} is empty",
+                    )
 
         return tightened_lb, tightened_ub
 
@@ -422,7 +457,7 @@ class SeparableQuadraticUpperBoundRule(NonlinearBoundTighteningRule):
         tightened_ub = flat_ub.copy()
 
         for constraint in model._constraints:
-            if getattr(constraint, "sense", None) != "<=":
+            if getattr(constraint, "sense", None) not in ("<=", "=="):
                 continue
 
             terms: list[tuple[float, object]] = []
@@ -477,6 +512,13 @@ class SeparableQuadraticUpperBoundRule(NonlinearBoundTighteningRule):
                 )
 
             total_min = float(sum(min_contribs.values()))
+            if constant_term + total_min > 1e-12:
+                _prove_infeasible(
+                    self.name,
+                    constraint,
+                    "minimum separable quadratic activity exceeds the upper bound",
+                )
+
             for flat_idx, (a, b) in coeffs.items():
                 rhs = -constant_term - (total_min - min_contribs[flat_idx])
                 if not np.isfinite(rhs):
@@ -490,7 +532,11 @@ class SeparableQuadraticUpperBoundRule(NonlinearBoundTighteningRule):
                     float(tightened_ub[flat_idx]),
                 )
                 if interval is None:
-                    continue
+                    _prove_infeasible(
+                        self.name,
+                        constraint,
+                        f"required interval for flat variable {flat_idx} is empty",
+                    )
 
                 new_lb, new_ub = interval
                 var_type = metadata.flat_var_types[flat_idx]
@@ -504,6 +550,12 @@ class SeparableQuadraticUpperBoundRule(NonlinearBoundTighteningRule):
                 if new_lb <= new_ub:
                     tightened_lb[flat_idx] = new_lb
                     tightened_ub[flat_idx] = new_ub
+                else:
+                    _prove_infeasible(
+                        self.name,
+                        constraint,
+                        f"required interval for flat variable {flat_idx} is empty",
+                    )
 
         return tightened_lb, tightened_ub
 
@@ -514,6 +566,32 @@ def _safe_exp(value: float) -> float:
     if value < -745.0:
         return 0.0
     return float(np.exp(value))
+
+
+def _monotone_function_value(func_name: str, value: float) -> float:
+    if func_name == "exp":
+        return _safe_exp(value)
+    if func_name == "log":
+        if value <= 0.0:
+            return -float("inf")
+        return float(np.log(value))
+    if func_name == "log2":
+        if value <= 0.0:
+            return -float("inf")
+        return float(np.log2(value))
+    if func_name == "log10":
+        if value <= 0.0:
+            return -float("inf")
+        return float(np.log10(value))
+    if func_name == "log1p":
+        if value <= -1.0:
+            return -float("inf")
+        return float(np.log1p(value))
+    if func_name == "sqrt":
+        if value < 0.0:
+            return float("nan")
+        return float(np.sqrt(value))
+    raise ValueError(f"Unsupported monotone function: {func_name}")
 
 
 def _inverse_monotone_upper(func_name: str, rhs: float) -> Optional[float]:
@@ -617,7 +695,7 @@ class MonotoneFunctionBoundsRule(NonlinearBoundTighteningRule):
         tightened_ub = flat_ub.copy()
 
         for constraint in model._constraints:
-            if getattr(constraint, "sense", None) != "<=":
+            if getattr(constraint, "sense", None) not in ("<=", "=="):
                 continue
 
             terms: list[tuple[float, object]] = []
@@ -649,12 +727,41 @@ class MonotoneFunctionBoundsRule(NonlinearBoundTighteningRule):
             domain_lb, domain_ub = _MONOTONE_DOMAINS[func_name]
             arg_lb = domain_lb
             arg_ub = domain_ub
+            arg_endpoint_a = arg_coeff * float(tightened_lb[flat_idx]) + arg_offset
+            arg_endpoint_b = arg_coeff * float(tightened_ub[flat_idx]) + arg_offset
+            current_arg_lb = min(arg_endpoint_a, arg_endpoint_b)
+            current_arg_ub = max(arg_endpoint_a, arg_endpoint_b)
+            if domain_lb is not None:
+                current_arg_lb = max(current_arg_lb, domain_lb)
+            if domain_ub is not None:
+                current_arg_ub = min(current_arg_ub, domain_ub)
+            if current_arg_lb > current_arg_ub + 1e-12:
+                _prove_infeasible(
+                    self.name,
+                    constraint,
+                    f"{func_name} argument domain is empty on the current box",
+                )
+
+            func_min = _monotone_function_value(func_name, current_arg_lb)
+            func_max = _monotone_function_value(func_name, current_arg_ub)
             rhs = -constant_term / func_coeff
             if func_coeff > 0.0:
+                if rhs < func_min - 1e-12:
+                    _prove_infeasible(
+                        self.name,
+                        constraint,
+                        f"{func_name}(argument) cannot be <= {rhs}",
+                    )
                 upper = _inverse_monotone_upper(func_name, rhs)
                 if upper is not None:
                     arg_ub = upper if arg_ub is None else min(arg_ub, upper)
             else:
+                if rhs > func_max + 1e-12:
+                    _prove_infeasible(
+                        self.name,
+                        constraint,
+                        f"{func_name}(argument) cannot be >= {rhs}",
+                    )
                 lower = _inverse_monotone_lower(func_name, rhs)
                 if lower is not None:
                     arg_lb = lower if arg_lb is None else max(arg_lb, lower)
@@ -724,7 +831,7 @@ class ReciprocalBoundsRule(NonlinearBoundTighteningRule):
         max_val = max(vals)
         if rhs >= max_val - 1e-12:
             return None, None
-        if rhs < min_val - 1e-12 or abs(rhs) <= 1e-12:
+        if rhs < min_val - 1e-12:
             return None, None
 
         threshold = numerator / rhs
@@ -743,7 +850,7 @@ class ReciprocalBoundsRule(NonlinearBoundTighteningRule):
         tightened_ub = flat_ub.copy()
 
         for constraint in model._constraints:
-            if getattr(constraint, "sense", None) != "<=":
+            if getattr(constraint, "sense", None) not in ("<=", "=="):
                 continue
 
             terms: list[tuple[float, object]] = []
@@ -776,9 +883,18 @@ class ReciprocalBoundsRule(NonlinearBoundTighteningRule):
             if arg_lo <= 0.0 <= arg_hi:
                 continue
 
+            rhs = -constant_term
+            vals = (numerator / arg_lo, numerator / arg_hi)
+            if rhs < min(vals) - 1e-12:
+                _prove_infeasible(
+                    self.name,
+                    constraint,
+                    "reciprocal activity exceeds the upper bound on the sign-stable box",
+                )
+
             arg_lb, arg_ub = self._argument_interval_for_leq(
                 numerator,
-                -constant_term,
+                rhs,
                 arg_lo,
                 arg_hi,
             )
@@ -817,13 +933,58 @@ def tighten_nonlinear_bounds(
 
     applied_rules: list[str] = []
     n_tightened = 0
+    empty_initial = np.flatnonzero(tightened_lb > tightened_ub + 1e-12)
+    if empty_initial.size > 0:
+        first_idx = int(empty_initial[0])
+        return (
+            tightened_lb,
+            tightened_ub,
+            NonlinearBoundTighteningStats(
+                n_tightened=0,
+                applied_rules=(),
+                infeasible=True,
+                infeasibility_reason=f"initial interval is empty for flat variable {first_idx}",
+            ),
+        )
 
     for rule in rules:
         prev_lb = tightened_lb.copy()
         prev_ub = tightened_ub.copy()
-        cand_lb, cand_ub = rule.tighten(model, prev_lb, prev_ub, metadata)
-        tightened_lb = np.maximum(prev_lb, np.asarray(cand_lb, dtype=np.float64))
-        tightened_ub = np.minimum(prev_ub, np.asarray(cand_ub, dtype=np.float64))
+        try:
+            cand_lb, cand_ub = rule.tighten(model, prev_lb, prev_ub, metadata)
+        except NonlinearBoundTighteningInfeasible as exc:
+            applied_rules.append(rule.name)
+            return (
+                prev_lb,
+                prev_ub,
+                NonlinearBoundTighteningStats(
+                    n_tightened=n_tightened,
+                    applied_rules=tuple(applied_rules),
+                    infeasible=True,
+                    infeasibility_reason=str(exc),
+                ),
+            )
+
+        cand_lb_arr = np.asarray(cand_lb, dtype=np.float64)
+        cand_ub_arr = np.asarray(cand_ub, dtype=np.float64)
+        empty_indices = np.flatnonzero(cand_lb_arr > cand_ub_arr + 1e-12)
+        if empty_indices.size > 0:
+            applied_rules.append(rule.name)
+            first_idx = int(empty_indices[0])
+            return (
+                prev_lb,
+                prev_ub,
+                NonlinearBoundTighteningStats(
+                    n_tightened=n_tightened,
+                    applied_rules=tuple(applied_rules),
+                    infeasible=True,
+                    infeasibility_reason=(
+                        f"{rule.name} returned an empty interval for flat variable {first_idx}"
+                    ),
+                ),
+            )
+        tightened_lb = np.maximum(prev_lb, cand_lb_arr)
+        tightened_ub = np.minimum(prev_ub, cand_ub_arr)
 
         n_changed = int(
             np.count_nonzero(np.abs(tightened_lb - prev_lb) > 1e-12)

--- a/python/discopt/_jax/nonlinear_bound_tightening.py
+++ b/python/discopt/_jax/nonlinear_bound_tightening.py
@@ -1,0 +1,843 @@
+"""Pattern-based nonlinear bound tightening shared across solver frontends.
+
+These rules complement the existing linear FBBT and LP-based OBBT paths.
+Each rule must be sound with respect to the current variable box and may only
+tighten bounds. The runner clips every rule's output against the current box so
+future rules can be added without changing solver-side plumbing.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional, Sequence
+
+import numpy as np
+
+from discopt.modeling.core import (
+    BinaryOp,
+    Constant,
+    FunctionCall,
+    IndexExpression,
+    Model,
+    UnaryOp,
+    Variable,
+    VarType,
+)
+
+_EFFECTIVE_INF = 1e19
+
+
+def is_effectively_finite(value: float) -> bool:
+    """Return True when a bound is finite in the solver sense."""
+    return bool(np.isfinite(value) and abs(float(value)) < _EFFECTIVE_INF)
+
+
+@dataclass(frozen=True)
+class FlatVariableMetadata:
+    """Flat indexing metadata shared by nonlinear tightening rules."""
+
+    base_offsets: dict[int, int]
+    flat_var_types: tuple[VarType, ...]
+
+    def scalar_flat_index(self, expr) -> Optional[int]:
+        """Return the flat scalar index for a scalar variable expression."""
+        if isinstance(expr, Variable):
+            if expr.size != 1:
+                return None
+            return self.base_offsets[id(expr)]
+
+        if isinstance(expr, IndexExpression) and isinstance(expr.base, Variable):
+            base = expr.base
+            base_offset = self.base_offsets[id(base)]
+            idx = expr.index
+            if base.shape == ():
+                flat_idx = 0
+            else:
+                if not isinstance(idx, tuple):
+                    idx = (idx,)
+                flat_idx = int(np.ravel_multi_index(idx, base.shape))
+            return base_offset + flat_idx
+
+        return None
+
+
+def build_flat_variable_metadata(model: Model) -> FlatVariableMetadata:
+    """Build flat-variable indexing metadata for a model."""
+    base_offsets: dict[int, int] = {}
+    flat_var_types: list[VarType] = []
+    offset = 0
+    for var in model._variables:
+        base_offsets[id(var)] = offset
+        flat_var_types.extend([var.var_type] * var.size)
+        offset += var.size
+    return FlatVariableMetadata(base_offsets=base_offsets, flat_var_types=tuple(flat_var_types))
+
+
+@dataclass(frozen=True)
+class NonlinearBoundTighteningStats:
+    """Summary of a nonlinear tightening pass."""
+
+    n_tightened: int
+    applied_rules: tuple[str, ...]
+
+
+class NonlinearBoundTighteningRule:
+    """Base class for extensible nonlinear bound tightening rules."""
+
+    name = "unnamed_rule"
+
+    def tighten(
+        self,
+        model: Model,
+        flat_lb: np.ndarray,
+        flat_ub: np.ndarray,
+        metadata: FlatVariableMetadata,
+    ) -> tuple[np.ndarray, np.ndarray]:
+        raise NotImplementedError
+
+
+def _constant_value(expr) -> Optional[float]:
+    if not isinstance(expr, Constant):
+        return None
+    values = np.asarray(expr.value, dtype=np.float64).ravel()
+    if values.size != 1:
+        return None
+    return float(values[0])
+
+
+def _match_scaled_linear_var(
+    expr,
+    scale: float,
+    metadata: FlatVariableMetadata,
+) -> Optional[tuple[int, float]]:
+    if isinstance(expr, UnaryOp) and expr.op == "neg":
+        return _match_scaled_linear_var(expr.operand, -scale, metadata)
+
+    if isinstance(expr, BinaryOp) and expr.op == "*":
+        left_const = _constant_value(expr.left)
+        if left_const is not None:
+            return _match_scaled_linear_var(expr.right, scale * left_const, metadata)
+        right_const = _constant_value(expr.right)
+        if right_const is not None:
+            return _match_scaled_linear_var(expr.left, scale * right_const, metadata)
+
+    flat_idx = metadata.scalar_flat_index(expr)
+    if flat_idx is None:
+        return None
+    return flat_idx, scale
+
+
+def _merge_affine_matches(
+    left: tuple[Optional[int], float, float],
+    right: tuple[Optional[int], float, float],
+) -> Optional[tuple[Optional[int], float, float]]:
+    left_idx, left_coeff, left_offset = left
+    right_idx, right_coeff, right_offset = right
+    if left_idx is not None and right_idx is not None and left_idx != right_idx:
+        return None
+    flat_idx = left_idx if left_idx is not None else right_idx
+    return flat_idx, left_coeff + right_coeff, left_offset + right_offset
+
+
+def _match_affine_var(
+    expr,
+    scale: float,
+    metadata: FlatVariableMetadata,
+) -> Optional[tuple[Optional[int], float, float]]:
+    """Match an affine scalar expression a*x + b in one flat variable."""
+    const_val = _constant_value(expr)
+    if const_val is not None:
+        return None, 0.0, scale * const_val
+
+    flat_idx = metadata.scalar_flat_index(expr)
+    if flat_idx is not None:
+        return flat_idx, scale, 0.0
+
+    if isinstance(expr, UnaryOp) and expr.op == "neg":
+        return _match_affine_var(expr.operand, -scale, metadata)
+
+    if isinstance(expr, BinaryOp) and expr.op == "*":
+        left_const = _constant_value(expr.left)
+        if left_const is not None:
+            return _match_affine_var(expr.right, scale * left_const, metadata)
+        right_const = _constant_value(expr.right)
+        if right_const is not None:
+            return _match_affine_var(expr.left, scale * right_const, metadata)
+        return None
+
+    if isinstance(expr, BinaryOp) and expr.op in ("+", "-"):
+        left = _match_affine_var(expr.left, scale, metadata)
+        right_scale = scale if expr.op == "+" else -scale
+        right = _match_affine_var(expr.right, right_scale, metadata)
+        if left is None or right is None:
+            return None
+        return _merge_affine_matches(left, right)
+
+    return None
+
+
+def _apply_integrality(
+    lb: float,
+    ub: float,
+    var_type: VarType,
+) -> tuple[float, float]:
+    if var_type == VarType.BINARY:
+        return max(lb, 0.0), min(ub, 1.0)
+    if var_type == VarType.INTEGER:
+        return float(np.ceil(lb - 1e-9)), float(np.floor(ub + 1e-9))
+    return lb, ub
+
+
+def _tighten_affine_argument_interval(
+    tightened_lb: np.ndarray,
+    tightened_ub: np.ndarray,
+    metadata: FlatVariableMetadata,
+    flat_idx: int,
+    coeff: float,
+    offset: float,
+    arg_lb: Optional[float] = None,
+    arg_ub: Optional[float] = None,
+) -> None:
+    """Intersect a flat variable box with L <= coeff*x + offset <= U."""
+    if abs(coeff) <= 1e-12:
+        return
+
+    new_lb = float(tightened_lb[flat_idx])
+    new_ub = float(tightened_ub[flat_idx])
+
+    if arg_lb is not None and np.isfinite(arg_lb):
+        bound = (float(arg_lb) - offset) / coeff
+        if coeff > 0.0:
+            new_lb = max(new_lb, bound)
+        else:
+            new_ub = min(new_ub, bound)
+
+    if arg_ub is not None and np.isfinite(arg_ub):
+        bound = (float(arg_ub) - offset) / coeff
+        if coeff > 0.0:
+            new_ub = min(new_ub, bound)
+        else:
+            new_lb = max(new_lb, bound)
+
+    new_lb, new_ub = _apply_integrality(
+        new_lb,
+        new_ub,
+        metadata.flat_var_types[flat_idx],
+    )
+    if new_lb <= new_ub:
+        tightened_lb[flat_idx] = new_lb
+        tightened_ub[flat_idx] = new_ub
+
+
+def _flatten_sum(expr, scale: float, out: list[tuple[float, object]]) -> None:
+    if isinstance(expr, BinaryOp) and expr.op == "+":
+        _flatten_sum(expr.left, scale, out)
+        _flatten_sum(expr.right, scale, out)
+        return
+    if isinstance(expr, BinaryOp) and expr.op == "-":
+        _flatten_sum(expr.left, scale, out)
+        _flatten_sum(expr.right, -scale, out)
+        return
+    out.append((scale, expr))
+
+
+def _min_univariate_quadratic(a: float, b: float, lb: float, ub: float) -> float:
+    """Return min of a*x^2 + b*x over [lb, ub] for a >= 0."""
+    if a < -1e-12:
+        raise ValueError("nonconvex univariate quadratic is not supported")
+
+    if abs(a) <= 1e-12:
+        return min(b * lb, b * ub)
+
+    x_star = -b / (2.0 * a)
+    x_eval = min(max(x_star, lb), ub)
+    return min(a * lb * lb + b * lb, a * x_eval * x_eval + b * x_eval, a * ub * ub + b * ub)
+
+
+def _tighten_univariate_quadratic_interval(
+    a: float,
+    b: float,
+    rhs: float,
+    lb: float,
+    ub: float,
+) -> Optional[tuple[float, float]]:
+    """Intersect [lb, ub] with the feasible set of a*x^2 + b*x <= rhs for a >= 0."""
+    if abs(a) <= 1e-12:
+        if abs(b) <= 1e-12:
+            return (lb, ub) if rhs >= -1e-12 else None
+        bound = rhs / b
+        if b > 0.0:
+            return (lb, min(ub, bound))
+        return (max(lb, bound), ub)
+
+    discriminant = b * b + 4.0 * a * rhs
+    if discriminant < -1e-12:
+        return None
+    discriminant = max(discriminant, 0.0)
+    sqrt_disc = float(np.sqrt(discriminant))
+    root_lo = (-b - sqrt_disc) / (2.0 * a)
+    root_hi = (-b + sqrt_disc) / (2.0 * a)
+    return (max(lb, root_lo), min(ub, root_hi))
+
+
+class SumOfSquaresUpperBoundRule(NonlinearBoundTighteningRule):
+    """Tighten bounds from constraints like sum(a_i * x_i^2) <= c."""
+
+    name = "sum_of_squares_upper_bound"
+
+    def _match_scaled_square(
+        self,
+        expr,
+        scale: float,
+        metadata: FlatVariableMetadata,
+    ) -> Optional[tuple[int, float]]:
+        if isinstance(expr, UnaryOp) and expr.op == "neg":
+            return self._match_scaled_square(expr.operand, -scale, metadata)
+
+        if isinstance(expr, BinaryOp) and expr.op == "*":
+            left_const = _constant_value(expr.left)
+            if left_const is not None:
+                return self._match_scaled_square(expr.right, scale * left_const, metadata)
+            right_const = _constant_value(expr.right)
+            if right_const is not None:
+                return self._match_scaled_square(expr.left, scale * right_const, metadata)
+
+        if isinstance(expr, BinaryOp) and expr.op == "**":
+            exponent = _constant_value(expr.right)
+            if exponent is None or abs(exponent - 2.0) > 1e-12:
+                return None
+            flat_idx = metadata.scalar_flat_index(expr.left)
+            if flat_idx is None:
+                return None
+            return flat_idx, scale
+
+        return None
+
+    def tighten(
+        self,
+        model: Model,
+        flat_lb: np.ndarray,
+        flat_ub: np.ndarray,
+        metadata: FlatVariableMetadata,
+    ) -> tuple[np.ndarray, np.ndarray]:
+        tightened_lb = flat_lb.copy()
+        tightened_ub = flat_ub.copy()
+
+        for constraint in model._constraints:
+            if getattr(constraint, "sense", None) != "<=":
+                continue
+
+            terms: list[tuple[float, object]] = []
+            _flatten_sum(constraint.body, 1.0, terms)
+
+            constant_term = 0.0
+            square_coeffs: dict[int, float] = {}
+            matches_pattern = True
+
+            for scale, term in terms:
+                const_val = _constant_value(term)
+                if const_val is not None:
+                    constant_term += scale * const_val
+                    continue
+
+                match = self._match_scaled_square(term, scale, metadata)
+                if match is None:
+                    matches_pattern = False
+                    break
+
+                flat_idx, coeff = match
+                if coeff <= 0.0:
+                    matches_pattern = False
+                    break
+                square_coeffs[flat_idx] = square_coeffs.get(flat_idx, 0.0) + coeff
+
+            if not matches_pattern or not square_coeffs:
+                continue
+
+            rhs = max(0.0, -constant_term)
+            for flat_idx, coeff in square_coeffs.items():
+                if coeff <= 0.0:
+                    continue
+
+                radius = float(np.sqrt(rhs / coeff))
+                new_lb = max(float(tightened_lb[flat_idx]), -radius)
+                new_ub = min(float(tightened_ub[flat_idx]), radius)
+
+                var_type = metadata.flat_var_types[flat_idx]
+                if var_type == VarType.BINARY:
+                    new_lb = max(new_lb, 0.0)
+                    new_ub = min(new_ub, 1.0)
+                elif var_type == VarType.INTEGER:
+                    new_lb = float(np.ceil(new_lb - 1e-9))
+                    new_ub = float(np.floor(new_ub + 1e-9))
+
+                if new_lb <= new_ub:
+                    tightened_lb[flat_idx] = new_lb
+                    tightened_ub[flat_idx] = new_ub
+
+        return tightened_lb, tightened_ub
+
+
+class SeparableQuadraticUpperBoundRule(NonlinearBoundTighteningRule):
+    """Tighten bounds from separable convex quadratic constraints like x + y^2 <= c."""
+
+    name = "separable_quadratic_upper_bound"
+
+    def _match_scaled_square(
+        self,
+        expr,
+        scale: float,
+        metadata: FlatVariableMetadata,
+    ) -> Optional[tuple[int, float]]:
+        if isinstance(expr, UnaryOp) and expr.op == "neg":
+            return self._match_scaled_square(expr.operand, -scale, metadata)
+
+        if isinstance(expr, BinaryOp) and expr.op == "*":
+            left_const = _constant_value(expr.left)
+            if left_const is not None:
+                return self._match_scaled_square(expr.right, scale * left_const, metadata)
+            right_const = _constant_value(expr.right)
+            if right_const is not None:
+                return self._match_scaled_square(expr.left, scale * right_const, metadata)
+
+        if isinstance(expr, BinaryOp) and expr.op == "**":
+            exponent = _constant_value(expr.right)
+            if exponent is None or abs(exponent - 2.0) > 1e-12:
+                return None
+            flat_idx = metadata.scalar_flat_index(expr.left)
+            if flat_idx is None:
+                return None
+            return flat_idx, scale
+
+        return None
+
+    def tighten(
+        self,
+        model: Model,
+        flat_lb: np.ndarray,
+        flat_ub: np.ndarray,
+        metadata: FlatVariableMetadata,
+    ) -> tuple[np.ndarray, np.ndarray]:
+        tightened_lb = flat_lb.copy()
+        tightened_ub = flat_ub.copy()
+
+        for constraint in model._constraints:
+            if getattr(constraint, "sense", None) != "<=":
+                continue
+
+            terms: list[tuple[float, object]] = []
+            _flatten_sum(constraint.body, 1.0, terms)
+
+            constant_term = 0.0
+            quad_coeffs: dict[int, float] = {}
+            linear_coeffs: dict[int, float] = {}
+            matches_pattern = True
+
+            for scale, term in terms:
+                const_val = _constant_value(term)
+                if const_val is not None:
+                    constant_term += scale * const_val
+                    continue
+
+                square_match = self._match_scaled_square(term, scale, metadata)
+                if square_match is not None:
+                    flat_idx, coeff = square_match
+                    quad_coeffs[flat_idx] = quad_coeffs.get(flat_idx, 0.0) + coeff
+                    continue
+
+                linear_match = _match_scaled_linear_var(term, scale, metadata)
+                if linear_match is not None:
+                    flat_idx, coeff = linear_match
+                    linear_coeffs[flat_idx] = linear_coeffs.get(flat_idx, 0.0) + coeff
+                    continue
+
+                matches_pattern = False
+                break
+
+            if not matches_pattern or (not quad_coeffs and not linear_coeffs):
+                continue
+
+            coeffs = {
+                flat_idx: (
+                    quad_coeffs.get(flat_idx, 0.0),
+                    linear_coeffs.get(flat_idx, 0.0),
+                )
+                for flat_idx in set(quad_coeffs) | set(linear_coeffs)
+            }
+            if any(a < -1e-12 for a, _ in coeffs.values()):
+                continue
+
+            min_contribs: dict[int, float] = {}
+            for flat_idx, (a, b) in coeffs.items():
+                min_contribs[flat_idx] = _min_univariate_quadratic(
+                    a,
+                    b,
+                    float(tightened_lb[flat_idx]),
+                    float(tightened_ub[flat_idx]),
+                )
+
+            total_min = float(sum(min_contribs.values()))
+            for flat_idx, (a, b) in coeffs.items():
+                rhs = -constant_term - (total_min - min_contribs[flat_idx])
+                if not np.isfinite(rhs):
+                    continue
+
+                interval = _tighten_univariate_quadratic_interval(
+                    a,
+                    b,
+                    rhs,
+                    float(tightened_lb[flat_idx]),
+                    float(tightened_ub[flat_idx]),
+                )
+                if interval is None:
+                    continue
+
+                new_lb, new_ub = interval
+                var_type = metadata.flat_var_types[flat_idx]
+                if var_type == VarType.BINARY:
+                    new_lb = max(new_lb, 0.0)
+                    new_ub = min(new_ub, 1.0)
+                elif var_type == VarType.INTEGER:
+                    new_lb = float(np.ceil(new_lb - 1e-9))
+                    new_ub = float(np.floor(new_ub + 1e-9))
+
+                if new_lb <= new_ub:
+                    tightened_lb[flat_idx] = new_lb
+                    tightened_ub[flat_idx] = new_ub
+
+        return tightened_lb, tightened_ub
+
+
+def _safe_exp(value: float) -> float:
+    if value > 709.0:
+        return float("inf")
+    if value < -745.0:
+        return 0.0
+    return float(np.exp(value))
+
+
+def _inverse_monotone_upper(func_name: str, rhs: float) -> Optional[float]:
+    """Return U such that f(arg) <= rhs implies arg <= U."""
+    if func_name == "exp":
+        if rhs <= 0.0:
+            return None
+        return float(np.log(rhs))
+    if func_name == "log":
+        return _safe_exp(rhs)
+    if func_name == "log2":
+        return float("inf") if rhs > 1024.0 else float(2.0**rhs)
+    if func_name == "log10":
+        return float("inf") if rhs > 308.0 else float(10.0**rhs)
+    if func_name == "log1p":
+        return _safe_exp(rhs) - 1.0
+    if func_name == "sqrt":
+        if rhs < 0.0:
+            return None
+        return rhs * rhs
+    return None
+
+
+def _inverse_monotone_lower(func_name: str, rhs: float) -> Optional[float]:
+    """Return L such that f(arg) >= rhs implies arg >= L."""
+    if func_name == "exp":
+        if rhs <= 0.0:
+            return None
+        return float(np.log(rhs))
+    if func_name == "log":
+        return _safe_exp(rhs)
+    if func_name == "log2":
+        return 0.0 if rhs < -1074.0 else float(2.0**rhs)
+    if func_name == "log10":
+        return 0.0 if rhs < -324.0 else float(10.0**rhs)
+    if func_name == "log1p":
+        return _safe_exp(rhs) - 1.0
+    if func_name == "sqrt":
+        if rhs <= 0.0:
+            return None
+        return rhs * rhs
+    return None
+
+
+_MONOTONE_DOMAINS: dict[str, tuple[Optional[float], Optional[float]]] = {
+    "exp": (None, None),
+    "log": (0.0, None),
+    "log2": (0.0, None),
+    "log10": (0.0, None),
+    "log1p": (-1.0, None),
+    "sqrt": (0.0, None),
+}
+
+
+class MonotoneFunctionBoundsRule(NonlinearBoundTighteningRule):
+    """Tighten affine arguments of monotone unary function constraints."""
+
+    name = "monotone_function_bounds"
+
+    def _match_scaled_function(
+        self,
+        expr,
+        scale: float,
+        metadata: FlatVariableMetadata,
+    ) -> Optional[tuple[str, float, int, float, float]]:
+        if isinstance(expr, UnaryOp) and expr.op == "neg":
+            return self._match_scaled_function(expr.operand, -scale, metadata)
+
+        if isinstance(expr, BinaryOp) and expr.op == "*":
+            left_const = _constant_value(expr.left)
+            if left_const is not None:
+                return self._match_scaled_function(expr.right, scale * left_const, metadata)
+            right_const = _constant_value(expr.right)
+            if right_const is not None:
+                return self._match_scaled_function(expr.left, scale * right_const, metadata)
+            return None
+
+        if (
+            not isinstance(expr, FunctionCall)
+            or expr.func_name not in _MONOTONE_DOMAINS
+            or len(expr.args) != 1
+        ):
+            return None
+
+        affine_match = _match_affine_var(expr.args[0], 1.0, metadata)
+        if affine_match is None:
+            return None
+        flat_idx, arg_coeff, arg_offset = affine_match
+        if flat_idx is None or abs(arg_coeff) <= 1e-12:
+            return None
+        return expr.func_name, scale, flat_idx, arg_coeff, arg_offset
+
+    def tighten(
+        self,
+        model: Model,
+        flat_lb: np.ndarray,
+        flat_ub: np.ndarray,
+        metadata: FlatVariableMetadata,
+    ) -> tuple[np.ndarray, np.ndarray]:
+        tightened_lb = flat_lb.copy()
+        tightened_ub = flat_ub.copy()
+
+        for constraint in model._constraints:
+            if getattr(constraint, "sense", None) != "<=":
+                continue
+
+            terms: list[tuple[float, object]] = []
+            _flatten_sum(constraint.body, 1.0, terms)
+
+            constant_term = 0.0
+            function_match: Optional[tuple[str, float, int, float, float]] = None
+            matches_pattern = True
+
+            for scale, term in terms:
+                const_val = _constant_value(term)
+                if const_val is not None:
+                    constant_term += scale * const_val
+                    continue
+
+                match = self._match_scaled_function(term, scale, metadata)
+                if match is None or function_match is not None:
+                    matches_pattern = False
+                    break
+                function_match = match
+
+            if not matches_pattern or function_match is None:
+                continue
+
+            func_name, func_coeff, flat_idx, arg_coeff, arg_offset = function_match
+            if abs(func_coeff) <= 1e-12:
+                continue
+
+            domain_lb, domain_ub = _MONOTONE_DOMAINS[func_name]
+            arg_lb = domain_lb
+            arg_ub = domain_ub
+            rhs = -constant_term / func_coeff
+            if func_coeff > 0.0:
+                upper = _inverse_monotone_upper(func_name, rhs)
+                if upper is not None:
+                    arg_ub = upper if arg_ub is None else min(arg_ub, upper)
+            else:
+                lower = _inverse_monotone_lower(func_name, rhs)
+                if lower is not None:
+                    arg_lb = lower if arg_lb is None else max(arg_lb, lower)
+
+            _tighten_affine_argument_interval(
+                tightened_lb,
+                tightened_ub,
+                metadata,
+                flat_idx,
+                arg_coeff,
+                arg_offset,
+                arg_lb=arg_lb,
+                arg_ub=arg_ub,
+            )
+
+        return tightened_lb, tightened_ub
+
+
+class ReciprocalBoundsRule(NonlinearBoundTighteningRule):
+    """Tighten sign-stable affine denominators in simple reciprocal constraints."""
+
+    name = "reciprocal_bounds"
+
+    def _match_scaled_reciprocal(
+        self,
+        expr,
+        scale: float,
+        metadata: FlatVariableMetadata,
+    ) -> Optional[tuple[float, int, float, float]]:
+        if isinstance(expr, UnaryOp) and expr.op == "neg":
+            return self._match_scaled_reciprocal(expr.operand, -scale, metadata)
+
+        if isinstance(expr, BinaryOp) and expr.op == "*":
+            left_const = _constant_value(expr.left)
+            if left_const is not None:
+                return self._match_scaled_reciprocal(expr.right, scale * left_const, metadata)
+            right_const = _constant_value(expr.right)
+            if right_const is not None:
+                return self._match_scaled_reciprocal(expr.left, scale * right_const, metadata)
+            return None
+
+        if not isinstance(expr, BinaryOp) or expr.op != "/":
+            return None
+
+        numerator = _constant_value(expr.left)
+        if numerator is None or abs(numerator) <= 1e-12:
+            return None
+
+        denominator = _match_affine_var(expr.right, 1.0, metadata)
+        if denominator is None:
+            return None
+        flat_idx, denom_coeff, denom_offset = denominator
+        if flat_idx is None or abs(denom_coeff) <= 1e-12:
+            return None
+
+        return scale * numerator, flat_idx, denom_coeff, denom_offset
+
+    @staticmethod
+    def _argument_interval_for_leq(
+        numerator: float,
+        rhs: float,
+        arg_lo: float,
+        arg_hi: float,
+    ) -> tuple[Optional[float], Optional[float]]:
+        vals = (numerator / arg_lo, numerator / arg_hi)
+        min_val = min(vals)
+        max_val = max(vals)
+        if rhs >= max_val - 1e-12:
+            return None, None
+        if rhs < min_val - 1e-12 or abs(rhs) <= 1e-12:
+            return None, None
+
+        threshold = numerator / rhs
+        if numerator > 0.0:
+            return threshold, None
+        return None, threshold
+
+    def tighten(
+        self,
+        model: Model,
+        flat_lb: np.ndarray,
+        flat_ub: np.ndarray,
+        metadata: FlatVariableMetadata,
+    ) -> tuple[np.ndarray, np.ndarray]:
+        tightened_lb = flat_lb.copy()
+        tightened_ub = flat_ub.copy()
+
+        for constraint in model._constraints:
+            if getattr(constraint, "sense", None) != "<=":
+                continue
+
+            terms: list[tuple[float, object]] = []
+            _flatten_sum(constraint.body, 1.0, terms)
+
+            constant_term = 0.0
+            reciprocal_match: Optional[tuple[float, int, float, float]] = None
+            matches_pattern = True
+
+            for scale, term in terms:
+                const_val = _constant_value(term)
+                if const_val is not None:
+                    constant_term += scale * const_val
+                    continue
+
+                match = self._match_scaled_reciprocal(term, scale, metadata)
+                if match is None or reciprocal_match is not None:
+                    matches_pattern = False
+                    break
+                reciprocal_match = match
+
+            if not matches_pattern or reciprocal_match is None:
+                continue
+
+            numerator, flat_idx, denom_coeff, denom_offset = reciprocal_match
+            arg_endpoint_a = denom_coeff * float(tightened_lb[flat_idx]) + denom_offset
+            arg_endpoint_b = denom_coeff * float(tightened_ub[flat_idx]) + denom_offset
+            arg_lo = min(arg_endpoint_a, arg_endpoint_b)
+            arg_hi = max(arg_endpoint_a, arg_endpoint_b)
+            if arg_lo <= 0.0 <= arg_hi:
+                continue
+
+            arg_lb, arg_ub = self._argument_interval_for_leq(
+                numerator,
+                -constant_term,
+                arg_lo,
+                arg_hi,
+            )
+            _tighten_affine_argument_interval(
+                tightened_lb,
+                tightened_ub,
+                metadata,
+                flat_idx,
+                denom_coeff,
+                denom_offset,
+                arg_lb=arg_lb,
+                arg_ub=arg_ub,
+            )
+
+        return tightened_lb, tightened_ub
+
+
+DEFAULT_NONLINEAR_BOUND_RULES: tuple[NonlinearBoundTighteningRule, ...] = (
+    MonotoneFunctionBoundsRule(),
+    ReciprocalBoundsRule(),
+    SumOfSquaresUpperBoundRule(),
+    SeparableQuadraticUpperBoundRule(),
+)
+
+
+def tighten_nonlinear_bounds(
+    model: Model,
+    flat_lb: np.ndarray,
+    flat_ub: np.ndarray,
+    rules: Sequence[NonlinearBoundTighteningRule] = DEFAULT_NONLINEAR_BOUND_RULES,
+) -> tuple[np.ndarray, np.ndarray, NonlinearBoundTighteningStats]:
+    """Run registered nonlinear tightening rules on a variable box."""
+    tightened_lb = np.asarray(flat_lb, dtype=np.float64).copy()
+    tightened_ub = np.asarray(flat_ub, dtype=np.float64).copy()
+    metadata = build_flat_variable_metadata(model)
+
+    applied_rules: list[str] = []
+    n_tightened = 0
+
+    for rule in rules:
+        prev_lb = tightened_lb.copy()
+        prev_ub = tightened_ub.copy()
+        cand_lb, cand_ub = rule.tighten(model, prev_lb, prev_ub, metadata)
+        tightened_lb = np.maximum(prev_lb, np.asarray(cand_lb, dtype=np.float64))
+        tightened_ub = np.minimum(prev_ub, np.asarray(cand_ub, dtype=np.float64))
+
+        n_changed = int(
+            np.count_nonzero(np.abs(tightened_lb - prev_lb) > 1e-12)
+            + np.count_nonzero(np.abs(tightened_ub - prev_ub) > 1e-12)
+        )
+        if n_changed > 0:
+            applied_rules.append(rule.name)
+            n_tightened += n_changed
+
+    return (
+        tightened_lb,
+        tightened_ub,
+        NonlinearBoundTighteningStats(
+            n_tightened=n_tightened,
+            applied_rules=tuple(applied_rules),
+        ),
+    )

--- a/python/discopt/solver.py
+++ b/python/discopt/solver.py
@@ -355,7 +355,7 @@ def _check_constraint_feasibility(evaluator, x, cl_list, cu_list, tol=1e-4):
     return max_viol <= tol
 
 
-def _tighten_node_bounds(evaluator, node_lb, node_ub, cl_list, cu_list, max_rounds=3):
+def _tighten_node_bounds_with_status(evaluator, node_lb, node_ub, cl_list, cu_list, max_rounds=3):
     """Constraint-based bound tightening (FBBT) for a single B&B node.
 
     Uses the constraint Jacobian to propagate implied variable bounds.
@@ -378,12 +378,14 @@ def _tighten_node_bounds(evaluator, node_lb, node_ub, cl_list, cu_list, max_roun
     -------
     lb, ub : np.ndarray
         Tightened variable bounds.
+    infeasible : bool
+        True if nonlinear tightening proved the node infeasible.
     """
     lb = node_lb.copy()
     ub = node_ub.copy()
 
     if evaluator.n_constraints == 0 or not cl_list:
-        return _apply_nonlinear_tightening(evaluator._model, lb, ub)
+        return _apply_nonlinear_tightening_with_status(evaluator._model, lb, ub)
 
     n = len(lb)
     m = len(cl_list)
@@ -402,15 +404,19 @@ def _tighten_node_bounds(evaluator, node_lb, node_ub, cl_list, cu_list, max_roun
         J_b = evaluator.evaluate_jacobian(pt_b)
         is_linear = np.all(np.abs(J_a - J_b) < 1e-8, axis=1)  # (m,) bool
     except Exception:
-        return _apply_nonlinear_tightening(evaluator._model, lb, ub)
+        return _apply_nonlinear_tightening_with_status(evaluator._model, lb, ub)
 
     if not np.any(is_linear):
-        return _apply_nonlinear_tightening(evaluator._model, lb, ub)
+        return _apply_nonlinear_tightening_with_status(evaluator._model, lb, ub)
 
     for _ in range(max_rounds):
         changed = False
 
-        tightened_lb, tightened_ub = _apply_nonlinear_tightening(evaluator._model, lb, ub)
+        tightened_lb, tightened_ub, infeasible = _apply_nonlinear_tightening_with_status(
+            evaluator._model, lb, ub
+        )
+        if infeasible:
+            return tightened_lb, tightened_ub, True
         if np.any(np.abs(tightened_lb - lb) > 1e-12) or np.any(np.abs(tightened_ub - ub) > 1e-12):
             lb = tightened_lb
             ub = tightened_ub
@@ -487,7 +493,34 @@ def _tighten_node_bounds(evaluator, node_lb, node_ub, cl_list, cu_list, max_roun
         if not changed:
             break
 
+    return lb, ub, False
+
+
+def _tighten_node_bounds(evaluator, node_lb, node_ub, cl_list, cu_list, max_rounds=3):
+    """Constraint-based bound tightening without the infeasibility status."""
+    lb, ub, _infeasible = _tighten_node_bounds_with_status(
+        evaluator, node_lb, node_ub, cl_list, cu_list, max_rounds=max_rounds
+    )
     return lb, ub
+
+
+def _apply_nonlinear_tightening_with_status(
+    model: Model,
+    lb: np.ndarray,
+    ub: np.ndarray,
+) -> tuple[np.ndarray, np.ndarray, bool]:
+    """Apply opportunistic nonlinear bound tightening without aborting node processing."""
+    try:
+        tightened_lb, tightened_ub, stats = tighten_nonlinear_bounds(model, lb, ub)
+    except Exception as exc:
+        logger.debug("Skipping nonlinear tightening after error: %s", exc)
+        return lb, ub, False
+
+    if stats.infeasible:
+        logger.debug("Nonlinear tightening proved infeasibility: %s", stats.infeasibility_reason)
+        return lb, ub, True
+
+    return tightened_lb, tightened_ub, False
 
 
 def _apply_nonlinear_tightening(
@@ -495,13 +528,8 @@ def _apply_nonlinear_tightening(
     lb: np.ndarray,
     ub: np.ndarray,
 ) -> tuple[np.ndarray, np.ndarray]:
-    """Apply opportunistic nonlinear bound tightening without aborting node processing."""
-    try:
-        tightened_lb, tightened_ub, _ = tighten_nonlinear_bounds(model, lb, ub)
-    except Exception as exc:
-        logger.debug("Skipping nonlinear tightening after error: %s", exc)
-        return lb, ub
-
+    """Apply opportunistic nonlinear bound tightening without the infeasibility status."""
+    tightened_lb, tightened_ub, _infeasible = _apply_nonlinear_tightening_with_status(model, lb, ub)
     return tightened_lb, tightened_ub
 
 
@@ -1185,6 +1213,12 @@ def _check_finite_bounds(model: Model) -> None:
     tightening_note = ""
     try:
         tightened_lb, tightened_ub, bt_stats = tighten_nonlinear_bounds(model, raw_lb, raw_ub)
+        if bt_stats.infeasible:
+            logger.info(
+                "Nonlinear tightening proved infeasibility before large-bound warning: %s",
+                bt_stats.infeasibility_reason,
+            )
+            return
         if bt_stats.n_tightened > 0:
             tightening_note = (
                 f" Nonlinear tightening adjusted {bt_stats.n_tightened} bounds"
@@ -1206,6 +1240,19 @@ def _check_finite_bounds(model: Model) -> None:
             f"m.continuous('x', lb=0, ub=1000).",
             stacklevel=3,
         )
+
+
+def _detect_nonlinear_bound_infeasibility(model: Model) -> Optional[str]:
+    """Return a nonlinear bound-tightening infeasibility proof when available."""
+    flat_lb, flat_ub = flat_variable_bounds(model)
+    try:
+        _tightened_lb, _tightened_ub, stats = tighten_nonlinear_bounds(model, flat_lb, flat_ub)
+    except Exception as exc:
+        logger.debug("Skipping nonlinear infeasibility precheck after error: %s", exc)
+        return None
+    if stats.infeasible:
+        return stats.infeasibility_reason or "nonlinear bound tightening proved infeasibility"
+    return None
 
 
 def _is_pure_continuous(model: Model) -> bool:
@@ -1491,6 +1538,16 @@ def solve_model(
     # All solver paths (LP IPM, QP IPM, NLP) use barrier methods that
     # struggle with bounds beyond ~1e15. Check once before any dispatch.
     _check_finite_bounds(model)
+    nonlinear_infeasibility = _detect_nonlinear_bound_infeasibility(model)
+    if nonlinear_infeasibility is not None:
+        logger.info(
+            "Nonlinear bound tightening proved model infeasible: %s", nonlinear_infeasibility
+        )
+        return SolveResult(
+            status="infeasible",
+            wall_time=time.perf_counter() - t_start,
+            gap_certified=True,
+        )
 
     # --- Explicit NLP-BB override: bypass specialized solvers ---
     if nlp_bb is True and not _is_pure_continuous(model):
@@ -1863,11 +1920,17 @@ def solve_model(
             break
 
         # Tighten node bounds via constraint propagation (FBBT).
+        node_infeasible_mask = np.zeros(n_batch, dtype=bool)
         if cl_list:
             for i in range(n_batch):
                 node_lb_i = np.array(batch_lb[i])
                 node_ub_i = np.array(batch_ub[i])
-                t_lb, t_ub = _tighten_node_bounds(evaluator, node_lb_i, node_ub_i, cl_list, cu_list)
+                t_lb, t_ub, node_infeasible = _tighten_node_bounds_with_status(
+                    evaluator, node_lb_i, node_ub_i, cl_list, cu_list
+                )
+                if node_infeasible:
+                    node_infeasible_mask[i] = True
+                    continue
                 batch_lb[i] = t_lb.tolist()
                 batch_ub[i] = t_ub.tolist()
 
@@ -2185,6 +2248,12 @@ def solve_model(
                     result_sols[i] = 0.5 * (lb_clipped + ub_clipped)
                     result_feas[i] = False
         jax_time += time.perf_counter() - t_jax_start
+
+        if np.any(node_infeasible_mask):
+            for idx in np.flatnonzero(node_infeasible_mask):
+                i = int(idx)
+                result_lbs[i] = _INFEASIBILITY_SENTINEL
+                result_feas[i] = False
 
         # --- Optional GNN branching scoring ---
         # GNN computes variable scores and passes hints to Rust TreeManager,
@@ -2781,11 +2850,17 @@ def _solve_nlp_bb(
         # Tighten node bounds via constraint propagation (FBBT).
         # This resolves degenerate bounds (e.g., x <= M*y with y fixed at 0)
         # that cause IPM convergence failures.
+        node_infeasible_mask = np.zeros(n_batch, dtype=bool)
         if cl_list:
             for i in range(n_batch):
                 node_lb_i = np.array(batch_lb[i])
                 node_ub_i = np.array(batch_ub[i])
-                t_lb, t_ub = _tighten_node_bounds(evaluator, node_lb_i, node_ub_i, cl_list, cu_list)
+                t_lb, t_ub, node_infeasible = _tighten_node_bounds_with_status(
+                    evaluator, node_lb_i, node_ub_i, cl_list, cu_list
+                )
+                if node_infeasible:
+                    node_infeasible_mask[i] = True
+                    continue
                 batch_lb[i] = t_lb.tolist()
                 batch_ub[i] = t_ub.tolist()
 
@@ -2919,6 +2994,12 @@ def _solve_nlp_bb(
                     result_feas[i] = False
 
         jax_time += time.perf_counter() - t_jax_start
+
+        if np.any(node_infeasible_mask):
+            for idx in np.flatnonzero(node_infeasible_mask):
+                i = int(idx)
+                result_lbs[i] = _INFEASIBILITY_SENTINEL
+                result_feas[i] = False
 
         # --- Feasibility pump after root node ---
         if iteration == 0 and not _fp_ran:

--- a/python/discopt/solver.py
+++ b/python/discopt/solver.py
@@ -17,7 +17,9 @@ import numpy as np
 from scipy.optimize import minimize as scipy_minimize
 
 from discopt._jax.alphabb import estimate_alpha as _estimate_alpha_jax
+from discopt._jax.model_utils import flat_variable_bounds
 from discopt._jax.nlp_evaluator import NLPEvaluator
+from discopt._jax.nonlinear_bound_tightening import tighten_nonlinear_bounds
 from discopt._rust import PyTreeManager
 from discopt.constants import INFEASIBILITY_SENTINEL as _INFEASIBILITY_SENTINEL
 from discopt.constants import SENTINEL_THRESHOLD as _SENTINEL_THRESHOLD
@@ -377,11 +379,12 @@ def _tighten_node_bounds(evaluator, node_lb, node_ub, cl_list, cu_list, max_roun
     lb, ub : np.ndarray
         Tightened variable bounds.
     """
-    if evaluator.n_constraints == 0 or not cl_list:
-        return node_lb.copy(), node_ub.copy()
-
     lb = node_lb.copy()
     ub = node_ub.copy()
+
+    if evaluator.n_constraints == 0 or not cl_list:
+        return _apply_nonlinear_tightening(evaluator._model, lb, ub)
+
     n = len(lb)
     m = len(cl_list)
     cu = np.array(cu_list, dtype=np.float64)
@@ -399,13 +402,20 @@ def _tighten_node_bounds(evaluator, node_lb, node_ub, cl_list, cu_list, max_roun
         J_b = evaluator.evaluate_jacobian(pt_b)
         is_linear = np.all(np.abs(J_a - J_b) < 1e-8, axis=1)  # (m,) bool
     except Exception:
-        return lb, ub  # can't determine linearity, skip FBBT
+        return _apply_nonlinear_tightening(evaluator._model, lb, ub)
 
     if not np.any(is_linear):
-        return lb, ub  # no linear constraints to tighten
+        return _apply_nonlinear_tightening(evaluator._model, lb, ub)
 
     for _ in range(max_rounds):
         changed = False
+
+        tightened_lb, tightened_ub = _apply_nonlinear_tightening(evaluator._model, lb, ub)
+        if np.any(np.abs(tightened_lb - lb) > 1e-12) or np.any(np.abs(tightened_ub - ub) > 1e-12):
+            lb = tightened_lb
+            ub = tightened_ub
+            changed = True
+
         # Evaluate Jacobian at midpoint of current bounds
         mid = np.clip(lb, -_SPC, _SPC)
         span = np.clip(ub, -_SPC, _SPC) - mid
@@ -478,6 +488,21 @@ def _tighten_node_bounds(evaluator, node_lb, node_ub, cl_list, cu_list, max_roun
             break
 
     return lb, ub
+
+
+def _apply_nonlinear_tightening(
+    model: Model,
+    lb: np.ndarray,
+    ub: np.ndarray,
+) -> tuple[np.ndarray, np.ndarray]:
+    """Apply opportunistic nonlinear bound tightening without aborting node processing."""
+    try:
+        tightened_lb, tightened_ub, _ = tighten_nonlinear_bounds(model, lb, ub)
+    except Exception as exc:
+        logger.debug("Skipping nonlinear tightening after error: %s", exc)
+        return lb, ub
+
+    return tightened_lb, tightened_ub
 
 
 def _infer_constraint_bounds(model: Model, evaluator=None):
@@ -1115,18 +1140,17 @@ def _strong_branch_lp(
 _BOUND_WARN_THRESHOLD = 1e15
 
 
-def _check_finite_bounds(model: Model) -> None:
-    """Warn if any variable has very large or infinite bounds.
-
-    Interior point methods use barrier terms that require reasonably sized
-    bounds. Bounds beyond 1e15 cause numerical difficulties (NaN gradients,
-    ill-conditioned KKT systems) and the solver silently produces NaN
-    objectives or reports iteration_limit. This check warns users early.
-    """
-    bad_vars = []
+def _format_bad_bound_entries(
+    model: Model,
+    flat_lb: np.ndarray,
+    flat_ub: np.ndarray,
+) -> list[str]:
+    """Return human-readable entries for scalar variables with problematic bounds."""
+    bad_vars: list[str] = []
+    offset = 0
     for v in model._variables:
-        lb_flat = v.lb.flatten()
-        ub_flat = v.ub.flatten()
+        lb_flat = np.asarray(flat_lb[offset : offset + v.size], dtype=np.float64)
+        ub_flat = np.asarray(flat_ub[offset : offset + v.size], dtype=np.float64)
         for j in range(v.size):
             lo, hi = float(lb_flat[j]), float(ub_flat[j])
             if (
@@ -1137,12 +1161,46 @@ def _check_finite_bounds(model: Model) -> None:
             ):
                 name = v.name if v.size == 1 else f"{v.name}[{j}]"
                 bad_vars.append(f"{name} (lb={lo:.2g}, ub={hi:.2g})")
+        offset += v.size
+    return bad_vars
+
+
+def _check_finite_bounds(model: Model) -> None:
+    """Warn if any variable still has very large or infinite bounds after cheap tightening.
+
+    Interior point methods use barrier terms that require reasonably sized
+    bounds. Bounds beyond 1e15 cause numerical difficulties (NaN gradients,
+    ill-conditioned KKT systems) and the solver silently produces NaN
+    objectives or reports iteration_limit. This check first applies the
+    lightweight nonlinear tightening rules used elsewhere in discopt and only
+    warns if large bounds remain afterward.
+    """
+    raw_lb, raw_ub = flat_variable_bounds(model)
+    raw_bad_vars = _format_bad_bound_entries(model, raw_lb, raw_ub)
+    if not raw_bad_vars:
+        return
+
+    tightened_lb = raw_lb
+    tightened_ub = raw_ub
+    tightening_note = ""
+    try:
+        tightened_lb, tightened_ub, bt_stats = tighten_nonlinear_bounds(model, raw_lb, raw_ub)
+        if bt_stats.n_tightened > 0:
+            tightening_note = (
+                f" Nonlinear tightening adjusted {bt_stats.n_tightened} bounds"
+                f" via {', '.join(bt_stats.applied_rules)}."
+            )
+    except Exception as exc:
+        logger.debug("Skipping nonlinear tightening before large-bound warning: %s", exc)
+
+    bad_vars = _format_bad_bound_entries(model, tightened_lb, tightened_ub)
     if bad_vars:
         import warnings
 
         warnings.warn(
-            f"Variables with very large or infinite bounds: "
+            f"Variables with very large or infinite bounds after nonlinear tightening: "
             f"{', '.join(bad_vars[:5])}. "
+            f"{tightening_note} "
             f"NLP solvers may fail (NaN, iteration_limit) when bounds "
             f"exceed ~1e15. Add tighter explicit bounds, e.g. "
             f"m.continuous('x', lb=0, ub=1000).",

--- a/python/discopt/solver.py
+++ b/python/discopt/solver.py
@@ -1194,25 +1194,23 @@ def _format_bad_bound_entries(
 
 
 def _check_finite_bounds(model: Model) -> None:
-    """Warn if any variable still has very large or infinite bounds after cheap tightening.
+    """Warn if any variable has very large or infinite declared bounds.
 
     Interior point methods use barrier terms that require reasonably sized
     bounds. Bounds beyond 1e15 cause numerical difficulties (NaN gradients,
     ill-conditioned KKT systems) and the solver silently produces NaN
-    objectives or reports iteration_limit. This check first applies the
-    lightweight nonlinear tightening rules used elsewhere in discopt and only
-    warns if large bounds remain afterward.
+    objectives or reports iteration_limit. Nonlinear tightening is consumed by
+    some solver paths, but this warning remains conservative because not every
+    path applies the tightened box to the actual NLP solve.
     """
     raw_lb, raw_ub = flat_variable_bounds(model)
     raw_bad_vars = _format_bad_bound_entries(model, raw_lb, raw_ub)
     if not raw_bad_vars:
         return
 
-    tightened_lb = raw_lb
-    tightened_ub = raw_ub
     tightening_note = ""
     try:
-        tightened_lb, tightened_ub, bt_stats = tighten_nonlinear_bounds(model, raw_lb, raw_ub)
+        _tightened_lb, _tightened_ub, bt_stats = tighten_nonlinear_bounds(model, raw_lb, raw_ub)
         if bt_stats.infeasible:
             logger.info(
                 "Nonlinear tightening proved infeasibility before large-bound warning: %s",
@@ -1221,18 +1219,18 @@ def _check_finite_bounds(model: Model) -> None:
             return
         if bt_stats.n_tightened > 0:
             tightening_note = (
-                f" Nonlinear tightening adjusted {bt_stats.n_tightened} bounds"
+                f" Nonlinear tightening can adjust {bt_stats.n_tightened} bounds"
                 f" via {', '.join(bt_stats.applied_rules)}."
             )
     except Exception as exc:
         logger.debug("Skipping nonlinear tightening before large-bound warning: %s", exc)
 
-    bad_vars = _format_bad_bound_entries(model, tightened_lb, tightened_ub)
+    bad_vars = raw_bad_vars
     if bad_vars:
         import warnings
 
         warnings.warn(
-            f"Variables with very large or infinite bounds after nonlinear tightening: "
+            f"Variables with very large or infinite declared bounds: "
             f"{', '.join(bad_vars[:5])}. "
             f"{tightening_note} "
             f"NLP solvers may fail (NaN, iteration_limit) when bounds "

--- a/python/discopt/solvers/amp.py
+++ b/python/discopt/solvers/amp.py
@@ -32,6 +32,7 @@ import numpy as np
 
 from discopt._jax.milp_relaxation import _normalize_convhull_formulation
 from discopt._jax.model_utils import flat_variable_bounds
+from discopt._jax.nonlinear_bound_tightening import tighten_nonlinear_bounds
 from discopt.modeling.core import Model, ObjectiveSense, SolveResult, VarType
 
 logger = logging.getLogger(__name__)
@@ -617,6 +618,17 @@ def solve_amp(
 
     n_orig = sum(v.size for v in model._variables)
     flat_lb, flat_ub = flat_variable_bounds(model)
+    tightened_lb, tightened_ub, nonlinear_bt_stats = tighten_nonlinear_bounds(
+        model, flat_lb, flat_ub
+    )
+    if nonlinear_bt_stats.n_tightened > 0:
+        flat_lb = tightened_lb
+        flat_ub = tightened_ub
+        logger.info(
+            "AMP: nonlinear bound tightening adjusted %d bounds via %s",
+            nonlinear_bt_stats.n_tightened,
+            ", ".join(nonlinear_bt_stats.applied_rules),
+        )
     evaluator = NLPEvaluator(model)
     constraint_lb, constraint_ub = _infer_constraint_bounds(model)
     deadline = t_start + time_limit

--- a/python/discopt/solvers/amp.py
+++ b/python/discopt/solvers/amp.py
@@ -621,6 +621,16 @@ def solve_amp(
     tightened_lb, tightened_ub, nonlinear_bt_stats = tighten_nonlinear_bounds(
         model, flat_lb, flat_ub
     )
+    if nonlinear_bt_stats.infeasible:
+        logger.info(
+            "AMP: nonlinear bound tightening proved infeasibility: %s",
+            nonlinear_bt_stats.infeasibility_reason,
+        )
+        return SolveResult(
+            status="infeasible",
+            wall_time=time.perf_counter() - t_start,
+            gap_certified=True,
+        )
     if nonlinear_bt_stats.n_tightened > 0:
         flat_lb = tightened_lb
         flat_ub = tightened_ub

--- a/python/tests/test_amp.py
+++ b/python/tests/test_amp.py
@@ -27,6 +27,7 @@ Sections:
 from __future__ import annotations
 
 import os
+import warnings
 
 os.environ["JAX_PLATFORMS"] = "cpu"
 os.environ["JAX_ENABLE_X64"] = "1"
@@ -1864,6 +1865,23 @@ class TestCurrentCodeWeaknesses:
 
         assert result.status == "infeasible"
         assert result.x is None
+
+    def test_large_bound_warning_uses_declared_bounds_even_when_rules_tighten(self):
+        """A warning should not be suppressed unless solve paths use the tightened box."""
+        from discopt.solver import _check_finite_bounds
+
+        m = Model("large_bound_warning")
+        x = m.continuous("x", lb=-1e20, ub=1e20)
+        m.subject_to(x**2 <= 4.0)
+        m.minimize(x)
+
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            _check_finite_bounds(m)
+
+        messages = [str(w.message) for w in caught]
+        assert any("very large or infinite declared bounds" in msg for msg in messages)
+        assert any("Nonlinear tightening can adjust" in msg for msg in messages)
 
     def test_amp_returns_infeasible_for_nonlinear_tightening_contradiction(self):
         """AMP should stop before MILP/NLP solves when tightening proves infeasibility."""

--- a/python/tests/test_amp.py
+++ b/python/tests/test_amp.py
@@ -1690,6 +1690,62 @@ class TestCurrentCodeWeaknesses:
         assert tightened_ub[2] == pytest.approx(1.0)
         assert "reciprocal_bounds" in stats.applied_rules
 
+    def test_nonlinear_bound_tightening_reports_quadratic_contradiction(self):
+        """A rule proof of infeasibility should be reported explicitly."""
+        from discopt._jax.nonlinear_bound_tightening import tighten_nonlinear_bounds
+
+        m = Model("bt_quadratic_contradiction")
+        x = m.continuous("x", lb=-10.0, ub=10.0)
+        m.subject_to(x**2 == -1.0)
+        m.minimize(x * 0.0)
+
+        tightened_lb, tightened_ub, stats = tighten_nonlinear_bounds(
+            m,
+            np.array([-10.0], dtype=np.float64),
+            np.array([10.0], dtype=np.float64),
+        )
+
+        assert stats.infeasible is True
+        assert "sum_of_squares_upper_bound" in stats.applied_rules
+        assert "negative upper bound" in (stats.infeasibility_reason or "")
+        assert tightened_lb[0] == pytest.approx(-10.0)
+        assert tightened_ub[0] == pytest.approx(10.0)
+
+    def test_nonlinear_bound_tightening_reports_monotone_domain_contradiction(self):
+        """Domain/range contradictions should not be encoded as invalid boxes."""
+        from discopt._jax.nonlinear_bound_tightening import tighten_nonlinear_bounds
+
+        sqrt_model = Model("bt_sqrt_contradiction")
+        sqrt_x = sqrt_model.continuous("x", lb=0.0, ub=10.0)
+        sqrt_model.subject_to(dm.sqrt(sqrt_x) <= -1.0)
+        sqrt_model.minimize(sqrt_x * 0.0)
+
+        tightened_lb, tightened_ub, stats = tighten_nonlinear_bounds(
+            sqrt_model,
+            np.array([0.0], dtype=np.float64),
+            np.array([10.0], dtype=np.float64),
+        )
+
+        assert stats.infeasible is True
+        assert "monotone_function_bounds" in stats.applied_rules
+        assert "sqrt(argument) cannot be <=" in (stats.infeasibility_reason or "")
+        assert tightened_lb[0] == pytest.approx(0.0)
+        assert tightened_ub[0] == pytest.approx(10.0)
+
+        exp_model = Model("bt_exp_contradiction")
+        exp_x = exp_model.continuous("x", lb=-10.0, ub=10.0)
+        exp_model.subject_to(dm.exp(exp_x) <= -1.0)
+        exp_model.minimize(exp_x * 0.0)
+
+        _, _, exp_stats = tighten_nonlinear_bounds(
+            exp_model,
+            np.array([-10.0], dtype=np.float64),
+            np.array([10.0], dtype=np.float64),
+        )
+
+        assert exp_stats.infeasible is True
+        assert "exp(argument) cannot be <=" in (exp_stats.infeasibility_reason or "")
+
     def test_nonlinear_bound_tightening_accepts_custom_rules(self):
         """The shared registry should accept external sound rule objects."""
         from discopt._jax.nonlinear_bound_tightening import (
@@ -1772,6 +1828,54 @@ class TestCurrentCodeWeaknesses:
 
         assert tightened_ub[0] == pytest.approx(np.log(10.0))
         assert tightened_lb[1] == pytest.approx(np.e)
+
+    def test_solver_fbbt_reports_nonlinear_infeasibility_status(self):
+        """The FBBT entry point should expose proven nonlinear infeasibility."""
+        from discopt._jax.nlp_evaluator import NLPEvaluator
+        from discopt.solver import _infer_constraint_bounds, _tighten_node_bounds_with_status
+
+        m = Model("nonlinear_fbbt_contradiction")
+        x = m.continuous("x", lb=-10.0, ub=10.0)
+        m.subject_to(x**2 == -1.0)
+        m.minimize(x * 0.0)
+
+        evaluator = NLPEvaluator(m)
+        cl, cu = _infer_constraint_bounds(m)
+        tightened_lb, tightened_ub, infeasible = _tighten_node_bounds_with_status(
+            evaluator,
+            np.array([-10.0], dtype=np.float64),
+            np.array([10.0], dtype=np.float64),
+            cl,
+            cu,
+        )
+
+        assert infeasible is True
+        assert tightened_lb[0] == pytest.approx(-10.0)
+        assert tightened_ub[0] == pytest.approx(10.0)
+
+    def test_solver_returns_infeasible_for_nonlinear_tightening_contradiction(self):
+        """The main solver should consume root nonlinear infeasibility proofs."""
+        m = Model("solver_contradiction")
+        x = m.continuous("x", lb=-10.0, ub=10.0)
+        m.subject_to(x**2 == -1.0)
+        m.minimize(x)
+
+        result = m.solve(skip_convex_check=True, time_limit=5)
+
+        assert result.status == "infeasible"
+        assert result.x is None
+
+    def test_amp_returns_infeasible_for_nonlinear_tightening_contradiction(self):
+        """AMP should stop before MILP/NLP solves when tightening proves infeasibility."""
+        m = Model("amp_contradiction")
+        x = m.continuous("x", lb=0.0, ub=10.0)
+        m.subject_to(dm.sqrt(x) <= -1.0)
+        m.minimize(x)
+
+        result = m.solve(solver="amp", skip_convex_check=True, max_iter=1, time_limit=5)
+
+        assert result.status == "infeasible"
+        assert result.x is None
 
     def test_amp_uses_nonlinear_tightened_partition_bounds(self, monkeypatch):
         """AMP should initialize partitions from the tightened nonlinear box."""

--- a/python/tests/test_amp.py
+++ b/python/tests/test_amp.py
@@ -1599,6 +1599,218 @@ class TestCurrentCodeWeaknesses:
         assert best_x is None
         assert best_obj is None
 
+    def test_tighten_sum_of_squares_bounds_infers_finite_integer_domain(self):
+        """Quadratic norm constraints should clamp otherwise unbounded domains."""
+        from discopt._jax.nonlinear_bound_tightening import tighten_nonlinear_bounds
+
+        m = Model("bt_sum_of_squares")
+        x = m.continuous("x", lb=-1e20, ub=1e20)
+        y = m.integer("y", lb=-100, ub=100)
+        m.subject_to(x**2 + y**2 <= 10.0)
+        m.minimize(x * 0.0 + y * 0.0)
+
+        flat_lb = np.array([-1e20, -100.0], dtype=np.float64)
+        flat_ub = np.array([1e20, 100.0], dtype=np.float64)
+        tightened_lb, tightened_ub, stats = tighten_nonlinear_bounds(m, flat_lb, flat_ub)
+
+        radius = np.sqrt(10.0)
+        assert tightened_lb[0] == pytest.approx(-radius)
+        assert tightened_ub[0] == pytest.approx(radius)
+        assert tightened_lb[1] == pytest.approx(-3.0)
+        assert tightened_ub[1] == pytest.approx(3.0)
+        assert "sum_of_squares_upper_bound" in stats.applied_rules
+
+    def test_tighten_separable_quadratic_bounds_infers_finite_box(self):
+        """Constraints like x + y^2 <= c should infer finite bounds for both variables."""
+        from discopt._jax.nonlinear_bound_tightening import tighten_nonlinear_bounds
+
+        m = Model("bt_separable_quadratic")
+        x = m.continuous("x", lb=0.0, ub=1e20)
+        y = m.continuous("y", lb=-1e20, ub=1e20)
+        m.subject_to(x + y**2 <= 4.0)
+        m.minimize(x * 0.0 + y * 0.0)
+
+        flat_lb = np.array([0.0, -1e20], dtype=np.float64)
+        flat_ub = np.array([1e20, 1e20], dtype=np.float64)
+        tightened_lb, tightened_ub, stats = tighten_nonlinear_bounds(m, flat_lb, flat_ub)
+
+        assert tightened_lb[0] == pytest.approx(0.0)
+        assert tightened_ub[0] == pytest.approx(4.0)
+        assert tightened_lb[1] == pytest.approx(-2.0)
+        assert tightened_ub[1] == pytest.approx(2.0)
+        assert "separable_quadratic_upper_bound" in stats.applied_rules
+
+    def test_tighten_monotone_function_bounds(self):
+        """Monotone unary constraints should tighten affine argument domains."""
+        from discopt._jax.nonlinear_bound_tightening import tighten_nonlinear_bounds
+
+        m = Model("bt_monotone_functions")
+        x = m.continuous("x", lb=-1e20, ub=1e20)
+        y = m.continuous("y", lb=0.0, ub=1e20)
+        z = m.continuous("z", lb=-1e20, ub=1e20)
+        m.subject_to(dm.exp(x) <= 100.0)
+        m.subject_to(dm.log(y) >= 2.0)
+        m.subject_to(dm.sqrt(z) <= 3.0)
+        m.minimize(x * 0.0 + y * 0.0 + z * 0.0)
+
+        tightened_lb, tightened_ub, stats = tighten_nonlinear_bounds(
+            m,
+            np.array([-1e20, 0.0, -1e20], dtype=np.float64),
+            np.array([1e20, 1e20, 1e20], dtype=np.float64),
+        )
+
+        assert tightened_ub[0] == pytest.approx(np.log(100.0))
+        assert tightened_lb[1] == pytest.approx(np.exp(2.0))
+        assert tightened_lb[2] == pytest.approx(0.0)
+        assert tightened_ub[2] == pytest.approx(9.0)
+        assert "monotone_function_bounds" in stats.applied_rules
+
+    def test_tighten_sign_stable_reciprocal_bounds(self):
+        """Reciprocal propagation should only apply on sign-stable denominator boxes."""
+        from discopt._jax.nonlinear_bound_tightening import tighten_nonlinear_bounds
+
+        m = Model("bt_reciprocal")
+        x = m.continuous("x", lb=0.1, ub=1e20)
+        y = m.continuous("y", lb=-1e20, ub=-0.1)
+        z = m.continuous("z", lb=-1.0, ub=1.0)
+        m.subject_to(1.0 / x <= 0.25)
+        m.subject_to(1.0 / y >= -0.25)
+        m.subject_to(1.0 / z <= 0.25)
+        m.minimize(x * 0.0 + y * 0.0 + z * 0.0)
+
+        tightened_lb, tightened_ub, stats = tighten_nonlinear_bounds(
+            m,
+            np.array([0.1, -1e20, -1.0], dtype=np.float64),
+            np.array([1e20, -0.1, 1.0], dtype=np.float64),
+        )
+
+        assert tightened_lb[0] == pytest.approx(4.0)
+        assert tightened_ub[1] == pytest.approx(-4.0)
+        assert tightened_lb[2] == pytest.approx(-1.0)
+        assert tightened_ub[2] == pytest.approx(1.0)
+        assert "reciprocal_bounds" in stats.applied_rules
+
+    def test_nonlinear_bound_tightening_accepts_custom_rules(self):
+        """The shared registry should accept external sound rule objects."""
+        from discopt._jax.nonlinear_bound_tightening import (
+            NonlinearBoundTighteningRule,
+            tighten_nonlinear_bounds,
+        )
+
+        class ClampFirstVarRule(NonlinearBoundTighteningRule):
+            name = "custom_clamp"
+
+            def tighten(self, model, flat_lb, flat_ub, metadata):
+                del model, metadata
+                new_lb = flat_lb.copy()
+                new_ub = flat_ub.copy()
+                new_ub[0] = min(float(new_ub[0]), 2.0)
+                return new_lb, new_ub
+
+        m = Model("custom_bt")
+        x = m.continuous("x", lb=0.0, ub=10.0)
+        m.minimize(x)
+
+        tightened_lb, tightened_ub, stats = tighten_nonlinear_bounds(
+            m,
+            np.array([0.0], dtype=np.float64),
+            np.array([10.0], dtype=np.float64),
+            rules=(ClampFirstVarRule(),),
+        )
+
+        assert tightened_lb[0] == pytest.approx(0.0)
+        assert tightened_ub[0] == pytest.approx(2.0)
+        assert stats.applied_rules == ("custom_clamp",)
+
+    def test_solver_fbbt_applies_nonlinear_rules_without_linear_constraints(self):
+        """The shared nonlinear tightening rules should run through solver FBBT too."""
+        from discopt._jax.nlp_evaluator import NLPEvaluator
+        from discopt.solver import _infer_constraint_bounds, _tighten_node_bounds
+
+        m = Model("nonlinear_fbbt_sum_of_squares")
+        x = m.continuous("x", lb=-1e20, ub=1e20)
+        y = m.integer("y", lb=-100, ub=100)
+        m.subject_to(x**2 + y**2 <= 9.0)
+        m.minimize(x * 0.0 + y * 0.0)
+
+        evaluator = NLPEvaluator(m)
+        cl, cu = _infer_constraint_bounds(m)
+        tightened_lb, tightened_ub = _tighten_node_bounds(
+            evaluator,
+            np.array([-1e20, -100.0], dtype=np.float64),
+            np.array([1e20, 100.0], dtype=np.float64),
+            cl,
+            cu,
+        )
+
+        assert tightened_lb[0] == pytest.approx(-3.0)
+        assert tightened_ub[0] == pytest.approx(3.0)
+        assert tightened_lb[1] == pytest.approx(-3.0)
+        assert tightened_ub[1] == pytest.approx(3.0)
+
+    def test_solver_fbbt_applies_monotone_nonlinear_rules(self):
+        """Solver FBBT should reuse the shared monotone function tightening rule."""
+        from discopt._jax.nlp_evaluator import NLPEvaluator
+        from discopt.solver import _infer_constraint_bounds, _tighten_node_bounds
+
+        m = Model("nonlinear_fbbt_monotone")
+        x = m.continuous("x", lb=-1e20, ub=1e20)
+        y = m.continuous("y", lb=0.0, ub=1e20)
+        m.subject_to(dm.exp(x) <= 10.0)
+        m.subject_to(dm.log(y) >= 1.0)
+        m.minimize(x * 0.0 + y * 0.0)
+
+        evaluator = NLPEvaluator(m)
+        cl, cu = _infer_constraint_bounds(m)
+        tightened_lb, tightened_ub = _tighten_node_bounds(
+            evaluator,
+            np.array([-1e20, 0.0], dtype=np.float64),
+            np.array([1e20, 1e20], dtype=np.float64),
+            cl,
+            cu,
+        )
+
+        assert tightened_ub[0] == pytest.approx(np.log(10.0))
+        assert tightened_lb[1] == pytest.approx(np.e)
+
+    def test_amp_uses_nonlinear_tightened_partition_bounds(self, monkeypatch):
+        """AMP should initialize partitions from the tightened nonlinear box."""
+        import discopt._jax.discretization as disc_mod
+        from discopt._jax.milp_relaxation import MilpRelaxationResult
+        from discopt.solvers import amp as amp_mod
+
+        captured = {}
+        real_initialize = disc_mod.initialize_partitions
+
+        def spy_initialize(part_vars, lb, ub, **kwargs):
+            captured["part_vars"] = list(part_vars)
+            captured["lb"] = list(lb)
+            captured["ub"] = list(ub)
+            return real_initialize(part_vars, lb=lb, ub=ub, **kwargs)
+
+        monkeypatch.setattr(disc_mod, "initialize_partitions", spy_initialize)
+        monkeypatch.setattr(
+            amp_mod,
+            "_solve_milp_with_oa_recovery",
+            lambda **kwargs: (
+                MilpRelaxationResult(status="error", objective=None, x=None),
+                {},
+                [],
+            ),
+        )
+
+        m = Model("amp_bt_partition_bounds")
+        x = m.continuous("x", lb=-1e20, ub=1e20)
+        m.subject_to(x**2 <= 4.0)
+        m.minimize(x)
+
+        result = m.solve(solver="amp", skip_convex_check=True, max_iter=1, time_limit=30)
+
+        assert result.status == "error"
+        assert captured["part_vars"] == [0]
+        assert captured["lb"] == pytest.approx([-2.0])
+        assert captured["ub"] == pytest.approx([2.0])
+
     def test_oa_cut_recovery_drops_oldest_half(self, monkeypatch):
         """OA recovery should retry with the oldest half of cuts removed."""
         from discopt._jax.milp_relaxation import MilpRelaxationResult


### PR DESCRIPTION
## Summary

Adds a shared nonlinear bound-tightening registry and wires it into both AMP and the main solver FBBT path.

Implemented rules:

- quadratic norm upper bounds
- separable convex quadratic upper bounds
- monotone `exp`/`log`/`log2`/`log10`/`log1p`/`sqrt` constraints
- sign-stable reciprocal denominator constraints
- explicit infeasibility reporting for rule-proven contradictions such as `x**2 == -1`, `sqrt(x) <= -1`, and `exp(x) <= -1`

## Validation

```text
ruff check python/discopt/_jax/nonlinear_bound_tightening.py python/discopt/solver.py python/discopt/solvers/amp.py python/tests/test_amp.py
mypy python/discopt/_jax/nonlinear_bound_tightening.py python/discopt/solver.py python/discopt/solvers/amp.py
pytest -q python/tests/test_amp.py::TestCurrentCodeWeaknesses --timeout=120
pytest -q python/tests/test_amp.py --timeout=120
```

Results:

```text
ruff: passed
mypy: passed
TestCurrentCodeWeaknesses: 35 passed, 1 xfailed
python/tests/test_amp.py: 102 passed, 2 xfailed
```

## Related

- Addresses #17 for shared domain-reduction rules and solver/AMP integration.
- Fixes #28 by adding an explicit infeasibility signal and consuming it from solver FBBT, the main solver root precheck, and AMP.