### PR TITLE
Expose AMP partition hooks

### DIFF
--- a/discopt_benchmarks/README.md
+++ b/discopt_benchmarks/README.md
@@ -47,6 +47,48 @@ python run_benchmarks.py --suite comparison --solvers discopt,baron
 python run_benchmarks.py --suite phase2 --report
 ```
 
+## AMP Custom Partition Heuristics
+
+AMP benchmark runs can supply Alpine-style custom partition hooks directly to
+`Model.solve`. This keeps heuristic experiments outside solver internals:
+
+```python
+from discopt._jax.discretization import add_adaptive_partition
+
+
+def choose_partition_vars(ctx):
+    # Start from any built-in rule, then customize the returned flat indices.
+    selected = ctx["builtin_pick_partition_vars"]("adaptive_vertex_cover", ctx.get("distance"))
+    return selected[:1] or ctx["partition_candidates"][:1]
+
+
+def update_scaling(ctx):
+    return min(40.0, ctx["current_scaling_factor"] * 1.25)
+
+
+def refine_partitions(ctx):
+    return add_adaptive_partition(
+        ctx["disc_state"],
+        ctx["solution"],
+        ctx["var_indices"],
+        ctx["lb"],
+        ctx["ub"],
+    )
+
+
+result = model.solve(
+    solver="amp",
+    disc_var_pick=choose_partition_vars,
+    partition_scaling_factor_update=update_scaling,
+    disc_add_partition_method=refine_partitions,
+    time_limit=300,
+)
+```
+
+For local Alpine/incidence checks, use the repository's documented pixi plus uv
+`.venv` workflow before running `make test-amp-integration`; avoid reusing an
+uncontrolled local Python environment for those solver-dependent examples.
+
 ## Benchmark Suites
 
 | Suite       | Purpose                              | Instances | Time Limit |

--- a/python/discopt/solver.py
+++ b/python/discopt/solver.py
@@ -1403,6 +1403,7 @@ def solve_model(
             "apply_partitioning",
             "disc_var_pick",
             "partition_scaling_factor",
+            "partition_scaling_factor_update",
             "disc_add_partition_method",
             "disc_abs_width_tol",
             "convhull_formulation",

--- a/python/discopt/solvers/amp.py
+++ b/python/discopt/solvers/amp.py
@@ -1046,6 +1046,7 @@ def _run_partitioned_obbt(
     total_time_limit: float,
     time_limit_per_mip: float,
     gap_tolerance: float,
+    partition_scaling_factor_update: Optional[Callable[[dict[str, Any]], Any]] = None,
     disc_var_pick_hook: Optional[Callable[[dict[str, Any]], Any]] = None,
     disc_add_partition_hook: Optional[Callable[[dict[str, Any]], Any]] = None,
     min_width: float = 1e-6,
@@ -1094,6 +1095,30 @@ def _run_partitioned_obbt(
             abs_width_tol=disc_abs_width_tol,
         )
         solution = {i: float(incumbent[i]) for i in part_vars}
+        refinement_context = {
+            "stage": "presolve_obbt_refinement",
+            "model": model,
+            "terms": terms,
+            "disc_state": base_state,
+            "solution": solution,
+            "var_indices": list(part_vars),
+            "lb": list(part_lbs),
+            "ub": list(part_ubs),
+            "flat_lb": flat_lb.copy(),
+            "flat_ub": flat_ub.copy(),
+            "partition_mode": partition_mode,
+            "partition_scaling_factor": partition_scaling_factor,
+            "incumbent": incumbent.copy(),
+            "incumbent_objective": incumbent_obj,
+        }
+        partition_scaling_factor = _apply_partition_scaling_update(
+            partition_scaling_factor_update,
+            current_scaling_factor=partition_scaling_factor,
+            context=refinement_context,
+        )
+        base_state.scaling_factor = partition_scaling_factor
+        refinement_context["partition_scaling_factor"] = partition_scaling_factor
+        refinement_context["disc_state"] = base_state
         if disc_add_partition_hook is None:
             disc_state = add_adaptive_partition(
                 base_state,
@@ -1105,22 +1130,7 @@ def _run_partitioned_obbt(
         else:
             disc_state = _apply_partition_refinement_hook(
                 disc_add_partition_hook,
-                {
-                    "stage": "presolve_obbt_refinement",
-                    "model": model,
-                    "terms": terms,
-                    "disc_state": base_state,
-                    "solution": solution,
-                    "var_indices": list(part_vars),
-                    "lb": list(part_lbs),
-                    "ub": list(part_ubs),
-                    "flat_lb": flat_lb.copy(),
-                    "flat_ub": flat_ub.copy(),
-                    "partition_mode": partition_mode,
-                    "partition_scaling_factor": partition_scaling_factor,
-                    "incumbent": incumbent.copy(),
-                    "incumbent_objective": incumbent_obj,
-                },
+                refinement_context,
             )
     else:
         disc_state = DiscretizationState(
@@ -1262,6 +1272,7 @@ def _run_amp_presolve_bound_tightening(
     milp_gap_tolerance: Optional[float],
     presolve_bt_time_limit: Optional[float],
     presolve_bt_mip_time_limit: Optional[float],
+    partition_scaling_factor_update: Optional[Callable[[dict[str, Any]], Any]] = None,
     disc_var_pick_hook: Optional[Callable[[dict[str, Any]], Any]] = None,
     disc_add_partition_hook: Optional[Callable[[dict[str, Any]], Any]] = None,
 ) -> tuple[np.ndarray, np.ndarray, Any]:
@@ -1321,6 +1332,7 @@ def _run_amp_presolve_bound_tightening(
             total_time_limit=partitioned_budget,
             time_limit_per_mip=subproblem_budget,
             gap_tolerance=milp_gap_tolerance if milp_gap_tolerance is not None else 1e-4,
+            partition_scaling_factor_update=partition_scaling_factor_update,
             disc_var_pick_hook=disc_var_pick_hook,
             disc_add_partition_hook=disc_add_partition_hook,
         )
@@ -1629,6 +1641,7 @@ def solve_amp(
                 milp_gap_tolerance=milp_gap_tolerance,
                 presolve_bt_time_limit=presolve_bt_time_limit,
                 presolve_bt_mip_time_limit=presolve_bt_mip_time_limit,
+                partition_scaling_factor_update=partition_scaling_factor_update,
                 disc_var_pick_hook=disc_var_pick_hook,
                 disc_add_partition_hook=disc_add_partition_hook,
             )

--- a/python/discopt/solvers/amp.py
+++ b/python/discopt/solvers/amp.py
@@ -750,12 +750,127 @@ def _default_milp_time_limit(
     return min(iter_budget * 3, remaining * 0.8, 60.0)
 
 
+def _validate_partition_scaling_factor(
+    value: Any,
+    option_name: str = "partition_scaling_factor",
+) -> float:
+    """Return a numeric AMP partition scaling factor."""
+    try:
+        factor = float(value)
+    except (TypeError, ValueError) as err:
+        raise ValueError(f"{option_name} must be a finite number > 1.0") from err
+    if not np.isfinite(factor) or factor <= 1.0:
+        raise ValueError(f"{option_name} must be a finite number > 1.0")
+    return factor
+
+
+def _normalize_partition_var_indices(
+    selected: Any,
+    n_orig: int,
+    *,
+    source: str,
+) -> list[int]:
+    """Validate flat variable indices returned by a custom AMP selection hook."""
+    if selected is None:
+        raise ValueError(f"{source} callable must return an iterable of flat variable indices")
+    try:
+        raw_indices = list(selected)
+    except TypeError as err:
+        raise ValueError(
+            f"{source} callable must return an iterable of flat variable indices"
+        ) from err
+
+    normalized: list[int] = []
+    seen: set[int] = set()
+    for raw_idx in raw_indices:
+        if isinstance(raw_idx, bool) or not isinstance(raw_idx, (int, np.integer)):
+            raise ValueError(f"{source} callable returned a non-integer index: {raw_idx!r}")
+        idx = int(raw_idx)
+        if idx < 0 or idx >= n_orig:
+            raise ValueError(
+                f"{source} callable returned index {idx}, outside valid range [0, {n_orig})"
+            )
+        if idx not in seen:
+            seen.add(idx)
+            normalized.append(idx)
+    return normalized
+
+
+def _select_partition_vars_with_hook(
+    terms,
+    *,
+    method: str,
+    disc_var_pick_hook: Optional[Callable[[dict[str, Any]], Any]],
+    pick_partition_vars: Callable[..., list[int]],
+    n_orig: int,
+    context: dict[str, Any],
+) -> list[int]:
+    """Select AMP partition variables through either a built-in method or user hook."""
+    if disc_var_pick_hook is None:
+        return pick_partition_vars(terms, method=method, distance=context.get("distance"))
+
+    def builtin_pick(
+        builtin_method: str = method,
+        distance: Optional[dict[int, float]] = None,
+    ) -> list[int]:
+        return pick_partition_vars(terms, method=builtin_method, distance=distance)
+
+    context = dict(context)
+    context.setdefault("partition_candidates", list(getattr(terms, "partition_candidates", [])))
+    context.setdefault("builtin_pick_partition_vars", builtin_pick)
+    return _normalize_partition_var_indices(
+        disc_var_pick_hook(context),
+        n_orig,
+        source="disc_var_pick",
+    )
+
+
+def _apply_partition_scaling_update(
+    partition_scaling_factor_update: Optional[Callable[[dict[str, Any]], Any]],
+    *,
+    current_scaling_factor: float,
+    context: dict[str, Any],
+) -> float:
+    """Apply an optional user hook that updates AMP's adaptive refinement width."""
+    if partition_scaling_factor_update is None:
+        return current_scaling_factor
+
+    hook_context = dict(context)
+    hook_context["current_scaling_factor"] = current_scaling_factor
+    updated = partition_scaling_factor_update(hook_context)
+    if updated is None:
+        return current_scaling_factor
+    return _validate_partition_scaling_factor(updated, "partition_scaling_factor_update")
+
+
+def _apply_partition_refinement_hook(
+    disc_add_partition_hook: Callable[[dict[str, Any]], Any],
+    context: dict[str, Any],
+) -> Any:
+    """Run a custom AMP partition-refinement hook and validate its state result."""
+    result = disc_add_partition_hook(dict(context))
+    if result is None:
+        result = context.get("disc_state")
+    if not (
+        hasattr(result, "partitions")
+        and hasattr(result, "scaling_factor")
+        and hasattr(result, "abs_width_tol")
+    ):
+        raise ValueError(
+            "disc_add_partition_method callable must return a DiscretizationState "
+            "or mutate context['disc_state'] in place"
+        )
+    return result
+
+
 def _normalize_partition_method(
     partition_method: str,
-    disc_var_pick: int | str | None,
+    disc_var_pick: int | str | Callable[[dict[str, Any]], Any] | None,
 ) -> str:
     """Resolve public AMP aliases to the internal partition-selection strategy."""
     if disc_var_pick is None:
+        return partition_method
+    if callable(disc_var_pick):
         return partition_method
 
     if isinstance(disc_var_pick, str):
@@ -931,6 +1046,8 @@ def _run_partitioned_obbt(
     total_time_limit: float,
     time_limit_per_mip: float,
     gap_tolerance: float,
+    disc_var_pick_hook: Optional[Callable[[dict[str, Any]], Any]] = None,
+    disc_add_partition_hook: Optional[Callable[[dict[str, Any]], Any]] = None,
     min_width: float = 1e-6,
 ):
     """Run incumbent-seeded OBBT on AMP's partition-aware MILP relaxation."""
@@ -944,7 +1061,24 @@ def _run_partitioned_obbt(
     from discopt._jax.partition_selection import pick_partition_vars
 
     n_orig = len(flat_lb)
-    part_vars = pick_partition_vars(terms, method=partition_mode)
+    part_vars = _select_partition_vars_with_hook(
+        terms,
+        method=partition_mode,
+        disc_var_pick_hook=disc_var_pick_hook,
+        pick_partition_vars=pick_partition_vars,
+        n_orig=n_orig,
+        context={
+            "stage": "presolve_obbt_selection",
+            "model": model,
+            "terms": terms,
+            "flat_lb": flat_lb.copy(),
+            "flat_ub": flat_ub.copy(),
+            "partition_mode": partition_mode,
+            "partition_scaling_factor": partition_scaling_factor,
+            "incumbent": incumbent.copy(),
+            "incumbent_objective": incumbent_obj,
+        },
+    )
     if not part_vars and terms.monomial:
         part_vars = sorted(set(var_idx for var_idx, _ in terms.monomial))
 
@@ -960,13 +1094,34 @@ def _run_partitioned_obbt(
             abs_width_tol=disc_abs_width_tol,
         )
         solution = {i: float(incumbent[i]) for i in part_vars}
-        disc_state = add_adaptive_partition(
-            base_state,
-            solution,
-            part_vars,
-            part_lbs,
-            part_ubs,
-        )
+        if disc_add_partition_hook is None:
+            disc_state = add_adaptive_partition(
+                base_state,
+                solution,
+                part_vars,
+                part_lbs,
+                part_ubs,
+            )
+        else:
+            disc_state = _apply_partition_refinement_hook(
+                disc_add_partition_hook,
+                {
+                    "stage": "presolve_obbt_refinement",
+                    "model": model,
+                    "terms": terms,
+                    "disc_state": base_state,
+                    "solution": solution,
+                    "var_indices": list(part_vars),
+                    "lb": list(part_lbs),
+                    "ub": list(part_ubs),
+                    "flat_lb": flat_lb.copy(),
+                    "flat_ub": flat_ub.copy(),
+                    "partition_mode": partition_mode,
+                    "partition_scaling_factor": partition_scaling_factor,
+                    "incumbent": incumbent.copy(),
+                    "incumbent_objective": incumbent_obj,
+                },
+            )
     else:
         disc_state = DiscretizationState(
             scaling_factor=partition_scaling_factor,
@@ -1107,6 +1262,8 @@ def _run_amp_presolve_bound_tightening(
     milp_gap_tolerance: Optional[float],
     presolve_bt_time_limit: Optional[float],
     presolve_bt_mip_time_limit: Optional[float],
+    disc_var_pick_hook: Optional[Callable[[dict[str, Any]], Any]] = None,
+    disc_add_partition_hook: Optional[Callable[[dict[str, Any]], Any]] = None,
 ) -> tuple[np.ndarray, np.ndarray, Any]:
     """Run the configured AMP presolve OBBT mode and return tightened bounds."""
     from discopt._jax.obbt import run_obbt
@@ -1164,6 +1321,8 @@ def _run_amp_presolve_bound_tightening(
             total_time_limit=partitioned_budget,
             time_limit_per_mip=subproblem_budget,
             gap_tolerance=milp_gap_tolerance if milp_gap_tolerance is not None else 1e-4,
+            disc_var_pick_hook=disc_var_pick_hook,
+            disc_add_partition_hook=disc_add_partition_hook,
         )
     except Exception as err:
         logger.warning(
@@ -1221,9 +1380,10 @@ def solve_amp(
     milp_time_limit: Optional[float] = None,
     milp_gap_tolerance: Optional[float] = None,
     apply_partitioning: bool = True,
-    disc_var_pick: int | str | None = None,
+    disc_var_pick: int | str | Callable[[dict[str, Any]], Any] | None = None,
     partition_scaling_factor: float = 10.0,
-    disc_add_partition_method: str = "adaptive",
+    partition_scaling_factor_update: Optional[Callable[[dict[str, Any]], Any]] = None,
+    disc_add_partition_method: str | Callable[[dict[str, Any]], Any] = "adaptive",
     disc_abs_width_tol: float = 1e-3,
     convhull_formulation: str = "disaggregated",
     convhull_ebd: bool = False,
@@ -1264,16 +1424,24 @@ def solve_amp(
         MILP solver gap tolerance (default 1e-4).
     apply_partitioning : bool
         If False, solve a single relaxation/NLP pass without adaptive refinement.
-    disc_var_pick : int | str, optional
+    disc_var_pick : int, str, or callable, optional
         Alpine-style alias for partition selection:
         0/``"all"`` → max_cover, 1 → min_vertex_cover, 2 → auto,
         3 → adaptive weighted cover. This intentionally collapses Alpine's
         separate `disc_var_pick_algo` and `disc_var_pick` options into one
-        user-facing control.
+        user-facing control. A callable may also be supplied; it receives a
+        context dict and must return flat variable indices to partition.
     partition_scaling_factor : float
         Width scaling used by adaptive partition refinement.
-    disc_add_partition_method : str
-        Refinement update rule: ``"adaptive"`` or ``"uniform"``.
+    partition_scaling_factor_update : callable, optional
+        Hook called before each partition-refinement step. It receives the same
+        context dict shape as the partition hooks plus ``current_scaling_factor``
+        and may return a new finite factor greater than 1. Returning ``None``
+        keeps the current factor.
+    disc_add_partition_method : str or callable
+        Refinement update rule: ``"adaptive"`` or ``"uniform"``. A callable
+        may also be supplied; it receives a context dict and must return a
+        ``DiscretizationState`` or mutate ``context["disc_state"]`` in place.
     disc_abs_width_tol : float
         Absolute partition-width convergence tolerance.
     convhull_formulation : str
@@ -1337,9 +1505,12 @@ def solve_amp(
     part_lbs: list[float] = []
     part_ubs: list[float] = []
 
-    if partition_scaling_factor <= 1.0:
-        raise ValueError("partition_scaling_factor must be > 1.0")
-    if disc_add_partition_method not in {"adaptive", "uniform"}:
+    partition_scaling_factor = _validate_partition_scaling_factor(partition_scaling_factor)
+    disc_var_pick_hook = disc_var_pick if callable(disc_var_pick) else None
+    disc_add_partition_hook = (
+        disc_add_partition_method if callable(disc_add_partition_method) else None
+    )
+    if disc_add_partition_hook is None and disc_add_partition_method not in {"adaptive", "uniform"}:
         raise ValueError("disc_add_partition_method must be 'adaptive' or 'uniform'")
 
     partition_mode = _normalize_partition_method(partition_method, disc_var_pick)
@@ -1458,6 +1629,8 @@ def solve_amp(
                 milp_gap_tolerance=milp_gap_tolerance,
                 presolve_bt_time_limit=presolve_bt_time_limit,
                 presolve_bt_mip_time_limit=presolve_bt_mip_time_limit,
+                disc_var_pick_hook=disc_var_pick_hook,
+                disc_add_partition_hook=disc_add_partition_hook,
             )
         except ImportError as err:
             logger.warning("AMP: OBBT presolve unavailable; continuing without it: %s", err)
@@ -1476,7 +1649,26 @@ def solve_amp(
 
     # ── Select partition variables ───────────────────────────────────────────
     if apply_partitioning:
-        part_vars = pick_partition_vars(terms, method=partition_mode)
+        part_vars = _select_partition_vars_with_hook(
+            terms,
+            method=partition_mode,
+            disc_var_pick_hook=disc_var_pick_hook,
+            pick_partition_vars=pick_partition_vars,
+            n_orig=n_orig,
+            context={
+                "stage": "initial_selection",
+                "model": model,
+                "terms": terms,
+                "flat_lb": flat_lb.copy(),
+                "flat_ub": flat_ub.copy(),
+                "iteration": 0,
+                "partition_mode": partition_mode,
+                "partition_scaling_factor": partition_scaling_factor,
+                "incumbent": None,
+                "milp_result": None,
+                "distance": None,
+            },
+        )
     else:
         part_vars = []
 
@@ -1488,7 +1680,8 @@ def solve_amp(
     elif not apply_partitioning:
         logger.info("AMP: partitioning disabled; running a single fixed relaxation pass")
     else:
-        logger.info("AMP: partitioning %d variables via %s", len(part_vars), partition_mode)
+        partition_label = "custom hook" if disc_var_pick_hook is not None else partition_mode
+        logger.info("AMP: partitioning %d variables via %s", len(part_vars), partition_label)
 
     # ── Initialize partitions ────────────────────────────────────────────────
     if part_vars:
@@ -1777,19 +1970,39 @@ def solve_amp(
             break
 
         if (
-            partition_mode == "adaptive_vertex_cover"
+            (partition_mode == "adaptive_vertex_cover" or disc_var_pick_hook is not None)
             and incumbent is not None
             and milp_result.x is not None
         ):
             distances = {
                 i: abs(float(incumbent[i]) - float(x0[i])) for i in terms.partition_candidates
             }
-            adaptive_vars = pick_partition_vars(
-                terms,
-                method="adaptive_vertex_cover",
-                distance=distances,
+            adaptive_method = (
+                "adaptive_vertex_cover" if disc_var_pick_hook is None else partition_mode
             )
-            if adaptive_vars and set(adaptive_vars) != set(part_vars):
+            adaptive_vars = _select_partition_vars_with_hook(
+                terms,
+                method=adaptive_method,
+                disc_var_pick_hook=disc_var_pick_hook,
+                pick_partition_vars=pick_partition_vars,
+                n_orig=n_orig,
+                context={
+                    "stage": "iteration_selection",
+                    "model": model,
+                    "terms": terms,
+                    "flat_lb": flat_lb.copy(),
+                    "flat_ub": flat_ub.copy(),
+                    "iteration": iteration,
+                    "partition_mode": partition_mode,
+                    "partition_scaling_factor": partition_scaling_factor,
+                    "incumbent": incumbent.copy(),
+                    "milp_solution": x0.copy(),
+                    "milp_result": milp_result,
+                    "distance": distances,
+                    "part_vars": list(part_vars),
+                },
+            )
+            if set(adaptive_vars) != set(part_vars):
                 logger.info(
                     "AMP: updating adaptive partition set from %d to %d variables",
                     len(part_vars),
@@ -1812,6 +2025,9 @@ def solve_amp(
                 part_lbs = [float(flat_lb[i]) for i in part_vars]
                 part_ubs = [float(flat_ub[i]) for i in part_vars]
 
+        if not part_vars:
+            break
+
         # Use MILP solution (original vars) as the refinement point
         refine_solution: dict[int, float] = {}
         if milp_result.x is not None:
@@ -1819,7 +2035,41 @@ def solve_amp(
             for i in part_vars:
                 refine_solution[i] = float(x_orig[i])
 
-        if disc_add_partition_method == "uniform":
+        refinement_context = {
+            "stage": "refinement",
+            "model": model,
+            "terms": terms,
+            "disc_state": disc_state,
+            "solution": dict(refine_solution),
+            "var_indices": list(part_vars),
+            "lb": list(part_lbs),
+            "ub": list(part_ubs),
+            "flat_lb": flat_lb.copy(),
+            "flat_ub": flat_ub.copy(),
+            "iteration": iteration,
+            "partition_mode": partition_mode,
+            "partition_scaling_factor": partition_scaling_factor,
+            "incumbent": None if incumbent is None else incumbent.copy(),
+            "milp_solution": x0.copy(),
+            "milp_result": milp_result,
+            "lower_bound": LB,
+            "upper_bound": UB,
+        }
+        partition_scaling_factor = _apply_partition_scaling_update(
+            partition_scaling_factor_update,
+            current_scaling_factor=partition_scaling_factor,
+            context=refinement_context,
+        )
+        disc_state.scaling_factor = partition_scaling_factor
+        refinement_context["partition_scaling_factor"] = partition_scaling_factor
+        refinement_context["disc_state"] = disc_state
+
+        if disc_add_partition_hook is not None:
+            disc_state = _apply_partition_refinement_hook(
+                disc_add_partition_hook,
+                refinement_context,
+            )
+        elif disc_add_partition_method == "uniform":
             disc_state = add_uniform_partition(
                 disc_state,
                 refine_solution,

--- a/python/discopt/solvers/amp.py
+++ b/python/discopt/solvers/amp.py
@@ -2002,7 +2002,12 @@ def solve_amp(
                     "part_vars": list(part_vars),
                 },
             )
-            if set(adaptive_vars) != set(part_vars):
+            if adaptive_vars or disc_var_pick_hook is not None:
+                should_update_adaptive_vars = set(adaptive_vars) != set(part_vars)
+            else:
+                should_update_adaptive_vars = False
+
+            if should_update_adaptive_vars:
                 logger.info(
                     "AMP: updating adaptive partition set from %d to %d variables",
                     len(part_vars),

--- a/python/tests/test_amp.py
+++ b/python/tests/test_amp.py
@@ -547,6 +547,60 @@ def test_amp_custom_partition_hooks_run_inside_amp(monkeypatch):
     assert result.gap_certified is False
 
 
+def test_amp_adaptive_keeps_monomial_fallback_partitions(monkeypatch):
+    """Built-in adaptive selection must not erase monomial-only partitions."""
+    import discopt._jax.discretization as disc_mod
+    from discopt._jax.milp_relaxation import MilpRelaxationResult
+    from discopt.solvers import amp as amp_mod
+
+    refined_var_sets = []
+
+    def fake_add_adaptive_partition(state, solution, var_indices, lb, ub):
+        del solution, lb, ub
+        refined_var_sets.append(list(var_indices))
+        return state
+
+    monkeypatch.setattr(
+        amp_mod,
+        "_solve_milp_with_oa_recovery",
+        lambda **kwargs: (
+            MilpRelaxationResult(
+                status="optimal",
+                objective=0.0,
+                x=np.array([0.0], dtype=np.float64),
+            ),
+            {},
+            [],
+            1,
+        ),
+    )
+    monkeypatch.setattr(
+        amp_mod,
+        "_solve_best_nlp_candidate",
+        lambda *args, **kwargs: (np.array([1.0], dtype=np.float64), 1.0),
+    )
+    monkeypatch.setattr(disc_mod, "add_adaptive_partition", fake_add_adaptive_partition)
+    monkeypatch.setattr(disc_mod, "check_partition_convergence", lambda state: True)
+
+    m = Model("monomial_only_adaptive")
+    x = m.continuous("x", lb=-2.0, ub=2.0)
+    m.minimize(x**2)
+
+    result = amp_mod.solve_amp(
+        m,
+        disc_var_pick="adaptive",
+        presolve_bt=False,
+        skip_convex_check=True,
+        rel_gap=1e-6,
+        max_iter=2,
+        time_limit=30,
+    )
+
+    assert refined_var_sets == [[0]]
+    assert result.status == "feasible"
+    assert result.gap_certified is False
+
+
 def test_partitioned_presolve_obbt_falls_back_without_incumbent(monkeypatch):
     """Alpine-style mode 2 should use LP OBBT when no feasible incumbent exists."""
     import discopt._jax.obbt as obbt_mod

--- a/python/tests/test_amp.py
+++ b/python/tests/test_amp.py
@@ -238,6 +238,7 @@ def test_amp_small_helpers_cover_aliases_gaps_and_pruning():
     assert amp_mod._normalize_partition_method("auto", "all") == "max_cover"
     assert amp_mod._normalize_partition_method("auto", "adaptive") == "adaptive_vertex_cover"
     assert amp_mod._normalize_partition_method("auto", 3) == "adaptive_vertex_cover"
+    assert amp_mod._normalize_partition_method("auto", lambda ctx: [0]) == "auto"
 
     with pytest.raises(ValueError, match="Unsupported disc_var_pick string"):
         amp_mod._normalize_partition_method("auto", "missing")
@@ -433,6 +434,10 @@ def test_solve_model_forwards_alpine_amp_aliases(monkeypatch):
     x = m.continuous("x", lb=0, ub=1)
     m.minimize(x)
 
+    def update_scaling(context):
+        del context
+        return 8.0
+
     solve_model(
         m,
         solver="amp",
@@ -440,6 +445,7 @@ def test_solve_model_forwards_alpine_amp_aliases(monkeypatch):
         apply_partitioning=False,
         disc_var_pick=1,
         partition_scaling_factor=7.0,
+        partition_scaling_factor_update=update_scaling,
         disc_add_partition_method="uniform",
         disc_abs_width_tol=1e-2,
         convhull_formulation="sos2",
@@ -452,12 +458,93 @@ def test_solve_model_forwards_alpine_amp_aliases(monkeypatch):
     assert captured["apply_partitioning"] is False
     assert captured["disc_var_pick"] == 1
     assert captured["partition_scaling_factor"] == pytest.approx(7.0)
+    assert captured["partition_scaling_factor_update"] is update_scaling
     assert captured["disc_add_partition_method"] == "uniform"
     assert captured["disc_abs_width_tol"] == pytest.approx(1e-2)
     assert captured["convhull_formulation"] == "sos2"
     assert captured["presolve_bt_algo"] == 2
     assert captured["presolve_bt_time_limit"] == pytest.approx(12.0)
     assert captured["presolve_bt_mip_time_limit"] == pytest.approx(0.5)
+
+
+def test_amp_custom_partition_hooks_run_inside_amp(monkeypatch):
+    """AMP should expose callable selection, scaling, and refinement hooks."""
+    import discopt._jax.discretization as disc_mod
+    from discopt._jax.discretization import add_adaptive_partition
+    from discopt._jax.milp_relaxation import MilpRelaxationResult
+    from discopt.solvers import amp as amp_mod
+
+    selection_stages = []
+    refinement_calls = []
+    scaling_calls = []
+
+    def custom_select(context):
+        selection_stages.append(context["stage"])
+        assert set(context["builtin_pick_partition_vars"]("max_cover")) == {0, 1}
+        if context["stage"] == "initial_selection":
+            return [0]
+        assert "distance" in context
+        return [1]
+
+    def custom_scaling(context):
+        scaling_calls.append((context["iteration"], context["current_scaling_factor"]))
+        return 12.0
+
+    def custom_refine(context):
+        refinement_calls.append(
+            (
+                context["stage"],
+                list(context["var_indices"]),
+                context["disc_state"].scaling_factor,
+            )
+        )
+        return add_adaptive_partition(
+            context["disc_state"],
+            context["solution"],
+            context["var_indices"],
+            context["lb"],
+            context["ub"],
+        )
+
+    monkeypatch.setattr(
+        amp_mod,
+        "_solve_milp_with_oa_recovery",
+        lambda **kwargs: (
+            MilpRelaxationResult(
+                status="optimal",
+                objective=0.0,
+                x=np.array([2.0, 4.0], dtype=np.float64),
+            ),
+            {},
+            [],
+            1,
+        ),
+    )
+    monkeypatch.setattr(
+        amp_mod,
+        "_solve_best_nlp_candidate",
+        lambda *args, **kwargs: (np.array([2.0, 4.0], dtype=np.float64), 1.0),
+    )
+    monkeypatch.setattr(disc_mod, "check_partition_convergence", lambda state: True)
+
+    result = amp_mod.solve_amp(
+        _make_nlp1(),
+        disc_var_pick=custom_select,
+        partition_scaling_factor=10.0,
+        partition_scaling_factor_update=custom_scaling,
+        disc_add_partition_method=custom_refine,
+        presolve_bt=False,
+        skip_convex_check=True,
+        rel_gap=1e-6,
+        max_iter=2,
+        time_limit=30,
+    )
+
+    assert selection_stages == ["initial_selection", "iteration_selection"]
+    assert scaling_calls == [(1, 10.0)]
+    assert refinement_calls == [("refinement", [1], 12.0)]
+    assert result.status == "feasible"
+    assert result.gap_certified is False
 
 
 def test_partitioned_presolve_obbt_falls_back_without_incumbent(monkeypatch):

--- a/python/tests/test_amp.py
+++ b/python/tests/test_amp.py
@@ -685,12 +685,17 @@ def test_partitioned_presolve_obbt_uses_feasible_initial_incumbent(monkeypatch):
 
     captured = {}
 
+    def update_scaling(context):
+        del context
+        return None
+
     def fake_partitioned_obbt(model, terms, flat_lb, flat_ub, incumbent, incumbent_obj, **kwargs):
-        del model, terms, kwargs
+        del model, terms
         captured["flat_lb"] = flat_lb.copy()
         captured["flat_ub"] = flat_ub.copy()
         captured["incumbent"] = incumbent.copy()
         captured["incumbent_obj"] = incumbent_obj
+        captured["partition_scaling_factor_update"] = kwargs["partition_scaling_factor_update"]
         return ObbtResult(
             tightened_lb=np.array([0.2], dtype=np.float64),
             tightened_ub=flat_ub.copy(),
@@ -720,13 +725,96 @@ def test_partitioned_presolve_obbt_uses_feasible_initial_incumbent(monkeypatch):
         milp_gap_tolerance=None,
         presolve_bt_time_limit=2.0,
         presolve_bt_mip_time_limit=0.5,
+        partition_scaling_factor_update=update_scaling,
     )
 
     np.testing.assert_allclose(captured["incumbent"], np.array([0.4]))
     assert captured["incumbent_obj"] == pytest.approx(0.4)
+    assert captured["partition_scaling_factor_update"] is update_scaling
     np.testing.assert_allclose(lb, np.array([0.2]))
     np.testing.assert_allclose(ub, np.array([1.0]))
     assert result.n_tightened == 1
+
+
+def test_partitioned_obbt_applies_scaling_update_before_custom_refinement(monkeypatch):
+    """Partitioned OBBT should honor the scaling hook before custom refinement."""
+    import discopt._jax.milp_relaxation as milp_mod
+    from discopt.solvers import amp as amp_mod
+
+    m = _make_obbt_demo()
+    terms = SimpleNamespace(
+        partition_candidates=[0, 1],
+        bilinear=[(0, 1)],
+        trilinear=[],
+        multilinear=[],
+        monomial=[],
+    )
+    scaling_calls = []
+    refinement_calls = []
+
+    def fake_build_milp_relaxation(*args, **kwargs):
+        del args, kwargs
+        return (
+            SimpleNamespace(
+                _A_ub=np.zeros((0, 2), dtype=np.float64),
+                _b_ub=np.zeros(0, dtype=np.float64),
+                _objective_bound_valid=False,
+                _c=np.zeros(2, dtype=np.float64),
+                _obj_offset=0.0,
+                _bounds=[(0.0, 1.0), (0.0, 1.0)],
+                _integrality=np.zeros(2, dtype=np.int32),
+            ),
+            {},
+        )
+
+    def update_scaling(context):
+        scaling_calls.append(
+            (
+                context["stage"],
+                context["current_scaling_factor"],
+                context["disc_state"].scaling_factor,
+            )
+        )
+        return 14.0
+
+    def refine_partitions(context):
+        refinement_calls.append(
+            (
+                context["stage"],
+                context["partition_scaling_factor"],
+                context["disc_state"].scaling_factor,
+                list(context["var_indices"]),
+            )
+        )
+        return context["disc_state"]
+
+    monkeypatch.setattr(milp_mod, "build_milp_relaxation", fake_build_milp_relaxation)
+
+    result = amp_mod._run_partitioned_obbt(
+        m,
+        terms,
+        np.array([0.0, 0.0], dtype=np.float64),
+        np.array([1.0, 1.0], dtype=np.float64),
+        np.array([0.5, 0.5], dtype=np.float64),
+        0.25,
+        partition_mode="auto",
+        n_init_partitions=2,
+        partition_scaling_factor=10.0,
+        partition_scaling_factor_update=update_scaling,
+        disc_abs_width_tol=1e-3,
+        convhull_formulation="disaggregated",
+        convhull_ebd=False,
+        convhull_ebd_encoding="gray",
+        total_time_limit=0.0,
+        time_limit_per_mip=0.1,
+        gap_tolerance=1e-4,
+        disc_add_partition_hook=refine_partitions,
+    )
+
+    assert scaling_calls == [("presolve_obbt_refinement", 10.0, 10.0)]
+    assert refinement_calls == [("presolve_obbt_refinement", 14.0, 14.0, [0, 1])]
+    assert result.n_lp_solves == 0
+    assert result.n_tightened == 0
 
 
 def test_partitioned_presolve_obbt_runs_on_bilinear_demo():


### PR DESCRIPTION
## Summary

- Adds callable AMP hooks for partition-variable selection via `disc_var_pick`.
- Adds callable partition-refinement hooks via `disc_add_partition_method`.
- Adds `partition_scaling_factor_update` so adaptive refinement scaling can be updated without patching solver internals.
- Keeps existing string/int Alpine aliases and default built-in behavior unchanged.
- Documents how to reproduce benchmark runs with custom AMP partition heuristics.

## Tests run

- `pixi exec -s python=3.12 -s ipopt -s pkg-config -s c-compiler -s cxx-compiler -s gfortran -- uv venv --allow-existing .venv` - passed
- `pixi exec -s python=3.12 -s ipopt -s pkg-config -s c-compiler -s cxx-compiler -s gfortran -- uv pip install --python .venv/bin/python maturin pytest pytest-timeout pytest-cov numpy scipy jax jaxlib highspy cyipopt ruff mypy` - passed
- `pixi exec -s python=3.12 -s ipopt -s pkg-config -s c-compiler -s cxx-compiler -s gfortran -- uv pip install --python .venv/bin/python -e .[dev,ipopt,highs]` - passed
- `pixi exec -s python=3.12 -s ipopt -s pkg-config -s c-compiler -s cxx-compiler -s gfortran -- .venv/bin/python -m pytest python/tests/test_amp.py -q -k "custom_partition_hooks or solve_model_forwards_alpine_amp_aliases or small_helpers"` - passed, 3 passed
- `pixi exec -s python=3.12 -s ipopt -s pkg-config -s c-compiler -s cxx-compiler -s gfortran -- make test-amp-fast PYTHON=.venv/bin/python PYTEST=".venv/bin/python -m pytest"` - passed, 38 passed
- `.venv/bin/python -m ruff check python/` - passed
- `.venv/bin/python -m ruff format --check python/` - passed
- `.venv/bin/python -m mypy python/discopt/` - passed
- `pixi exec -s python=3.12 -s ipopt -s pkg-config -s c-compiler -s cxx-compiler -s gfortran -- make test PYTHON=.venv/bin/python PYTEST=".venv/bin/python -m pytest"` - passed, 2412 passed, 72 skipped, 494 deselected, 2 xfailed
- `pixi exec -s python=3.12 -s ipopt -s pkg-config -s c-compiler -s cxx-compiler -s gfortran -- .venv/bin/python -m pytest python/tests/test_amp.py -q -k "custom_partition_hooks"` - passed, 1 passed
- `.venv/bin/python -m ruff check python/discopt/solvers/amp.py python/discopt/solver.py python/tests/test_amp.py` - passed
- `.venv/bin/python -m ruff format --check python/discopt/solvers/amp.py python/discopt/solver.py python/tests/test_amp.py` - passed
- `cargo test -p discopt-core` - passed, 157 unit tests and 1 doctest
- `/home/bernalde/.pixi/bin/pixi exec -s python=3.12 -s ipopt -s pkg-config -s c-compiler -s cxx-compiler -s gfortran -- make test-amp-integration PYTHON=.venv/bin/python PYTEST='.venv/bin/python -m pytest'` - passed, 160 passed, 2 xfailed

## Notes

- Not run: `cargo clippy -p discopt-core -- -D warnings`; this PR does not change Rust code, and `cargo test -p discopt-core` passed.

Closes #18
