### PR TITLE
Fix AMP incumbent warm-start policy

### DIFF
--- a/python/discopt/modeling/core.py
+++ b/python/discopt/modeling/core.py
@@ -1830,7 +1830,8 @@ class Model:
         initial_solution : dict, optional
             Initial feasible solution mapping Variable objects to values
             (scalars, lists, or numpy arrays).  Used as a warm-start point
-            for NLP solves and as the initial incumbent in Branch & Bound.
+            for NLP solves, AMP local incumbent improvement, and as the initial
+            incumbent in Branch & Bound.
             Values are validated against variable bounds and integrality
             requirements; violations produce warnings and are corrected
             automatically (clamped / rounded).

--- a/python/discopt/solver.py
+++ b/python/discopt/solver.py
@@ -1405,10 +1405,13 @@ def solve_model(
             "convhull_formulation",
             "convhull_ebd",
             "convhull_ebd_encoding",
+            "use_start_as_incumbent",
         )
         for key in amp_option_keys:
             if key in kwargs:
                 amp_kwargs[key] = kwargs.pop(key)
+        if initial_point is not None:
+            amp_kwargs["initial_point"] = initial_point
 
         ignored_amp_options = []
 
@@ -1429,7 +1432,6 @@ def solve_model(
         _note_ignored("use_learned_relaxations", use_learned_relaxations is not False)
         _note_ignored("mccormick_bounds", mccormick_bounds != "auto")
         _note_ignored("gdp_method", gdp_method != "big-m")
-        _note_ignored("initial_point", initial_point is not None)
         _note_ignored("nlp_bb", nlp_bb is not None)
         _note_ignored("lazy_constraints", lazy_constraints is not None)
         _note_ignored("incumbent_callback", incumbent_callback is not None)

--- a/python/discopt/solvers/amp.py
+++ b/python/discopt/solvers/amp.py
@@ -483,7 +483,7 @@ def _select_best_nlp_candidate(
     nlp_solver: str,
     deadline: Optional[float] = None,
 ) -> tuple[Optional[np.ndarray], Optional[float]]:
-    """Return the best feasible NLP candidate across the integer-rounding set."""
+    """Return the best feasible NLP candidate from a prioritized candidate list."""
     best_x: Optional[np.ndarray] = None
     best_obj: Optional[float] = None
 
@@ -530,21 +530,23 @@ def _solve_best_nlp_candidate(
     constraint_ub: np.ndarray,
     nlp_solver: str,
     incumbent: Optional[np.ndarray] = None,
+    initial_point: Optional[np.ndarray] = None,
     deadline: Optional[float] = None,
 ) -> tuple[Optional[np.ndarray], Optional[float]]:
-    """Return the best feasible NLP candidate across the integer-rounding set."""
+    """Improve the incumbent from Alpine-ordered local NLP starts."""
     if all(v.var_type == VarType.CONTINUOUS for v in model._variables):
         starts: list[np.ndarray] = []
-        for seed in (x0, incumbent):
+        for seed in (incumbent, initial_point, x0):
             if seed is not None:
-                starts.extend(_continuous_recovery_starts(flat_lb, flat_ub, seed))
+                starts.append(np.clip(np.asarray(seed, dtype=np.float64), flat_lb, flat_ub))
+        starts.extend(_continuous_recovery_starts(flat_lb, flat_ub))
         candidates = _dedupe_candidate_points(starts)
     else:
-        candidates = _integer_rounding_candidates(x0, model)
-        if incumbent is not None:
-            candidates = _dedupe_candidate_points(
-                _integer_rounding_candidates(incumbent, model) + candidates
-            )
+        candidates = []
+        for seed in (incumbent, initial_point, x0, _default_nlp_start(flat_lb, flat_ub)):
+            if seed is not None:
+                candidates.extend(_integer_rounding_candidates(seed, model))
+        candidates = _dedupe_candidate_points(candidates)
 
     return _select_best_nlp_candidate(
         candidates,
@@ -819,6 +821,8 @@ def solve_amp(
     convhull_ebd: bool = False,
     convhull_ebd_encoding: str = "gray",
     presolve_bt: bool = True,
+    initial_point: Optional[np.ndarray] = None,
+    use_start_as_incumbent: bool = False,
     skip_convex_check: bool = False,
 ) -> SolveResult:
     """Solve MINLP globally using Adaptive Multivariate Partitioning (AMP).
@@ -872,6 +876,13 @@ def solve_amp(
         ``"binary"`` is only valid for two partitions.
     presolve_bt : bool
         Run LP-based OBBT before the AMP loop to tighten variable bounds.
+    initial_point : ndarray, optional
+        Validated model start point used by AMP's local incumbent-improvement
+        phase. Candidate local NLP starts are tried as incumbent, model start,
+        MILP point, then safe fallback starts.
+    use_start_as_incumbent : bool
+        If True, accept a feasible initial point as the first incumbent before
+        the AMP bounding loop starts, matching Alpine's warm-start policy.
     skip_convex_check : bool
         If True, force AMP even when the model is detected as a pure
         continuous convex problem.
@@ -931,6 +942,7 @@ def solve_amp(
                     ipopt_options=None,
                     t_start=t_start,
                     nlp_solver=nlp_solver,
+                    initial_point=initial_point,
                 )
                 result.convex_fast_path = True
                 return result
@@ -1012,6 +1024,15 @@ def solve_amp(
         else:
             logger.info("AMP: skipping OBBT presolve because no wall-clock budget remains")
 
+    initial_point_arr: Optional[np.ndarray] = None
+    if initial_point is not None:
+        initial_point_arr = np.asarray(initial_point, dtype=np.float64).reshape(-1)
+        if initial_point_arr.size != n_orig:
+            raise ValueError(
+                f"AMP initial_point has length {initial_point_arr.size}; expected {n_orig}"
+            )
+        initial_point_arr = np.clip(initial_point_arr, flat_lb, flat_ub)
+
     # ── Select partition variables ───────────────────────────────────────────
     if apply_partitioning:
         part_vars = pick_partition_vars(terms, method=partition_mode)
@@ -1051,6 +1072,20 @@ def solve_amp(
     LB = -np.inf
     UB = np.inf
     incumbent = None
+    if (
+        use_start_as_incumbent
+        and initial_point_arr is not None
+        and _check_integer_feasible(initial_point_arr, model)
+        and _check_constraints_with_evaluator(
+            evaluator,
+            initial_point_arr,
+            constraint_lb,
+            constraint_ub,
+        )
+    ):
+        UB = float(evaluator.evaluate_objective(initial_point_arr))
+        incumbent = initial_point_arr.copy()
+        logger.info("AMP: accepted feasible initial point as incumbent")
     gap_certified = False
     oa_cuts: list = []  # accumulated OA linearizations from NLP incumbents
     mip_count = 0
@@ -1106,7 +1141,7 @@ def solve_amp(
             termination_reason = "error" if milp_result.status == "error" else "infeasible"
             if LB == -np.inf:
                 # Problem may be infeasible
-                if iteration == 1:
+                if iteration == 1 and incumbent is None:
                     if pure_continuous:
                         recovered = _recover_pure_continuous_solution(
                             model,
@@ -1116,6 +1151,7 @@ def solve_amp(
                             nlp_solver=nlp_solver,
                             t_start=t_start,
                             time_limit=time_limit,
+                            initial_point=initial_point_arr,
                         )
                         if recovered is not None:
                             recovered.mip_count = mip_count
@@ -1162,7 +1198,7 @@ def solve_amp(
             x0 = _extract_orig_solution(milp_result.x, n_orig)
             x0 = np.clip(x0, flat_lb, flat_ub)
         else:
-            x0 = 0.5 * (flat_lb + flat_ub)
+            x0 = _default_nlp_start(flat_lb, flat_ub)
 
         x_nlp, obj_nlp_min = _solve_best_nlp_candidate(
             x0,
@@ -1174,6 +1210,7 @@ def solve_amp(
             constraint_ub,
             nlp_solver,
             incumbent=incumbent,
+            initial_point=initial_point_arr,
             deadline=deadline,
         )
 
@@ -1418,6 +1455,7 @@ def solve_amp(
             nlp_solver=nlp_solver,
             t_start=t_start,
             time_limit=time_limit,
+            initial_point=initial_point_arr,
         )
         if recovered is not None:
             recovered.mip_count = mip_count

--- a/python/discopt/solvers/amp.py
+++ b/python/discopt/solvers/amp.py
@@ -265,8 +265,15 @@ def _solve_nlp_subproblem(
         from discopt.solvers import SolveStatus
 
         if result is not None and result.status == SolveStatus.OPTIMAL:
-            obj = float(evaluator.evaluate_objective(result.x))
-            return result.x, obj
+            x_opt = np.asarray(result.x, dtype=np.float64)
+            if not np.all(np.isfinite(x_opt)):
+                logger.debug("AMP NLP subproblem returned a non-finite solution; rejecting it")
+                return None, None
+            obj = float(evaluator.evaluate_objective(x_opt))
+            if not np.isfinite(obj):
+                logger.debug("AMP NLP subproblem returned a non-finite objective; rejecting it")
+                return None, None
+            return x_opt, obj
     except Exception as e:
         logger.debug("AMP NLP subproblem failed: %s", e)
     return None, None

--- a/python/discopt/solvers/amp.py
+++ b/python/discopt/solvers/amp.py
@@ -171,6 +171,26 @@ def _dedupe_candidate_points(points: list[np.ndarray]) -> list[np.ndarray]:
     return unique
 
 
+def _normalize_initial_point(
+    initial_point: Optional[np.ndarray],
+    n_orig: int,
+    flat_lb: np.ndarray,
+    flat_ub: np.ndarray,
+) -> Optional[np.ndarray]:
+    """Validate and clip an optional AMP initial point."""
+    if initial_point is None:
+        return None
+
+    initial_point_arr = np.asarray(initial_point, dtype=np.float64).reshape(-1)
+    if initial_point_arr.size != n_orig:
+        raise ValueError(
+            f"AMP initial_point has length {initial_point_arr.size}; expected {n_orig}"
+        )
+    if not np.all(np.isfinite(initial_point_arr)):
+        raise ValueError("AMP initial_point must contain only finite values")
+    return np.clip(initial_point_arr, flat_lb, flat_ub)
+
+
 def _remaining_wall_time(deadline: Optional[float]) -> Optional[float]:
     """Return seconds remaining until a deadline, or None when uncapped."""
     if deadline is None:
@@ -925,6 +945,10 @@ def solve_amp(
     if convhull_ebd and convhull_mode != "sos2":
         raise ValueError("convhull_ebd requires convhull_formulation='sos2' or the 'lambda' alias.")
 
+    n_orig = sum(v.size for v in model._variables)
+    flat_lb, flat_ub = flat_variable_bounds(model)
+    initial_point_arr = _normalize_initial_point(initial_point, n_orig, flat_lb, flat_ub)
+
     if pure_continuous and not skip_convex_check:
         try:
             from discopt._jax.convexity import classify_model as _classify_convexity
@@ -942,7 +966,7 @@ def solve_amp(
                     ipopt_options=None,
                     t_start=t_start,
                     nlp_solver=nlp_solver,
-                    initial_point=initial_point,
+                    initial_point=initial_point_arr,
                 )
                 result.convex_fast_path = True
                 return result
@@ -952,8 +976,6 @@ def solve_amp(
     def _from_minimization_space(value: float) -> float:
         return -float(value) if maximize else float(value)
 
-    n_orig = sum(v.size for v in model._variables)
-    flat_lb, flat_ub = flat_variable_bounds(model)
     tightened_lb, tightened_ub, nonlinear_bt_stats = tighten_nonlinear_bounds(
         model, flat_lb, flat_ub
     )
@@ -1024,13 +1046,7 @@ def solve_amp(
         else:
             logger.info("AMP: skipping OBBT presolve because no wall-clock budget remains")
 
-    initial_point_arr: Optional[np.ndarray] = None
-    if initial_point is not None:
-        initial_point_arr = np.asarray(initial_point, dtype=np.float64).reshape(-1)
-        if initial_point_arr.size != n_orig:
-            raise ValueError(
-                f"AMP initial_point has length {initial_point_arr.size}; expected {n_orig}"
-            )
+    if initial_point_arr is not None:
         initial_point_arr = np.clip(initial_point_arr, flat_lb, flat_ub)
 
     # ── Select partition variables ───────────────────────────────────────────
@@ -1083,9 +1099,13 @@ def solve_amp(
             constraint_ub,
         )
     ):
-        UB = float(evaluator.evaluate_objective(initial_point_arr))
-        incumbent = initial_point_arr.copy()
-        logger.info("AMP: accepted feasible initial point as incumbent")
+        initial_obj = float(evaluator.evaluate_objective(initial_point_arr))
+        if np.isfinite(initial_obj):
+            UB = initial_obj
+            incumbent = initial_point_arr.copy()
+            logger.info("AMP: accepted feasible initial point as incumbent")
+        else:
+            logger.info("AMP: feasible initial point has non-finite objective; not using incumbent")
     gap_certified = False
     oa_cuts: list = []  # accumulated OA linearizations from NLP incumbents
     mip_count = 0

--- a/python/discopt/warm_start.py
+++ b/python/discopt/warm_start.py
@@ -54,7 +54,7 @@ def validate_initial_solution(
         If *initial_solution* is not a dict or contains non-Variable keys.
     ValueError
         If a Variable does not belong to the model, or a value has the
-        wrong shape.
+        wrong shape or non-finite entries.
     """
     if not isinstance(initial_solution, dict):
         raise TypeError(
@@ -115,6 +115,11 @@ def validate_initial_solution(
             # Bounds checking and clamping
             lb_flat = v.lb.flatten()
             ub_flat = v.ub.flatten()
+
+            if not np.all(np.isfinite(val)):
+                raise ValueError(
+                    f"Variable '{v.name}' initial_solution contains non-finite value(s)"
+                )
 
             below = val < lb_flat - tol_bounds
             above = val > ub_flat + tol_bounds

--- a/python/tests/test_amp.py
+++ b/python/tests/test_amp.py
@@ -2210,10 +2210,6 @@ class TestCurrentCodeWeaknesses:
                 1,
             ),
         )
-        monkeypatch.setattr(
-            amp_mod, "_recover_pure_continuous_solution", lambda *args, **kwargs: None
-        )
-
         result = m.solve(
             solver="amp",
             initial_solution={x: 0.5},

--- a/python/tests/test_amp.py
+++ b/python/tests/test_amp.py
@@ -1890,6 +1890,8 @@ class TestCurrentCodeWeaknesses:
             m,
             solver="amp",
             gap_tolerance=1e-3,
+            initial_point=np.array([0.25], dtype=np.float64),
+            use_start_as_incumbent=True,
             apply_partitioning=False,
             disc_var_pick=1,
             partition_scaling_factor=7.0,
@@ -1901,6 +1903,8 @@ class TestCurrentCodeWeaknesses:
         )
 
         assert captured["rel_gap"] == pytest.approx(1e-3)
+        assert np.allclose(captured["initial_point"], np.array([0.25], dtype=np.float64))
+        assert captured["use_start_as_incumbent"] is True
         assert captured["apply_partitioning"] is False
         assert captured["disc_var_pick"] == 1
         assert captured["partition_scaling_factor"] == pytest.approx(7.0)
@@ -2051,6 +2055,40 @@ class TestCurrentCodeWeaknesses:
         assert float(best_x[0]) == pytest.approx(1.0)
         assert best_obj == pytest.approx(1.5)
 
+    def test_best_nlp_candidate_prioritizes_incumbent_start_then_model_start_then_milp(
+        self,
+        monkeypatch,
+    ):
+        """AMP local search should try incumbent, model start, then MILP point first."""
+        from discopt.solvers import amp as amp_mod
+
+        m = Model("candidate_priority")
+        m.continuous("x", lb=0.0, ub=10.0)
+        seen_starts = []
+
+        monkeypatch.setattr(
+            amp_mod,
+            "_solve_nlp_subproblem",
+            lambda evaluator, x0, lb, ub, nlp_solver, time_limit=None: (
+                seen_starts.append(float(x0[0])) or (None, None)
+            ),
+        )
+
+        amp_mod._solve_best_nlp_candidate(
+            np.array([6.0], dtype=np.float64),
+            m,
+            evaluator=object(),
+            flat_lb=np.array([0.0], dtype=np.float64),
+            flat_ub=np.array([10.0], dtype=np.float64),
+            constraint_lb=np.array([], dtype=np.float64),
+            constraint_ub=np.array([], dtype=np.float64),
+            nlp_solver="ipm",
+            incumbent=np.array([2.0], dtype=np.float64),
+            initial_point=np.array([4.0], dtype=np.float64),
+        )
+
+        assert seen_starts[:3] == [2.0, 4.0, 6.0]
+
     def test_best_nlp_candidate_rejects_noninteger_nlp_return(self, monkeypatch):
         """NLP candidates that violate integrality should be discarded."""
         from discopt.solvers import amp as amp_mod
@@ -2090,6 +2128,42 @@ class TestCurrentCodeWeaknesses:
 
         assert best_x is None
         assert best_obj is None
+
+    def test_amp_accepts_feasible_start_as_incumbent(self, monkeypatch):
+        """A feasible model start should survive when proof search fails immediately."""
+        from discopt._jax.milp_relaxation import MilpRelaxationResult
+        from discopt.solvers import amp as amp_mod
+
+        m = Model("amp_start_incumbent")
+        x = m.continuous("x", lb=0.0, ub=2.0)
+        m.subject_to(x >= 0.25)
+        m.minimize((x - 1.0) ** 2)
+
+        monkeypatch.setattr(
+            amp_mod,
+            "_solve_milp_with_oa_recovery",
+            lambda **kwargs: (
+                MilpRelaxationResult(status="error", objective=None, x=None),
+                {},
+                [],
+                1,
+            ),
+        )
+
+        result = m.solve(
+            solver="amp",
+            initial_solution={x: 0.5},
+            use_start_as_incumbent=True,
+            skip_convex_check=True,
+            presolve_bt=False,
+            max_iter=1,
+            time_limit=30,
+        )
+
+        assert result.status == "feasible"
+        assert result.objective == pytest.approx(0.25)
+        assert result.x is not None
+        assert np.asarray(result.x["x"]).item() == pytest.approx(0.5)
 
     def test_amp_recovers_minlptests_integer_incumbent_from_small_finite_box(self):
         """AMP should recover finite-domain MINLP incumbents even from integral MILP points."""

--- a/python/tests/test_amp.py
+++ b/python/tests/test_amp.py
@@ -2165,6 +2165,69 @@ class TestCurrentCodeWeaknesses:
         assert result.x is not None
         assert np.asarray(result.x["x"]).item() == pytest.approx(0.5)
 
+    @pytest.mark.parametrize("bad_value", [np.nan, np.inf, -np.inf])
+    def test_amp_rejects_nonfinite_direct_initial_point(self, bad_value):
+        """Direct AMP initial points must be finite before incumbent checks."""
+        from discopt.solvers import amp as amp_mod
+
+        m = Model("amp_nonfinite_start")
+        x = m.continuous("x", lb=0.0, ub=1.0)
+        m.minimize(x)
+
+        with pytest.raises(ValueError, match="finite"):
+            amp_mod.solve_amp(
+                m,
+                initial_point=np.array([bad_value], dtype=np.float64),
+                use_start_as_incumbent=True,
+                skip_convex_check=True,
+                presolve_bt=False,
+                max_iter=1,
+                time_limit=1.0,
+            )
+
+    def test_amp_does_not_accept_start_with_nonfinite_objective(self, monkeypatch):
+        """A finite start with NaN objective is not a valid AMP incumbent."""
+        import discopt._jax.nlp_evaluator as nlp_eval
+        from discopt._jax.milp_relaxation import MilpRelaxationResult
+        from discopt.solvers import amp as amp_mod
+
+        m = Model("amp_nan_objective_start")
+        x = m.continuous("x", lb=0.0, ub=1.0)
+        m.minimize(x)
+
+        monkeypatch.setattr(
+            nlp_eval.NLPEvaluator,
+            "evaluate_objective",
+            lambda self, x_flat: np.nan,
+        )
+        monkeypatch.setattr(
+            amp_mod,
+            "_solve_milp_with_oa_recovery",
+            lambda **kwargs: (
+                MilpRelaxationResult(status="error", objective=None, x=None),
+                {},
+                [],
+                1,
+            ),
+        )
+        monkeypatch.setattr(
+            amp_mod, "_recover_pure_continuous_solution", lambda *args, **kwargs: None
+        )
+
+        result = m.solve(
+            solver="amp",
+            initial_solution={x: 0.5},
+            use_start_as_incumbent=True,
+            skip_convex_check=True,
+            presolve_bt=False,
+            max_iter=1,
+            time_limit=1.0,
+        )
+
+        assert result.status == "error"
+        assert result.objective is None
+        assert result.x is None
+
     def test_amp_recovers_minlptests_integer_incumbent_from_small_finite_box(self):
         """AMP should recover finite-domain MINLP incumbents even from integral MILP points."""
         instance = MINLPTESTS_MI_BY_ID["nlp_mi_003_014"]

--- a/python/tests/test_warm_start.py
+++ b/python/tests/test_warm_start.py
@@ -110,6 +110,12 @@ class TestValidation:
         with pytest.raises(ValueError, match="shape"):
             validate_initial_solution(m, {x: [1.0, 2.0]})
 
+    @pytest.mark.parametrize("bad_value", [np.nan, np.inf, -np.inf])
+    def test_nonfinite_solution_raises_value_error(self, bad_value):
+        m, x, y = _make_nlp()
+        with pytest.raises(ValueError, match="non-finite"):
+            validate_initial_solution(m, {x: bad_value})
+
     def test_bounds_violation_warns_and_clamps(self):
         m, x, y = _make_nlp()
         with warnings.catch_warnings(record=True) as w:


### PR DESCRIPTION
## Summary

- Thread validated `initial_solution` / `initial_point` into AMP instead of treating it as ignored.
- Add Alpine-style `use_start_as_incumbent` so a feasible model start can become the first AMP incumbent before proof search.
- Order AMP local incumbent-improvement starts as incumbent, model start, MILP point, then safe fallback starts.
- Keep a feasible incumbent separate from proof/bound failure status, and document the AMP warm-start behavior.

Closes #15

## Tests run

- `PYTHONPATH=python JAX_PLATFORMS=cpu JAX_ENABLE_X64=1 .venv/bin/python -m pytest -q python/tests/test_amp.py::TestCurrentCodeWeaknesses::test_solve_model_forwards_alpine_amp_aliases python/tests/test_amp.py::TestCurrentCodeWeaknesses::test_best_nlp_candidate_prioritizes_incumbent_start_then_model_start_then_milp python/tests/test_amp.py::TestCurrentCodeWeaknesses::test_amp_accepts_feasible_start_as_incumbent --timeout=120`
  - Result: `3 passed in 1.31s`
- `PYTHONPATH=python JAX_PLATFORMS=cpu JAX_ENABLE_X64=1 .venv/bin/python -m pytest -q python/tests/test_amp.py::TestCurrentCodeWeaknesses::test_best_nlp_candidate_chooses_lowest_feasible_objective python/tests/test_amp.py::TestCurrentCodeWeaknesses::test_best_nlp_candidate_rejects_noninteger_nlp_return python/tests/test_amp.py::TestCurrentCodeWeaknesses::test_no_incumbent_after_search_returns_iteration_limit python/tests/test_amp.py::TestCurrentCodeWeaknesses::test_first_iteration_milp_error_is_not_reported_as_infeasible python/tests/test_amp.py::TestCurrentCodeWeaknesses::test_amp_time_limit_with_incumbent_returns_feasible --timeout=120`
  - Result: `5 passed in 0.90s`
- `PYTHONPATH=python JAX_PLATFORMS=cpu JAX_ENABLE_X64=1 .venv/bin/python -m pytest -q python/tests/test_amp.py::TestCurrentCodeWeaknesses --timeout=120 -k 'not spatial_bnb_bilinear_global_correctness'`
  - Result: `59 passed, 7 skipped, 1 deselected, 1 xfailed in 199.99s`
- `PYTHONPATH=python .venv/bin/python -m ruff check python/discopt/solvers/amp.py python/discopt/solver.py python/discopt/modeling/core.py python/tests/test_amp.py`
  - Result: `All checks passed!`
- `PYTHONPATH=python .venv/bin/python -m ruff format --check python/discopt/solvers/amp.py python/discopt/solver.py python/discopt/modeling/core.py python/tests/test_amp.py`
  - Result: `4 files already formatted`
- `PYTHONPATH=python .venv/bin/python -m mypy python/discopt/solvers/amp.py python/discopt/solver.py`
  - Result: `Success: no issues found in 2 source files`
- `git commit -m "Fix AMP incumbent warm-start policy (#15)"`
  - Result: pre-commit hooks passed: `ruff`, `ruff format`, `mypy`; `cargo fmt` skipped with no Rust files.

## Notes

- Created a fresh `.venv` with `uv`. A normal `uv pip install` could not complete because this environment had no PyPI DNS access, and the escalation request for network access was automatically rejected. I reran local checks through the fresh `.venv` on Python 3.13 with system site packages visible; HiGHS and the repo `_rust` extension were available there.
- `cyipopt` / Ipopt were not available locally. The full `TestCurrentCodeWeaknesses` command therefore had one environment-dependent failure in `test_spatial_bnb_bilinear_global_correctness`; rerunning the class with that cyipopt-dependent comparison excluded passed as reported above.
