### PR TITLE
Add Alpine AMP coverage

### DIFF
--- a/python/discopt/_jax/milp_relaxation.py
+++ b/python/discopt/_jax/milp_relaxation.py
@@ -284,6 +284,44 @@ def _decompose_product(expr: Expression, model: Model) -> tuple[float, list[int]
     return None
 
 
+def _collect_distinct_multilinear_products(model: Model) -> list[tuple[int, ...]]:
+    """Return distinct-variable product terms with four or more factors."""
+    terms: set[tuple[int, ...]] = set()
+
+    def visit(expr: Expression) -> None:
+        if isinstance(expr, BinaryOp):
+            if expr.op == "*":
+                decomp = _decompose_product(expr, model)
+                if decomp is not None:
+                    _, indices = decomp
+                    unique = list(dict.fromkeys(indices))
+                    if len(unique) >= 4 and len(unique) == len(indices):
+                        terms.add(tuple(sorted(unique)))
+                        return
+            visit(expr.left)
+            visit(expr.right)
+            return
+
+        if isinstance(expr, UnaryOp):
+            visit(expr.operand)
+            return
+
+        if isinstance(expr, SumExpression):
+            visit(expr.operand)
+            return
+
+        if isinstance(expr, SumOverExpression):
+            for term in expr.terms:
+                visit(term)
+
+    if model._objective is not None:
+        visit(model._objective.expression)
+    for constraint in model._constraints:
+        visit(constraint.body)
+
+    return sorted(terms)
+
+
 # ---------------------------------------------------------------------------
 # Helpers: expression linearizer
 # ---------------------------------------------------------------------------
@@ -294,6 +332,7 @@ def _linearize_expr(
     model: Model,
     bilinear_var_map: dict[tuple[int, int], int],
     trilinear_var_map: dict[tuple[int, int, int], int],
+    multilinear_var_map: dict[tuple[int, ...], int],
     monomial_var_map: dict[tuple[int, int], int],
     n_total_vars: int,
 ) -> tuple[np.ndarray, float]:
@@ -406,7 +445,13 @@ def _linearize_expr(
                     else:
                         raise ValueError(f"Trilinear {tri_key} not in map")
                 else:
-                    raise ValueError(f"Higher-order product ({len(unique)} vars) not supported")
+                    if len(unique) != len(indices):
+                        raise ValueError("Mixed repeated-factor products are not supported")
+                    multilinear_key = tuple(sorted(unique))
+                    if multilinear_key in multilinear_var_map:
+                        coeff[multilinear_var_map[multilinear_key]] += scale * c
+                    else:
+                        raise ValueError(f"Multilinear {multilinear_key} not in map")
 
             else:
                 raise ValueError(f"Cannot linearize BinaryOp: {e.op}")
@@ -514,6 +559,8 @@ def build_milp_relaxation(
     bilinear_var_map: dict[tuple[int, int], int] = {}
     trilinear_var_map: dict[tuple[int, int, int], int] = {}
     trilinear_stage_map: dict[tuple[int, int, int], dict[str, object]] = {}
+    multilinear_var_map: dict[tuple[int, ...], int] = {}
+    multilinear_stage_map: dict[tuple[int, ...], list[dict[str, int]]] = {}
     monomial_var_map: dict[tuple[int, int], int] = {}
 
     col_idx = n_orig
@@ -545,6 +592,26 @@ def build_milp_relaxation(
         col_idx += 1
         return bilinear_relation_map[key]
 
+    def _ensure_multilinear_aux(term: tuple[int, ...]) -> tuple[int, list[dict[str, int]]]:
+        ordered = tuple(sorted(term))
+        if len(ordered) < 2:
+            raise ValueError("multilinear terms require at least two variables")
+
+        stages: list[dict[str, int]] = []
+        current_col = ordered[0]
+        for rhs_col in ordered[1:]:
+            lhs_col = current_col
+            product_col = _ensure_bilinear_aux(lhs_col, rhs_col)
+            stages.append(
+                {
+                    "lhs_col": lhs_col,
+                    "rhs_col": rhs_col,
+                    "product_col": product_col,
+                }
+            )
+            current_col = product_col
+        return current_col, stages
+
     original_bilinear_keys = sorted({(min(i, j), max(i, j)) for i, j in terms.bilinear})
     for key in original_bilinear_keys:
         bilinear_var_map[key] = _ensure_bilinear_aux(*key)
@@ -568,6 +635,11 @@ def build_milp_relaxation(
             "remaining_var": remaining,
             "product_col": final_col,
         }
+
+    for multi_term in _collect_distinct_multilinear_products(model):
+        final_col, stages = _ensure_multilinear_aux(multi_term)
+        multilinear_var_map[multi_term] = final_col
+        multilinear_stage_map[multi_term] = stages
 
     for var_idx, n in terms.monomial:
         lb_i = float(flat_lb[var_idx])
@@ -1026,6 +1098,7 @@ def build_milp_relaxation(
                 model,
                 bilinear_var_map,
                 trilinear_var_map,
+                multilinear_var_map,
                 monomial_var_map,
                 n_total,
             )
@@ -1060,6 +1133,7 @@ def build_milp_relaxation(
             model,
             bilinear_var_map,
             trilinear_var_map,
+            multilinear_var_map,
             monomial_var_map,
             n_total,
         )
@@ -1108,6 +1182,8 @@ def build_milp_relaxation(
         "bilinear": bilinear_var_map,
         "trilinear": trilinear_var_map,
         "trilinear_stages": trilinear_stage_map,
+        "multilinear": multilinear_var_map,
+        "multilinear_stages": multilinear_stage_map,
         "monomial": monomial_var_map,
         "bilinear_pw": bilinear_pw_map,
         "bilinear_lambda": bilinear_lambda_map,

--- a/python/discopt/_jax/milp_relaxation.py
+++ b/python/discopt/_jax/milp_relaxation.py
@@ -636,7 +636,8 @@ def build_milp_relaxation(
             "product_col": final_col,
         }
 
-    for multi_term in _collect_distinct_multilinear_products(model):
+    multilinear_terms = terms.multilinear or _collect_distinct_multilinear_products(model)
+    for multi_term in multilinear_terms:
         final_col, stages = _ensure_multilinear_aux(multi_term)
         multilinear_var_map[multi_term] = final_col
         multilinear_stage_map[multi_term] = stages

--- a/python/discopt/_jax/partition_selection.py
+++ b/python/discopt/_jax/partition_selection.py
@@ -25,10 +25,11 @@ from discopt._jax.term_classifier import NonlinearTerms
 
 
 def _all_terms(terms: NonlinearTerms) -> list[tuple[int, ...]]:
-    """Flatten all nonlinear terms (bilinear + trilinear) into a single list."""
+    """Flatten product terms into a single list."""
     all_t: list[tuple[int, ...]] = []
     all_t.extend(terms.bilinear)
     all_t.extend(terms.trilinear)
+    all_t.extend(terms.multilinear)
     return all_t
 
 

--- a/python/discopt/_jax/term_classifier.py
+++ b/python/discopt/_jax/term_classifier.py
@@ -4,6 +4,7 @@ Nonlinear Term Classifier for AMP (Adaptive Multivariate Partitioning).
 Walks the expression DAG of a Model and catalogs nonlinear term structure:
   - bilinear terms:   x_i * x_j  (two distinct continuous variables)
   - trilinear terms:  x_i * x_j * x_k  (three distinct continuous variables)
+  - multilinear terms: x_i * ... * x_k (four or more distinct variables)
   - monomial terms:   x_i^n  (single variable raised to integer power n ≥ 2)
   - general_nl:       all other nonlinearities (sin, cos, exp, log, etc.)
 
@@ -55,23 +56,30 @@ class NonlinearTerms:
         The pair is always sorted (i <= j) to avoid duplicates.
     trilinear : list of (int, int, int)
         Each entry is a sorted triple of flat variable indices for x_i * x_j * x_k.
+    multilinear : list of tuple[int, ...]
+        Each entry is a sorted tuple of four or more flat variable indices for
+        a distinct-variable product.
     monomial : list of (int, int)
         Each entry is (var_idx, exponent) for x_i^n, n integer ≥ 2.
     general_nl : list of Expression
-        Nonlinear expression nodes that are neither bilinear, trilinear, nor monomial
-        (e.g., sin, cos, exp, log, sqrt, tan, abs).
+        Nonlinear expression nodes that are neither bilinear, trilinear,
+        higher-order multilinear, nor monomial (e.g., sin, cos, exp, log,
+        sqrt, tan, abs).
     term_incidence : dict[int, set[int]]
         Maps flat variable index → set of term indices (into the combined bilinear +
-        trilinear list) that the variable appears in.  Used for vertex-cover computation.
+        trilinear + multilinear list) that the variable appears in.  Used for
+        vertex-cover computation.
     partition_candidates : list[int]
-        Sorted list of flat variable indices appearing in any bilinear or trilinear term.
-        These are the candidates for domain partitioning in AMP.
+        Sorted list of flat variable indices appearing in any bilinear,
+        trilinear, or higher-order multilinear product.  These are the
+        candidates for domain partitioning in AMP.
         (Monomials are convex/treated separately; general_nl may also be candidates
         but are currently excluded from partitioning as AMP focuses on polynomial terms.)
     """
 
     bilinear: list[tuple[_VarIdx, _VarIdx]] = field(default_factory=list)
     trilinear: list[tuple[_VarIdx, _VarIdx, _VarIdx]] = field(default_factory=list)
+    multilinear: list[tuple[_VarIdx, ...]] = field(default_factory=list)
     monomial: list[tuple[_VarIdx, int]] = field(default_factory=list)
     general_nl: list[Expression] = field(default_factory=list)
     term_incidence: dict[_VarIdx, set[int]] = field(default_factory=dict)
@@ -171,13 +179,17 @@ def classify_nonlinear_terms(model: Model) -> NonlinearTerms:
     # Track seen terms to avoid duplicates
     seen_bilinear: set[tuple[int, int]] = set()
     seen_trilinear: set[tuple[int, int, int]] = set()
+    seen_multilinear: set[tuple[int, ...]] = set()
     seen_monomial: set[tuple[int, int]] = set()
+
+    def _next_product_term_idx() -> int:
+        return len(result.bilinear) + len(result.trilinear) + len(result.multilinear)
 
     def _record_bilinear(i: int, j: int) -> None:
         key = (min(i, j), max(i, j))
         if key not in seen_bilinear:
             seen_bilinear.add(key)
-            term_idx = len(result.bilinear) + len(result.trilinear)
+            term_idx = _next_product_term_idx()
             result.bilinear.append(key)
             # Update term incidence
             for v in key:
@@ -188,8 +200,19 @@ def classify_nonlinear_terms(model: Model) -> NonlinearTerms:
         key = (a, b, c)
         if key not in seen_trilinear:
             seen_trilinear.add(key)
-            term_idx = len(result.bilinear) + len(result.trilinear)
+            term_idx = _next_product_term_idx()
             result.trilinear.append(key)
+            for v in key:
+                result.term_incidence.setdefault(v, set()).add(term_idx)
+
+    def _record_multilinear(indices: list[int]) -> None:
+        key = tuple(sorted(indices))
+        if len(key) < 4:
+            raise ValueError("multilinear terms require at least four variables")
+        if key not in seen_multilinear:
+            seen_multilinear.add(key)
+            term_idx = _next_product_term_idx()
+            result.multilinear.append(key)
             for v in key:
                 result.term_incidence.setdefault(v, set()).add(term_idx)
 
@@ -259,11 +282,7 @@ def classify_nonlinear_terms(model: Model) -> NonlinearTerms:
                         _record_trilinear(unique_vars[0], unique_vars[1], unique_vars[2])
                         return
                     else:
-                        # Higher-order multilinear — decompose into bilinear pairs
-                        # (AMP handles multilinear via repeated bilinear decomposition)
-                        for ii in range(len(unique_vars)):
-                            for jj in range(ii + 1, len(unique_vars)):
-                                _record_bilinear(unique_vars[ii], unique_vars[jj])
+                        _record_multilinear(unique_vars)
                         return
                 # If product decomposition failed, recurse on children
                 _classify_node(expr.left)
@@ -331,8 +350,8 @@ def classify_nonlinear_terms(model: Model) -> NonlinearTerms:
         _classify_node(constraint.body)
 
     # ── Build partition_candidates ──
-    # Variables that appear in bilinear or trilinear terms (not just monomials,
-    # since x^2 is convex and handled by alphaBB/direct secant).
+    # Variables that appear in product terms (not just monomials, since x^2 is
+    # convex and handled by alphaBB/direct secant).
     candidates: set[int] = set()
     for i, j in result.bilinear:
         candidates.add(i)
@@ -341,6 +360,8 @@ def classify_nonlinear_terms(model: Model) -> NonlinearTerms:
         candidates.add(i)
         candidates.add(j)
         candidates.add(k)
+    for term in result.multilinear:
+        candidates.update(term)
     result.partition_candidates = sorted(candidates)
 
     return result

--- a/python/discopt/solvers/amp.py
+++ b/python/discopt/solvers/amp.py
@@ -977,9 +977,10 @@ def solve_amp(
     # ── Classify nonlinear terms ─────────────────────────────────────────────
     terms = classify_nonlinear_terms(model)
     logger.info(
-        "AMP: %d bilinear, %d trilinear, %d monomial, %d general_nl terms",
+        "AMP: %d bilinear, %d trilinear, %d multilinear, %d monomial, %d general_nl terms",
         len(terms.bilinear),
         len(terms.trilinear),
+        len(terms.multilinear),
         len(terms.monomial),
         len(terms.general_nl),
     )

--- a/python/tests/test_amp.py
+++ b/python/tests/test_amp.py
@@ -161,6 +161,199 @@ def _make_quartic_objective_demo() -> Model:
     return m
 
 
+def _make_alpine_multi2() -> Model:
+    """Alpine examples/MINLPs/multi.jl:multi2.
+
+    Alpine seeds Julia's RNG and documents the active upper-bound solution as
+    [0.7336635, 1.266336] with objective 0.92906489.  The translated fixture
+    fixes those generated bounds directly so the test is independent of Julia's
+    RNG implementation.
+    """
+    m = Model("alpine_multi2")
+    x0 = m.continuous("x0", lb=0.1, ub=0.7336635)
+    x1 = m.continuous("x1", lb=0.1, ub=10.0)
+    m.subject_to(x0 + x1 <= 2.0)
+    m.maximize(x0 * x1)
+    return m
+
+
+def _multi3_term(x, i: int, exprmode: int):
+    if exprmode == 1:
+        return x[i] * x[i + 1] * x[i + 2]
+    if exprmode == 2:
+        return (x[i] * x[i + 1]) * x[i + 2]
+    if exprmode == 3:
+        return x[i] * (x[i + 1] * x[i + 2])
+    raise ValueError("multi3N exprmode must be 1, 2, or 3")
+
+
+def _make_alpine_multi3n(n: int = 2, exprmode: int = 1, randomub: float = 4.0) -> Model:
+    """Alpine examples/MINLPs/multi.jl:multi3N."""
+    m = Model(f"alpine_multi3N_{n}_{exprmode}")
+    size = 1 + 2 * n
+    x = m.continuous("x", lb=0.1, ub=randomub, shape=(size,))
+
+    obj = None
+    for i in range(0, size - 1, 2):
+        term = _multi3_term(x, i, exprmode)
+        obj = term if obj is None else obj + term
+        m.subject_to(x[i] + x[i + 1] + x[i + 2] <= 3.0)
+
+    assert obj is not None
+    m.maximize(obj)
+    return m
+
+
+def _multi4_term(x, i: int, exprmode: int):
+    if exprmode == 1:
+        return x[i] * x[i + 1] * x[i + 2] * x[i + 3]
+    if exprmode == 2:
+        return (x[i] * x[i + 1]) * (x[i + 2] * x[i + 3])
+    if exprmode == 3:
+        return (x[i] * x[i + 1]) * x[i + 2] * x[i + 3]
+    if exprmode == 4:
+        return x[i] * x[i + 1] * (x[i + 2] * x[i + 3])
+    if exprmode == 5:
+        return ((x[i] * x[i + 1]) * x[i + 2]) * x[i + 3]
+    if exprmode == 6:
+        return (x[i] * x[i + 1] * x[i + 2]) * x[i + 3]
+    if exprmode == 7:
+        return x[i] * (x[i + 1] * (x[i + 2] * x[i + 3]))
+    if exprmode == 8:
+        return x[i] * (x[i + 1] * x[i + 2]) * x[i + 3]
+    if exprmode == 9:
+        return x[i] * (x[i + 1] * x[i + 2] * x[i + 3])
+    if exprmode == 10:
+        return x[i] * ((x[i + 1] * x[i + 2]) * x[i + 3])
+    if exprmode == 11:
+        return (x[i] * (x[i + 1] * x[i + 2])) * x[i + 3]
+    raise ValueError("multi4N exprmode must be in 1..11")
+
+
+def _make_alpine_multi4n(n: int = 2, exprmode: int = 1, randomub: float = 4.0) -> Model:
+    """Alpine examples/MINLPs/multi.jl:multi4N."""
+    m = Model(f"alpine_multi4N_{n}_{exprmode}")
+    size = 1 + 3 * n
+    x = m.continuous("x", lb=0.1, ub=randomub, shape=(size,))
+
+    obj = None
+    for i in range(0, size - 1, 3):
+        term = _multi4_term(x, i, exprmode)
+        obj = term if obj is None else obj + term
+        m.subject_to(x[i] + x[i + 1] + x[i + 2] + x[i + 3] <= 4.0)
+
+    assert obj is not None
+    m.maximize(obj)
+    return m
+
+
+def _make_alpine_castro2m2_partition_fixture() -> Model:
+    """Nonlinear partition skeleton from Alpine examples/MINLPs/castro.jl:castro2m2."""
+    m = Model("alpine_castro2m2_partition")
+    x = m.continuous("x", lb=0.0, ub=1e5, shape=(41,))
+    obj = m.continuous("obj", lb=0.0, ub=1e3)
+    m.minimize(obj)
+
+    for i, j, target in [
+        (27, 29, 15),
+        (27, 30, 16),
+        (28, 31, 17),
+        (28, 32, 18),
+        (27, 35, 21),
+        (28, 36, 22),
+        (13, 29, 0),
+        (13, 30, 1),
+        (14, 31, 2),
+        (14, 32, 3),
+        (13, 35, 6),
+        (14, 36, 7),
+    ]:
+        m.subject_to(x[i] * x[j] - x[target] == 0.0)
+
+    return m
+
+
+def _make_alpine_blend029_gl_partition_fixture() -> Model:
+    """Nonlinear partition skeleton from Alpine examples/MINLPs/blend.jl:blend029_gl."""
+    m = Model("alpine_blend029_gl_partition")
+    x = []
+    for i in range(48):
+        x.append(m.continuous(f"x{i + 1}", lb=0.0, ub=1.0))
+    for i in range(48, 66):
+        x.append(m.continuous(f"x{i + 1}", lb=0.0, ub=2.0))
+    for i in range(66, 102):
+        x.append(m.binary(f"x{i + 1}"))
+    m.maximize(0.0 * x[0])
+
+    exprs = [
+        (x[36] * x[54] - 0.6 * x[0] - 0.2 * x[12] + 0.2 * x[24] + 0.2 * x[27] + 0.2 * x[30], 0.04),
+        (x[39] * x[57] - 0.6 * x[3] - 0.2 * x[15] - 0.2 * x[24] + 0.7 * x[33], 0.07),
+        (x[42] * x[54] - 0.4 * x[0] - 0.4 * x[12] + 0.5 * x[24] + 0.5 * x[27] + 0.5 * x[30], 0.1),
+        (x[45] * x[57] - 0.4 * x[3] - 0.4 * x[15] - 0.5 * x[24] + 0.6 * x[33], 0.06),
+        (
+            x[37] * x[55]
+            - (x[36] * x[54] - (x[36] * x[25] + x[36] * x[28] + x[36] * x[31]))
+            - 0.6 * x[1]
+            - 0.2 * x[13],
+            0.0,
+        ),
+        (
+            x[38] * x[56]
+            - (x[37] * x[55] - (x[37] * x[26] + x[37] * x[29] + x[37] * x[32]))
+            - 0.6 * x[2]
+            - 0.2 * x[14],
+            0.0,
+        ),
+        (
+            x[40] * x[58]
+            - (x[39] * x[57] + x[36] * x[25] - x[39] * x[34])
+            - 0.6 * x[4]
+            - 0.2 * x[16],
+            0.0,
+        ),
+        (
+            x[41] * x[59]
+            - (x[40] * x[58] + x[37] * x[26] - x[40] * x[35])
+            - 0.6 * x[5]
+            - 0.2 * x[17],
+            0.0,
+        ),
+        (
+            x[43] * x[55]
+            - (x[42] * x[54] - (x[42] * x[25] + x[42] * x[28] + x[42] * x[31]))
+            - 0.4 * x[1]
+            - 0.4 * x[13],
+            0.0,
+        ),
+        (
+            x[44] * x[56]
+            - (x[43] * x[55] - (x[43] * x[26] + x[43] * x[29] + x[43] * x[32]))
+            - 0.4 * x[2]
+            - 0.4 * x[14],
+            0.0,
+        ),
+        (
+            x[46] * x[58]
+            - (x[45] * x[57] + x[42] * x[25] - x[45] * x[34])
+            - 0.4 * x[4]
+            - 0.4 * x[16],
+            0.0,
+        ),
+        (
+            x[47] * x[59]
+            - (x[46] * x[58] + x[43] * x[26] - x[46] * x[35])
+            - 0.4 * x[5]
+            - 0.4 * x[17],
+            0.0,
+        ),
+    ]
+    for expr, rhs in exprs:
+        m.subject_to(expr >= rhs)
+        m.subject_to(expr <= rhs)
+
+    return m
+
+
 # ===========================================================================
 # Section 1: Nonlinear Term Classifier
 #
@@ -425,6 +618,76 @@ class TestPartitionSelection:
         assert all(v % 2 == 0 for v in selected)
         for t in terms.bilinear:
             assert any(v in selected for v in t), f"term {t} not covered"
+
+
+class TestAlpinePortedPartitionSelection:
+    """Ports of Alpine partition-variable tests for larger named examples."""
+
+    @pytest.fixture(autouse=True)
+    def _import(self):
+        from discopt._jax.partition_selection import pick_partition_vars
+        from discopt._jax.term_classifier import classify_nonlinear_terms
+
+        self.classify = classify_nonlinear_terms
+        self.pick = pick_partition_vars
+
+    def _assert_terms_covered(self, terms, selected):
+        selected_set = set(selected)
+        for term in terms.bilinear + terms.trilinear:
+            assert any(v in selected_set for v in term), f"term {term} not covered"
+
+    def test_castro2m2_candidates_match_alpine_source(self):
+        """Alpine castro2m2 has 10 candidate discretization variables and a 4-var cover."""
+        terms = self.classify(_make_alpine_castro2m2_partition_fixture())
+
+        expected = {13, 14, 27, 28, 29, 30, 31, 32, 35, 36}
+        max_cover = self.pick(terms, method="max_cover")
+        min_cover = self.pick(terms, method="min_vertex_cover")
+
+        assert set(terms.partition_candidates) == expected
+        assert set(max_cover) == expected
+        assert len(min_cover) == 4
+        self._assert_terms_covered(terms, min_cover)
+
+    def test_blend029_gl_candidates_match_alpine_source(self):
+        """Alpine blend029_gl has 26 candidate discretization variables and a 10-var cover."""
+        terms = self.classify(_make_alpine_blend029_gl_partition_fixture())
+
+        expected = {
+            25,
+            26,
+            28,
+            29,
+            31,
+            32,
+            34,
+            35,
+            36,
+            37,
+            38,
+            39,
+            40,
+            41,
+            42,
+            43,
+            44,
+            45,
+            46,
+            47,
+            54,
+            55,
+            56,
+            57,
+            58,
+            59,
+        }
+        max_cover = self.pick(terms, method="max_cover")
+        min_cover = self.pick(terms, method="min_vertex_cover")
+
+        assert set(terms.partition_candidates) == expected
+        assert set(max_cover) == expected
+        assert len(min_cover) == 10
+        self._assert_terms_covered(terms, min_cover)
 
 
 # ===========================================================================
@@ -1088,6 +1351,66 @@ class TestAmpPhase4Coverage:
         assert result.objective is not None
         assert 0.0 < result.objective <= 3.0 + 1e-6
 
+    @pytest.mark.parametrize("exprmode", [1, 2, 3])
+    def test_alpine_multi3n_milp_builds_trilinear_auxiliaries(self, exprmode):
+        """Alpine multi3N should build one lifted trilinear objective per overlapping block."""
+        m = _make_alpine_multi3n(n=2, exprmode=exprmode)
+        terms = self.classify(m)
+        flat_lb, flat_ub = flat_variable_bounds(m)
+        state = self.init_partitions(
+            terms.partition_candidates,
+            lb=[flat_lb[i] for i in terms.partition_candidates],
+            ub=[flat_ub[i] for i in terms.partition_candidates],
+            n_init=2,
+        )
+
+        milp_model, varmap = self.build_milp(m, terms, state, incumbent=None)
+        result = milp_model.solve()
+
+        assert (0, 1, 2) in varmap["trilinear"]
+        assert (2, 3, 4) in varmap["trilinear"]
+        assert result.status == "optimal"
+        assert result.objective is not None
+
+    @pytest.mark.parametrize("exprmode", range(1, 12))
+    def test_alpine_multi4n_builds_recursive_multilinear_auxiliaries(self, exprmode):
+        """Alpine multi4N expression modes should linearize through recursive bilinear lifts."""
+        m = _make_alpine_multi4n(n=2, exprmode=exprmode)
+        terms = self.classify(m)
+        flat_lb, flat_ub = flat_variable_bounds(m)
+        state = self.init_partitions(
+            terms.partition_candidates,
+            lb=[flat_lb[i] for i in terms.partition_candidates],
+            ub=[flat_ub[i] for i in terms.partition_candidates],
+            n_init=2,
+        )
+
+        milp_model, varmap = self.build_milp(m, terms, state, incumbent=None)
+
+        assert (0, 1, 2, 3) in varmap["multilinear"]
+        assert (3, 4, 5, 6) in varmap["multilinear"]
+        assert len(varmap["multilinear_stages"][(0, 1, 2, 3)]) == 3
+        assert len(varmap["multilinear_stages"][(3, 4, 5, 6)]) == 3
+        assert milp_model._objective_bound_valid is True
+
+    def test_alpine_multi4n_milp_relaxation_solves_with_objective_bound(self):
+        """The recursive multi4N relaxation should solve with a real objective bound."""
+        m = _make_alpine_multi4n(n=2, exprmode=1)
+        terms = self.classify(m)
+        flat_lb, flat_ub = flat_variable_bounds(m)
+        state = self.init_partitions(
+            terms.partition_candidates,
+            lb=[flat_lb[i] for i in terms.partition_candidates],
+            ub=[flat_ub[i] for i in terms.partition_candidates],
+            n_init=2,
+        )
+
+        milp_model, _ = self.build_milp(m, terms, state, incumbent=None)
+        result = milp_model.solve()
+
+        assert result.status == "optimal"
+        assert result.objective is not None
+
     def test_quartic_relaxation_tightens_with_finer_partitions(self):
         """Breakpoint tangents should tighten n>2 monomial objectives as partitions refine."""
         m = _make_quartic_objective_demo()
@@ -1154,6 +1477,7 @@ class TestAmpPhase1Helpers:
 NLP1_OPTIMUM = 58.38368  # Alpine nlp1
 CIRCLE_OPTIMUM = 1.41421356  # √2
 NLP3_OPTIMUM = 7049.247898  # Alpine nlp3
+MULTI2_OPTIMUM = 0.92906489  # Alpine multi2
 
 
 class TestAmpEndToEnd:
@@ -1238,6 +1562,21 @@ class TestAmpEndToEnd:
         assert result.gap_certified is (result.status == "optimal")
         assert result.objective is not None
         assert abs(result.objective - 3.0) <= 1e-3
+
+    def test_alpine_multi2_global_optimum(self):
+        """Alpine multi2 should recover the documented incumbent objective."""
+        m = _make_alpine_multi2()
+        result = m.solve(
+            solver="amp",
+            rel_gap=1e-3,
+            max_iter=8,
+            presolve_bt=False,
+            time_limit=30,
+        )
+
+        assert result.status in ("optimal", "feasible")
+        assert result.objective is not None
+        assert abs(result.objective - MULTI2_OPTIMUM) <= 1e-3
 
     @pytest.mark.slow
     @pytest.mark.timeout(300)

--- a/python/tests/test_amp.py
+++ b/python/tests/test_amp.py
@@ -419,6 +419,19 @@ class TestTermClassifier:
         found = any(set(t) == {0, 1, 2} for t in terms.trilinear)
         assert found, f"Expected trilinear (0,1,2), got {terms.trilinear}"
 
+    def test_detect_higher_order_multilinear_without_pairwise_expansion(self):
+        """x[0]*x[1]*x[2]*x[3] should not create unused pairwise bilinear terms."""
+        m = Model("t")
+        x = m.continuous("x", lb=0, ub=10, shape=(4,))
+        m.minimize(x[0] * x[1] * x[2] * x[3])
+
+        terms = self.classify(m)
+
+        assert terms.bilinear == []
+        assert terms.trilinear == []
+        assert terms.multilinear == [(0, 1, 2, 3)]
+        assert set(terms.partition_candidates) == {0, 1, 2, 3}
+
     def test_mixed_bilinear_and_monomial(self):
         """nlp1: bilinear in constraint, monomial in objective."""
         m = _make_nlp1()
@@ -508,19 +521,23 @@ class TestPartitionSelection:
         self.pick = pick_partition_vars
         self.NonlinearTerms = NonlinearTerms
 
-    def _make_terms(self, bilinear=None, trilinear=None, monomial=None):
+    def _make_terms(self, bilinear=None, trilinear=None, multilinear=None, monomial=None):
         """Helper to build a NonlinearTerms stub."""
         bilinear = bilinear or []
         trilinear = trilinear or []
+        multilinear = multilinear or []
         monomial = monomial or []
-        candidates = list({v for t in bilinear + trilinear for v in t} | {v for v, _ in monomial})
+        candidates = list(
+            {v for t in bilinear + trilinear + multilinear for v in t} | {v for v, _ in monomial}
+        )
         incidence: dict[int, set[int]] = {}
-        for idx, t in enumerate(bilinear + trilinear):
+        for idx, t in enumerate(bilinear + trilinear + multilinear):
             for v in t:
                 incidence.setdefault(v, set()).add(idx)
         return self.NonlinearTerms(
             bilinear=bilinear,
             trilinear=trilinear,
+            multilinear=multilinear,
             monomial=monomial,
             general_nl=[],
             term_incidence=incidence,
@@ -582,6 +599,14 @@ class TestPartitionSelection:
         t = (0, 1, 2)
         assert any(v in selected for v in t), "trilinear term not covered"
 
+    def test_multilinear_terms_covered(self):
+        """Higher-order multilinear terms must be covered as one product term."""
+        terms = self._make_terms(multilinear=[(0, 1, 2, 3)])
+        selected = self.pick(terms, method="min_vertex_cover")
+
+        assert selected
+        assert any(v in selected for v in (0, 1, 2, 3)), "multilinear term not covered"
+
     def test_empty_terms_returns_empty(self):
         """No nonlinear terms → empty partition variable list."""
         terms = self._make_terms()
@@ -633,7 +658,7 @@ class TestAlpinePortedPartitionSelection:
 
     def _assert_terms_covered(self, terms, selected):
         selected_set = set(selected)
-        for term in terms.bilinear + terms.trilinear:
+        for term in terms.bilinear + terms.trilinear + terms.multilinear:
             assert any(v in selected_set for v in term), f"term {term} not covered"
 
     def test_castro2m2_candidates_match_alpine_source(self):
@@ -1392,6 +1417,35 @@ class TestAmpPhase4Coverage:
         assert len(varmap["multilinear_stages"][(0, 1, 2, 3)]) == 3
         assert len(varmap["multilinear_stages"][(3, 4, 5, 6)]) == 3
         assert milp_model._objective_bound_valid is True
+
+    def test_multilinear_build_avoids_unused_original_pairwise_lifts(self):
+        """A pure 4-factor product should build only the recursive product chain."""
+        m = Model("multilinear_chain_only")
+        x = m.continuous("x", lb=0.1, ub=4.0, shape=(4,))
+        m.maximize(x[0] * x[1] * x[2] * x[3])
+        terms = self.classify(m)
+        state = self.init_partitions(
+            terms.partition_candidates,
+            lb=[0.1] * 4,
+            ub=[4.0] * 4,
+            n_init=2,
+        )
+
+        _, varmap = self.build_milp(m, terms, state, incumbent=None)
+
+        stages = varmap["multilinear_stages"][(0, 1, 2, 3)]
+        chain_pairs = {tuple(sorted((stage["lhs_col"], stage["rhs_col"]))) for stage in stages}
+        unused_original_pairs = {
+            (0, 2),
+            (0, 3),
+            (1, 2),
+            (1, 3),
+            (2, 3),
+        }
+
+        assert varmap["bilinear"] == {}
+        assert set(varmap["bilinear_pw"]) == chain_pairs
+        assert not unused_original_pairs & set(varmap["bilinear_pw"])
 
     def test_alpine_multi4n_milp_relaxation_solves_with_objective_bound(self):
         """The recursive multi4N relaxation should solve with a real objective bound."""


### PR DESCRIPTION
## Summary

- Add Alpine-sourced AMP fixtures for `castro2m2`, `blend029_gl`, `multi2`, `multi3N`, and `multi4N` based on `../Alpine.jl`.
- Cover Alpine partition-variable expectations for `castro2m2` and `blend029_gl`.
- Extend AMP's MILP relaxation builder so distinct-variable products with four or more factors are represented by recursive bilinear lifts and keep a valid objective bound.
- Add tests for `multi3N` trilinear lifting, all `multi4N` expression modes, and the documented `multi2` incumbent objective.

## Tests run

- `ruff check python/discopt/_jax/milp_relaxation.py python/tests/test_amp.py` -> passed.
- `ruff format --check python/discopt/_jax/milp_relaxation.py python/tests/test_amp.py` -> passed.
- `PYTHONPATH=python pytest python/tests/test_amp.py::TestAlpinePortedPartitionSelection python/tests/test_amp.py::TestAmpPhase4Coverage::test_alpine_multi3n_milp_builds_trilinear_auxiliaries python/tests/test_amp.py::TestAmpPhase4Coverage::test_alpine_multi4n_builds_recursive_multilinear_auxiliaries python/tests/test_amp.py::TestAmpPhase4Coverage::test_alpine_multi4n_milp_relaxation_solves_with_objective_bound -q` -> 17 passed in 0.78s.
- `PYTHONPATH=python pytest python/tests/test_amp.py::TestAmpEndToEnd::test_alpine_multi2_global_optimum -q` -> 1 passed in 15.30s.
- `PYTHONPATH=python pytest python/tests/test_amp.py -q` -> 143 passed, 7 skipped, 2 xfailed, 1 failed in 955.71s before `cyipopt` was installed locally; the failure was due to missing `cyipopt`, not this PR.
- `PYTHONPATH=python JAX_PLATFORMS=cpu JAX_ENABLE_X64=1 ~/.local/bin/uv --cache-dir /tmp/uv-cache run --no-sync --python .venv/bin/python -m pytest python/tests/ -v --tb=short -q` -> 2805 passed, 77 skipped, 36 xfailed, 81 warnings in 3455.53s.
- `cargo test -p discopt-core` -> 157 passed; doctests 1 passed.
- Commit hook: `ruff`, `ruff format`, and `mypy` passed; `cargo fmt` skipped with no files to check.

## Notes about tests not run

- No PR-relevant local test command remains blocked.
- `.venv/bin/python` resolves `discopt` from a stale editable install unless `PYTHONPATH=python` is set; the successful full-suite command above forces this checkout.

Closes #2
