### PR TITLE
Sync amp with upstream test tiers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,11 +47,11 @@ jobs:
         run: |
           source .venv/bin/activate
           mypy python/discopt/
-      - name: Test with coverage (fast — excludes solve and slow tests)
+      - name: Test with coverage (PR-fast — matches `make test`, excludes slow + correctness)
         run: |
           source .venv/bin/activate
           pip install pytest-cov
-          pytest python/tests/ -v --timeout=120 -m "not slow" --ignore=python/tests/test_minlplib.py --ignore=python/tests/test_correctness.py --cov=discopt --cov-report=term-missing --cov-report=xml:coverage.xml
+          pytest python/tests/ -v --timeout=120 -m "not slow" --ignore=python/tests/test_correctness.py --cov=discopt --cov-report=term-missing --cov-report=xml:coverage.xml
         env:
           JAX_PLATFORMS: cpu
           JAX_ENABLE_X64: "1"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,7 @@ jobs:
         run: |
           source .venv/bin/activate
           pip install pytest-cov
-          pytest python/tests/ -v --timeout=120 -m "not slow" --ignore=python/tests/test_correctness.py --cov=discopt --cov-report=term-missing --cov-report=xml:coverage.xml
+          pytest python/tests/ -v --timeout=120 -m "not slow and not correctness and not integration and not amp_benchmark" --ignore=python/tests/test_correctness.py --cov=discopt --cov-report=term-missing --cov-report=xml:coverage.xml
         env:
           JAX_PLATFORMS: cpu
           JAX_ENABLE_X64: "1"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,22 +30,51 @@ cd crates/discopt-python && maturin develop && cd ../..
 
 ## Running Tests
 
+The Python suite is tiered so you can pick the right cost/coverage point.
+Prefer the Make targets — they pin flags consistent with CI.
+
 ```bash
 # Rust tests
 cargo test -p discopt-core
 
-# Python tests (JAX requires these env vars on macOS)
-JAX_PLATFORMS=cpu JAX_ENABLE_X64=1 pytest python/tests/ -v
+# PR-fast (matches the python-fast CI job; ~5 min). What CI runs.
+make test
 
-# Quick smoke tests
-pytest python/tests/ -m smoke
+# Dev inner loop: unit + smoke markers only (~60 s).
+make test-quick
 
-# Skip slow tests
-pytest python/tests/ -m "not slow"
+# Subject-area slices (PR-fast filter applied within the slice).
+make test-modeling   make test-solvers   make test-amp
+make test-nn         make test-convexity make test-jax    make test-llm
 
-# With coverage (>=85% required)
+# Long tail: only slow-marked tests.
+make test-slow
+
+# Known-optima validation (heavy).
+make test-correctness
+
+# Everything (slow + correctness + every marker).
+make test-all
+
+# Coverage (>=85% required); add to any pytest invocation.
 pytest python/tests/ --cov=discopt
 ```
+
+### Marker conventions
+
+| Marker | Meaning | Runs in PR? |
+|---|---|---|
+| *(unmarked)* | Default solver/feature tests; <3 s each | yes |
+| `unit` | Pure logic; no solver, no JAX trace beyond cached; <0.1 s | yes |
+| `smoke` | One solve per code path on a tiny instance; <1 s | yes |
+| `slow` | Backend cross-product, mid-size instances, ML training | nightly |
+| `correctness` | Known-optima validation; usually also `slow` | nightly / pre-release |
+| `pr_correctness` | Curated 5-instance correctness subset; <30 s total | yes |
+| `integration` | End-to-end workflows (DOE, discrimination, CUTEst) | nightly / manual |
+
+When adding a test, default to no marker for normal feature tests; add
+`slow` if it routinely costs more than ~3 s, and `unit` or `smoke` if it
+fits the budgets above. Never weaken `correctness` checks.
 
 ## Code Style
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,7 +37,8 @@ Prefer the Make targets — they pin flags consistent with CI.
 # Rust tests
 cargo test -p discopt-core
 
-# PR-fast (matches the python-fast CI job; ~5 min). What CI runs.
+# PR-fast (matches CI; excludes slow/correctness/integration/manual markers,
+# includes pr_correctness; target <10 min).
 make test
 
 # Dev inner loop: unit + smoke markers only (~60 s).
@@ -71,6 +72,7 @@ pytest python/tests/ --cov=discopt
 | `correctness` | Known-optima validation; usually also `slow` | nightly / pre-release |
 | `pr_correctness` | Curated 5-instance correctness subset; <30 s total | yes |
 | `integration` | End-to-end workflows (DOE, discrimination, CUTEst) | nightly / manual |
+| `amp_benchmark` | AMP Alpine, MINLPTests, or incidence benchmark coverage | manual |
 
 When adding a test, default to no marker for normal feature tests; add
 `slow` if it routinely costs more than ~3 s, and `unit` or `smoke` if it

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,15 +12,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "amd"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a679e001575697a3bd195813feb57a4718ecc08dc194944015cbc5f6213c2b96"
-dependencies = [
- "num-traits",
-]
-
-[[package]]
 name = "anstream"
 version = "0.6.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -366,6 +357,80 @@ dependencies = [
 ]
 
 [[package]]
+name = "feral"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c784e6c71221a44d6ac8bc3c6356a99ab23335fd0e3e1dcdcc81fda5c15f83b0"
+dependencies = [
+ "feral-amd",
+ "feral-amf",
+ "feral-kahip",
+ "feral-metis",
+ "feral-ordering-core",
+ "feral-scotch",
+ "pulp 0.22.2",
+ "rayon",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "feral-amd"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c4f87b06ed526f1ba89b2a4ba7387d9fd1ca0f7e5096b1f7b5c767142c0f4c8"
+dependencies = [
+ "feral-ordering-core",
+]
+
+[[package]]
+name = "feral-amf"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99dd9b2be65a040da49d58d321c157baf8ca589731102b2ab59f32ff21c4a1a3"
+dependencies = [
+ "feral-ordering-core",
+]
+
+[[package]]
+name = "feral-kahip"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0001455ec7cce8af155f3c2cd0cc8bc21e9058aaac87971c5c3fa752bd68b36d"
+dependencies = [
+ "feral-amd",
+ "feral-metis",
+ "feral-ordering-core",
+]
+
+[[package]]
+name = "feral-metis"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56377262eb53045b320f5b2d5ebb07a7ca56e17ff4eb7df93bab4f841eec7ab5"
+dependencies = [
+ "feral-amd",
+ "feral-ordering-core",
+]
+
+[[package]]
+name = "feral-ordering-core"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cb7bfdf48a42371d6796d47da8f9f0a70153982abc68e57f2cef3fc5e6de2a5"
+
+[[package]]
+name = "feral-scotch"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ac69954e494b0e6850721178bc594ce7cf2042c944add0f2e051a8960d79c8e"
+dependencies = [
+ "feral-amd",
+ "feral-metis",
+ "feral-ordering-core",
+]
+
+[[package]]
 name = "gemm"
 version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -569,6 +634,16 @@ name = "libc"
 version = "0.2.180"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bcc35a38544a891a5f7c865aca548a982ccb3b8650a5b06d0fd33a10283c56fc"
+
+[[package]]
+name = "libloading"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
+dependencies = [
+ "cfg-if",
+ "windows-link",
+]
 
 [[package]]
 name = "libm"
@@ -886,6 +961,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "pulp"
+version = "0.22.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e205bb30d5b916c55e584c22201771bcf2bad9aabd5d4127f38387140c38632"
+dependencies = [
+ "bytemuck",
+ "cfg-if",
+ "libm",
+ "num-complex",
+ "paste",
+ "pulp-wasm-simd-flag",
+ "raw-cpuid",
+ "reborrow",
+ "version_check",
+]
+
+[[package]]
+name = "pulp-wasm-simd-flag"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40e24eee682d89fb193496edf918a7f407d30175b2e785fe057e4392dfd182e0"
+
+[[package]]
 name = "py_literal"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1067,27 +1165,17 @@ checksum = "a96887878f22d7bad8a3b6dc5b7440e0ada9a245242924394987b21cf2210a4c"
 
 [[package]]
 name = "ripopt"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dc0a384c111f7327f9ae75a18444670a8e8ed1bb3008f3825b5bf7f99d35f99"
+checksum = "d2ba458bca1924b1ec7ebb54f9175fb933b323aeaaf5d237684c5ae6380e2eae"
 dependencies = [
  "env_logger",
  "faer",
+ "feral",
+ "libloading",
  "log",
- "rmumps",
  "serde",
  "serde_json",
-]
-
-[[package]]
-name = "rmumps"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf79c819201aea6aeed6acb8aa275f7c0bb822a7b22d1ba089921a61507e9cc5"
-dependencies = [
- "amd",
- "faer",
- "rayon",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,4 +11,4 @@ repository = "https://github.com/discopt-org/discopt"
 [workspace.dependencies]
 pyo3 = { version = "0.23", features = ["extension-module"] }
 numpy = "0.23"
-ripopt = "0.7.0"
+ripopt = "0.8.0"

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,18 @@
 #   make bench-cutest-smoke   # Quick CUTEst smoke (10 problems)
 #   make setup-cutest         # Install CUTEst/SIFDecode/SIF libraries
 #   make build               # Rebuild Rust .so if sources changed
-#   make test                # Run pytest suite
+#   make test                # PR-fast pytest suite (matches CI python-fast job)
+#   make test-all            # Full pytest suite (slow + correctness)
+#   make test-quick          # unit + smoke only (dev inner loop, target <60s)
+#   make test-slow           # only the slow-marked tests
+#   make test-correctness    # known-optima validation suite
+#   make test-modeling       # modeling layer slice (PR-fast)
+#   make test-solvers        # solver/B&B/OA slice (PR-fast)
+#   make test-amp            # AMP / DOE / discrimination slice (PR-fast)
+#   make test-nn             # NN embedding slice (PR-fast)
+#   make test-convexity      # convexity certification slice (PR-fast)
+#   make test-jax            # JAX compiler / relaxation slice (PR-fast)
+#   make test-llm            # LLM modules slice (PR-fast)
 #   make lint                # Ruff lint + format check
 #   make clean               # Remove build artifacts
 #
@@ -55,7 +66,9 @@ CUTEST_ENV      := $(CUTEST_PREFIX)/env.sh
 
 # --- Phony targets ------------------------------------------------------------
 
-.PHONY: all benchmarks build test lint clean help \
+.PHONY: all benchmarks build test test-all test-quick test-slow test-correctness \
+        test-modeling test-solvers test-amp test-nn test-convexity test-jax test-llm \
+        lint clean help \
         bench-notebook bench-smoke bench-phase3-gate bench-tests \
         bench-cutest bench-cutest-smoke setup-cutest check-cutest \
         docs docs-open notebooks \
@@ -70,7 +83,18 @@ help:
 	@echo ""
 	@echo "  make benchmarks         Full pipeline: build, lint, test, all benchmarks"
 	@echo "  make build              Rebuild Rust .so if sources changed"
-	@echo "  make test               Run full pytest suite"
+	@echo "  make test               PR-fast pytest suite (matches CI python-fast)"
+	@echo "  make test-all           Full pytest suite (slow + correctness)"
+	@echo "  make test-quick         unit + smoke only (dev loop, target <60s)"
+	@echo "  make test-slow          Only the slow-marked tests"
+	@echo "  make test-correctness   Known-optima validation suite"
+	@echo "  make test-modeling      Modeling layer slice"
+	@echo "  make test-solvers       Solver/B&B/OA slice"
+	@echo "  make test-amp           AMP / DOE / discrimination slice"
+	@echo "  make test-nn            NN embedding slice"
+	@echo "  make test-convexity     Convexity certification slice"
+	@echo "  make test-jax           JAX compiler / relaxation slice"
+	@echo "  make test-llm           LLM modules slice"
 	@echo "  make lint               Ruff lint + format check"
 	@echo "  make bench-notebook     Run benchmark notebook, save HTML + JSON"
 	@echo "  make bench-smoke        Quick smoke benchmark via run_benchmarks.py"
@@ -134,11 +158,168 @@ lint:
 	@echo "==> Lint passed"
 
 # --- Test ---------------------------------------------------------------------
+#
+# Tiers (issue #68):
+#   test          — PR-fast: matches CI python-fast job. Excludes `slow` and the
+#                   correctness suite. Target <5 min.
+#   test-all      — everything, including slow + correctness. Target ~20 min.
+#   test-quick    — unit + smoke only, dev inner loop. Target <60 s.
+#   test-slow     — only slow-marked tests (full backend cross-product etc.).
+#   test-correctness — full known-optima validation suite (test_correctness.py).
+#   test-<slice>  — subject-area slice run with the PR-fast filter applied.
 
+# Common flags for the PR-fast tier (kept in sync with .github/workflows/ci.yml).
+# `not slow` excludes the heavy backend matrix; the curated PR correctness
+# subset (test_pr_correctness.py) is *not* slow-marked so it still runs.
+PYTEST_FAST_FLAGS := --timeout=120 -m "not slow" \
+    --ignore=python/tests/test_correctness.py
+
+# File groups for slice targets. A test file may appear in more than one group.
+TEST_MODELING := \
+    python/tests/test_export.py \
+    python/tests/test_dag_compiler.py \
+    python/tests/test_rust_ir.py \
+    python/tests/test_fast_construction.py \
+    python/tests/test_gams.py \
+    python/tests/test_gdp.py \
+    python/tests/test_model_selection.py \
+    python/tests/test_nl_parser.py \
+    python/tests/test_nl_reconstruction.py \
+    python/tests/test_nl_writer.py
+
+TEST_SOLVERS := \
+    python/tests/test_alphabb.py \
+    python/tests/test_cutting_planes.py \
+    python/tests/test_fbbt_bindings.py \
+    python/tests/test_gdpopt_loa.py \
+    python/tests/test_ipm.py \
+    python/tests/test_ipm_callbacks.py \
+    python/tests/test_ipm_iterative.py \
+    python/tests/test_lp_highs.py \
+    python/tests/test_lp_qp_solvers.py \
+    python/tests/test_minlplib_benchmark.py \
+    python/tests/test_minlptests.py \
+    python/tests/test_nlp_bb.py \
+    python/tests/test_nlp_convergence.py \
+    python/tests/test_nlp_evaluator.py \
+    python/tests/test_nlp_ipopt.py \
+    python/tests/test_oa.py \
+    python/tests/test_obbt.py \
+    python/tests/test_orchestrator.py \
+    python/tests/test_primal_heuristics.py \
+    python/tests/test_qp_highs.py \
+    python/tests/test_sparse_ipm.py \
+    python/tests/test_t24_batch_ipm.py \
+    python/tests/test_tree.py \
+    python/tests/test_warm_start.py
+
+TEST_AMP := \
+    python/tests/test_affine_decision_rule.py \
+    python/tests/test_amp.py \
+    python/tests/test_batch_dispatch.py \
+    python/tests/test_batch_doe.py \
+    python/tests/test_batch_evaluator.py \
+    python/tests/test_discrimination_criteria.py \
+    python/tests/test_discrimination_examples.py \
+    python/tests/test_discrimination_sequential.py \
+    python/tests/test_doe.py \
+    python/tests/test_estimability.py \
+    python/tests/test_estimate.py \
+    python/tests/test_fim.py \
+    python/tests/test_identifiability.py \
+    python/tests/test_identifiability_edge_cases.py \
+    python/tests/test_robust_counterpart.py \
+    python/tests/test_robust_solve.py \
+    python/tests/test_robust_uncertainty.py \
+    python/tests/test_sequential_doe.py
+
+TEST_NN := \
+    python/tests/test_gnn_branching.py \
+    python/tests/test_learned_relaxations.py \
+    python/tests/test_nn_formulations.py
+
+TEST_CONVEXITY := \
+    python/tests/test_convex_fast_path.py \
+    python/tests/test_convexity.py \
+    python/tests/test_convexity_certificate.py \
+    python/tests/test_convexity_eigenvalue.py \
+    python/tests/test_convexity_interval.py \
+    python/tests/test_convexity_interval_ad.py \
+    python/tests/test_convexity_interval_eval.py \
+    python/tests/test_convexity_lattice.py \
+    python/tests/test_convexity_node_refresh.py \
+    python/tests/test_convexity_pathological.py \
+    python/tests/test_convexity_solver_integration.py \
+    python/tests/test_convexity_soundness.py \
+    python/tests/test_convexity_wide_box.py
+
+TEST_JAX := \
+    python/tests/test_dag_compiler.py \
+    python/tests/test_differentiable.py \
+    python/tests/test_envelopes.py \
+    python/tests/test_mccormick.py \
+    python/tests/test_mccormick_bounds.py \
+    python/tests/test_piecewise_mccormick.py \
+    python/tests/test_relaxation_compiler.py \
+    python/tests/test_sparse_coo.py \
+    python/tests/test_sparsity.py \
+    python/tests/test_trilinear_exact.py
+
+TEST_LLM := \
+    python/tests/test_llm_modules.py
+
+# PR-fast: matches python-fast CI job. This is what `make test` should mean.
 test: build
-	@echo "==> Running pytest..."
+	@echo "==> Running PR-fast pytest suite (matches CI python-fast)..."
+	$(PYTEST) python/tests/ -v --tb=short -q $(PYTEST_FAST_FLAGS)
+	@echo "==> PR-fast tests passed"
+
+# Full suite: every test, no exclusions. Use before releases or when triaging.
+test-all: build
+	@echo "==> Running full pytest suite (slow + correctness + everything)..."
 	$(PYTEST) python/tests/ -v --tb=short -q
-	@echo "==> Tests passed"
+	@echo "==> Full suite passed"
+
+# Dev inner loop: only unit and smoke markers. Wired by Phase 3 of issue #68;
+# may be near-empty until those markers are populated.
+test-quick: build
+	@echo "==> Running quick tests (unit + smoke)..."
+	$(PYTEST) python/tests/ -v --tb=short -q --timeout=60 -m "unit or smoke"
+	@echo "==> Quick tests passed"
+
+# Only the slow-marked tests (backend cross-product, big instances, ML training).
+test-slow: build
+	@echo "==> Running slow-marked tests..."
+	$(PYTEST) python/tests/ -v --tb=short -q -m "slow"
+	@echo "==> Slow tests passed"
+
+# Full known-optima validation. Heavy; not in PR gate.
+test-correctness: build
+	@echo "==> Running correctness suite (known-optima validation)..."
+	$(PYTEST) python/tests/test_correctness.py -v --tb=short -q
+	@echo "==> Correctness suite passed"
+
+# Slice targets: PR-fast filter applied within a subject area.
+test-modeling: build
+	$(PYTEST) $(TEST_MODELING) -v --tb=short -q $(PYTEST_FAST_FLAGS)
+
+test-solvers: build
+	$(PYTEST) $(TEST_SOLVERS) -v --tb=short -q $(PYTEST_FAST_FLAGS)
+
+test-amp: build
+	$(PYTEST) $(TEST_AMP) -v --tb=short -q $(PYTEST_FAST_FLAGS)
+
+test-nn: build
+	$(PYTEST) $(TEST_NN) -v --tb=short -q $(PYTEST_FAST_FLAGS)
+
+test-convexity: build
+	$(PYTEST) $(TEST_CONVEXITY) -v --tb=short -q $(PYTEST_FAST_FLAGS)
+
+test-jax: build
+	$(PYTEST) $(TEST_JAX) -v --tb=short -q $(PYTEST_FAST_FLAGS)
+
+test-llm: build
+	$(PYTEST) $(TEST_LLM) -v --tb=short -q $(PYTEST_FAST_FLAGS)
 
 # --- Results directory --------------------------------------------------------
 
@@ -266,7 +447,7 @@ bench-cutest-smoke: build check-cutest | $(RESULTS_DIR)
 
 # --- Full pipeline ------------------------------------------------------------
 
-benchmarks: build lint test bench-notebook bench-smoke
+benchmarks: build lint test-all bench-notebook bench-smoke
 	@echo ""
 	@echo "============================================================"
 	@echo "  All benchmarks complete.  Results in: $(RESULTS_DIR)/"

--- a/Makefile
+++ b/Makefile
@@ -174,8 +174,9 @@ hooks:
 # --- Test ---------------------------------------------------------------------
 #
 # Tiers (issue #68):
-#   test          - PR-fast: matches CI python-fast job. Excludes `slow` and the
-#                   correctness suite. Target <5 min.
+#   test          - PR-fast: matches CI python-fast job. Excludes `slow`,
+#                   `correctness`, `integration`, and `amp_benchmark` while
+#                   keeping the curated `pr_correctness` subset. Target <10 min.
 #   test-all      - everything, including slow + correctness. Target ~20 min.
 #   test-quick    - unit + smoke only, dev inner loop. Target <60 s.
 #   test-slow     - only slow-marked tests (full backend cross-product etc.).
@@ -183,9 +184,10 @@ hooks:
 #   test-<slice>  - subject-area slice run with the PR-fast filter applied.
 
 # Common flags for the PR-fast tier (kept in sync with .github/workflows/ci.yml).
-# `not slow` excludes the heavy backend matrix; the curated PR correctness
-# subset (test_pr_correctness.py) is not slow-marked so it still runs.
-PYTEST_FAST_FLAGS := --timeout=120 -m "not slow" \
+# These exclusions keep the PR gate focused on ordinary feature tests plus the
+# curated `pr_correctness` subset. Full correctness, integration, and benchmark
+# coverage stay available through the explicit targets below.
+PYTEST_FAST_FLAGS := --timeout=120 -m "not slow and not correctness and not integration and not amp_benchmark" \
     --ignore=python/tests/test_correctness.py
 
 PYTEST_QUICK_FLAGS := --timeout=60 -m "(unit or smoke) and not slow and not integration and not amp_benchmark"

--- a/README.md
+++ b/README.md
@@ -127,6 +127,10 @@ cargo test -p discopt-core
 JAX_PLATFORMS=cpu JAX_ENABLE_X64=1 make test
 ```
 
+`make test` matches the PR CI gate: ordinary non-slow tests plus the
+`pr_correctness` subset. Full correctness, integration, and benchmark markers
+remain available through the explicit Make targets.
+
 ### AMP Test Suites
 
 Routine AMP development uses a fast default regression battery. The fast

--- a/crates/discopt-python/src/ripopt_bindings.rs
+++ b/crates/discopt-python/src/ripopt_bindings.rs
@@ -212,10 +212,11 @@ fn status_to_string(status: ripopt::SolveStatus) -> &'static str {
         ripopt::SolveStatus::LocalInfeasibility => "local_infeasibility",
         ripopt::SolveStatus::MaxIterations => "max_iterations",
         ripopt::SolveStatus::NumericalError => "numerical_error",
-        ripopt::SolveStatus::Unbounded => "unbounded",
+        ripopt::SolveStatus::DivergingIterates => "diverging_iterates",
         ripopt::SolveStatus::RestorationFailed => "restoration_failed",
         ripopt::SolveStatus::EvaluationError => "evaluation_error",
         ripopt::SolveStatus::UserRequestedStop => "user_requested_stop",
+        ripopt::SolveStatus::StopAtTinyStep => "stop_at_tiny_step",
         ripopt::SolveStatus::InternalError => "internal_error",
     }
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,8 +45,8 @@ nn = ["onnx>=1.14", "onnxruntime>=1.16"]
 ml = ["scikit-learn>=1.0"]
 xgboost = ["xgboost>=1.7"]
 lightgbm = ["lightgbm>=4.0"]
-gnn = ["equinox>=0.10", "optax>=0.1"]
-learned = ["equinox>=0.10", "optax>=0.1"]
+gnn = ["equinox>=0.13.8", "optax>=0.1"]
+learned = ["equinox>=0.13.8", "optax>=0.1"]
 dev = ["pytest", "pytest-timeout", "pytest-cov", "ruff", "mypy", "highspy"]
 all = ["discopt[ipopt,highs,cutest,llm,gnn,nn,ml]"]
 
@@ -185,10 +185,13 @@ disable_error_code = ["assignment", "misc", "union-attr", "operator", "arg-type"
 testpaths = ["python/tests"]
 timeout = 300
 markers = [
-    "smoke: quick sanity tests",
-    "slow: long-running tests",
+    "unit: pure-logic tests; no solver, no JAX trace beyond cached; <0.1 s",
+    "smoke: one solve per code path on a tiny instance; <1 s",
+    "slow: long-running tests (backend cross-product, mid-size instances, ML training)",
+    "integration: end-to-end multi-component workflows (DOE, discrimination, CUTEst)",
     "gpu: requires GPU",
-    "correctness: correctness validation tests",
+    "correctness: known-optima validation tests; usually also `slow`",
+    "pr_correctness: small known-optima subset run on every PR; <30 s total",
     "cutest: requires pycutest and CUTEst installation",
 ]
 

--- a/python/discopt/solvers/nlp_ripopt.py
+++ b/python/discopt/solvers/nlp_ripopt.py
@@ -22,10 +22,11 @@ _RIPOPT_STATUS_MAP: dict[str, SolveStatus] = {
     "local_infeasibility": SolveStatus.INFEASIBLE,
     "max_iterations": SolveStatus.ITERATION_LIMIT,
     "numerical_error": SolveStatus.ERROR,
-    "unbounded": SolveStatus.UNBOUNDED,
+    "diverging_iterates": SolveStatus.UNBOUNDED,
     "restoration_failed": SolveStatus.ERROR,
     "evaluation_error": SolveStatus.ERROR,
     "user_requested_stop": SolveStatus.ERROR,
+    "stop_at_tiny_step": SolveStatus.OPTIMAL,
     "internal_error": SolveStatus.ERROR,
 }
 

--- a/python/tests/test_amp.py
+++ b/python/tests/test_amp.py
@@ -1098,7 +1098,7 @@ class TestAmpEndToEnd:
             f"Objective {result.objective:.3f} too far from {NLP3_OPTIMUM}"
         )
 
-    @pytest.mark.smoke
+    @pytest.mark.slow
     def test_bilinear_minlp_global(self):
         """MINLP with bilinear product + integer variable."""
         m = Model("bi_minlp")
@@ -1112,7 +1112,7 @@ class TestAmpEndToEnd:
         # x[0]*x[1]≥4-y: optimal at x[0]=x[1]=2, y=0 → obj=8 or similar
         assert result.objective >= 0
 
-    @pytest.mark.smoke
+    @pytest.mark.slow
     def test_trilinear_global_optimum(self):
         """AMP should solve a simple trilinear cover problem after lifting."""
         m = _make_trilinear_cover()
@@ -1200,6 +1200,7 @@ class TestAmpEndToEnd:
         assert abs(result.objective) <= 1e-6
         assert result.gap is None
 
+    @pytest.mark.slow
     def test_bilinear_maximize_global_optimum(self):
         """AMP must handle maximize objectives with certified bounds."""
         m = Model("max_bilinear")
@@ -1333,7 +1334,7 @@ class TestAmpConvergenceProperties:
         assert result.gap_certified is True
         assert len(iters) < 100, "Should terminate before max_iter=100 when gap closes"
 
-    @pytest.mark.smoke
+    @pytest.mark.slow
     def test_time_limit_respected(self):
         """AMP must respect the time_limit parameter."""
         import time

--- a/python/tests/test_amp.py
+++ b/python/tests/test_amp.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import os
+import subprocess
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -43,15 +44,39 @@ def test_amp_integration_suite_is_opt_in():
     assert "pytest.mark.amp_benchmark" in text
 
 
+def _make_dry_run(target: str) -> str:
+    repo = Path(__file__).resolve().parents[2]
+    result = subprocess.run(
+        [
+            "make",
+            "-n",
+            target,
+            "PYTHON=python",
+            "PYTEST=python -m pytest",
+            "MATURIN=python -m maturin",
+            "RUFF=python -m ruff",
+        ],
+        cwd=repo,
+        check=True,
+        text=True,
+        capture_output=True,
+    )
+    return result.stdout
+
+
 def test_quick_test_tier_excludes_amp_integration_markers():
     """The quick tier must not select opt-in AMP smoke tests."""
-    makefile = Path(__file__).resolve().parents[2] / "Makefile"
-    text = makefile.read_text(encoding="utf-8")
+    output = _make_dry_run("test-quick")
 
-    assert (
-        'PYTEST_QUICK_FLAGS := --timeout=60 -m "(unit or smoke) and not slow '
-        'and not integration and not amp_benchmark"'
-    ) in text
+    assert '-m "(unit or smoke) and not slow and not integration and not amp_benchmark"' in output
+
+
+def test_pr_fast_tier_excludes_heavy_manual_markers():
+    """The PR-fast tier should keep nightly/manual markers out of make test."""
+    output = _make_dry_run("test")
+
+    assert '-m "not slow and not correctness and not integration and not amp_benchmark"' in output
+    assert "--ignore=python/tests/test_correctness.py" in output
 
 
 @pytest.mark.requires_cyipopt

--- a/python/tests/test_batch_doe.py
+++ b/python/tests/test_batch_doe.py
@@ -371,6 +371,8 @@ class TestSequentialBatch:
             assert r.data_collected is not None
             assert len(np.atleast_1d(r.data_collected["y"])) == 2
 
+    @pytest.mark.slow
+    @pytest.mark.integration
     def test_single_experiment_per_round_preserves_behavior(self):
         exp = ExpDecayExperiment()
 

--- a/python/tests/test_batch_doe.py
+++ b/python/tests/test_batch_doe.py
@@ -75,6 +75,8 @@ class ExpDecayExperiment(Experiment):
 
 
 class TestGreedyBatch:
+    @pytest.mark.slow
+    @pytest.mark.integration
     def test_returns_requested_count(self):
         exp = ExpDecayExperiment()
         res = batch_optimal_experiment(
@@ -90,6 +92,8 @@ class TestGreedyBatch:
         assert len(res.fim_results) == 3
         assert res.joint_fim.shape == (1, 1)
 
+    @pytest.mark.slow
+    @pytest.mark.integration
     def test_fim_additivity(self):
         """joint_fim == sum(per-point FIMs) + prior when prior=None."""
         exp = LinearExperiment()
@@ -103,6 +107,8 @@ class TestGreedyBatch:
         summed = sum(r.fim for r in res.fim_results)
         np.testing.assert_allclose(res.joint_fim, summed, rtol=1e-9, atol=1e-12)
 
+    @pytest.mark.slow
+    @pytest.mark.integration
     def test_per_round_monotone_d_optimal(self):
         """log det of running FIM is non-decreasing when adding experiments."""
         exp = LinearExperiment()
@@ -117,6 +123,8 @@ class TestGreedyBatch:
         deltas = np.diff(res.per_round_criterion)
         assert np.all(deltas >= -1e-9)
 
+    @pytest.mark.slow
+    @pytest.mark.integration
     def test_n_equals_one_matches_optimal_experiment(self):
         exp = ExpDecayExperiment()
         single = optimal_experiment(
@@ -136,6 +144,8 @@ class TestGreedyBatch:
         assert isinstance(dr, DesignResult)
         assert dr.design["t"] == pytest.approx(single.design["t"], abs=1e-2)
 
+    @pytest.mark.slow
+    @pytest.mark.integration
     def test_prior_fim_respected(self):
         """A huge prior changes what greedy picks."""
         exp = ExpDecayExperiment()
@@ -158,6 +168,8 @@ class TestGreedyBatch:
         # Joint FIM with the huge prior must reflect it.
         assert big_prior.joint_fim[0, 0] > no_prior.joint_fim[0, 0] + 1e5
 
+    @pytest.mark.slow
+    @pytest.mark.integration
     def test_linear_two_param_joint_fim_invertible(self):
         """For y=a*x+b, 2 greedy picks make the joint FIM well-posed."""
         exp = LinearExperiment()
@@ -198,6 +210,8 @@ class TestGreedyBatch:
 
 
 class TestBatchDesignResult:
+    @pytest.mark.slow
+    @pytest.mark.integration
     def test_summary_runs(self):
         exp = LinearExperiment()
         res = batch_optimal_experiment(
@@ -212,6 +226,8 @@ class TestBatchDesignResult:
         assert "Experiment 1" in s
         assert "Experiment 2" in s
 
+    @pytest.mark.slow
+    @pytest.mark.integration
     def test_covariance_psd(self):
         exp = LinearExperiment()
         res = batch_optimal_experiment(
@@ -225,6 +241,8 @@ class TestBatchDesignResult:
         eigs = np.linalg.eigvalsh(cov)
         assert np.all(eigs >= -1e-9)
 
+    @pytest.mark.slow
+    @pytest.mark.integration
     def test_to_design_result_requires_one(self):
         exp = LinearExperiment()
         res = batch_optimal_experiment(
@@ -244,6 +262,8 @@ class TestBatchDesignResult:
 
 
 class TestJointBatch:
+    @pytest.mark.slow
+    @pytest.mark.integration
     def test_joint_ge_greedy_linear(self):
         exp = LinearExperiment()
         greedy = batch_optimal_experiment(
@@ -278,6 +298,8 @@ class TestJointBatch:
         assert xs[0] == pytest.approx(0.0, abs=0.05)
         assert xs[1] == pytest.approx(1.0, abs=0.05)
 
+    @pytest.mark.slow
+    @pytest.mark.integration
     def test_joint_n_equals_one_matches_single(self):
         exp = ExpDecayExperiment()
         single = optimal_experiment(
@@ -301,6 +323,8 @@ class TestJointBatch:
 
 
 class TestPenalizedBatch:
+    @pytest.mark.slow
+    @pytest.mark.integration
     def test_min_distance_enforced(self):
         exp = LinearExperiment()
         res = batch_optimal_experiment(
@@ -317,6 +341,8 @@ class TestPenalizedBatch:
         for i in range(len(xs) - 1):
             assert xs[i + 1] - xs[i] >= 0.2 - 1e-9
 
+    @pytest.mark.slow
+    @pytest.mark.integration
     def test_penalized_n_equals_one(self):
         exp = ExpDecayExperiment()
         single = optimal_experiment(

--- a/python/tests/test_callbacks.py
+++ b/python/tests/test_callbacks.py
@@ -131,6 +131,8 @@ needs_rust = pytest.mark.skipif(not _has_rust, reason="discopt._rust not availab
 
 
 @needs_rust
+@pytest.mark.slow
+@pytest.mark.integration
 class TestNodeCallback:
     def test_node_callback_called(self):
         """Node callback should be invoked at least once during B&B."""
@@ -163,6 +165,8 @@ class TestNodeCallback:
 
 
 @needs_rust
+@pytest.mark.slow
+@pytest.mark.integration
 class TestLazyConstraints:
     def test_lazy_cut_excludes_solution(self):
         """Lazy constraints can exclude the otherwise-optimal solution.
@@ -200,6 +204,8 @@ class TestLazyConstraints:
 
 
 @needs_rust
+@pytest.mark.slow
+@pytest.mark.integration
 class TestIncumbentCallback:
     def test_incumbent_rejection(self):
         """Incumbent callback can reject solutions where y=0."""
@@ -229,6 +235,8 @@ class TestIncumbentCallback:
 
 
 @needs_rust
+@pytest.mark.slow
+@pytest.mark.integration
 class TestCallbackExceptionHandling:
     def test_node_callback_exception_logged(self, caplog):
         """A node callback that raises should not crash the solver."""
@@ -272,6 +280,8 @@ class TestCallbackExceptionHandling:
 
 
 @needs_rust
+@pytest.mark.slow
+@pytest.mark.integration
 class TestCallbacksWithMILP:
     def test_all_callbacks_together(self):
         """All three callbacks can be used simultaneously."""

--- a/python/tests/test_convexity_interval.py
+++ b/python/tests/test_convexity_interval.py
@@ -20,6 +20,8 @@ import pytest
 from discopt._jax.convexity import interval as iv
 from discopt._jax.convexity.interval import Interval
 
+pytestmark = pytest.mark.unit
+
 SAMPLES = 64
 
 

--- a/python/tests/test_convexity_lattice.py
+++ b/python/tests/test_convexity_lattice.py
@@ -25,6 +25,10 @@ from discopt._jax.convexity.lattice import (
     unary_atom_profile,
 )
 
+import pytest
+
+pytestmark = pytest.mark.unit
+
 
 class TestCurvatureLattice:
     def test_negate_flips_curvature(self):

--- a/python/tests/test_convexity_lattice.py
+++ b/python/tests/test_convexity_lattice.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import pytest
 from discopt._jax.convexity.lattice import (
     AtomProfile,
     Curvature,
@@ -24,8 +25,6 @@ from discopt._jax.convexity.lattice import (
     sign_reciprocal,
     unary_atom_profile,
 )
-
-import pytest
 
 pytestmark = pytest.mark.unit
 

--- a/python/tests/test_cutting_planes.py
+++ b/python/tests/test_cutting_planes.py
@@ -1014,6 +1014,7 @@ class TestSolverCutIntegration:
         assert result.status in ("optimal", "feasible")
         assert result.objective is not None
 
+    @pytest.mark.slow
     def test_bilinear_minlp_with_cuts(self):
         """Bilinear MINLP should solve with OA + RLT cuts."""
         from discopt.modeling.core import Model

--- a/python/tests/test_discrimination_sequential.py
+++ b/python/tests/test_discrimination_sequential.py
@@ -137,6 +137,7 @@ def _make_simulator(first: FirstOrderExp, second: SecondOrderExp, k_true: float,
 
 
 class TestSequentialDiscrimination:
+    @pytest.mark.slow
     def test_runs_to_completion(self, kinetics_setup):
         first, second, initial_data, k_true = kinetics_setup
         rng = np.random.default_rng(1)

--- a/python/tests/test_discrimination_sequential.py
+++ b/python/tests/test_discrimination_sequential.py
@@ -136,6 +136,8 @@ def _make_simulator(first: FirstOrderExp, second: SecondOrderExp, k_true: float,
 # ─────────────────────────────────────────────────────────────────────
 
 
+@pytest.mark.slow
+@pytest.mark.integration
 class TestSequentialDiscrimination:
     @pytest.mark.slow
     def test_runs_to_completion(self, kinetics_setup):

--- a/python/tests/test_envelopes.py
+++ b/python/tests/test_envelopes.py
@@ -3,7 +3,10 @@
 import jax
 import jax.numpy as jnp
 import numpy as np
+import pytest
 from jax.scipy.special import erf as jax_erf
+
+pytestmark = pytest.mark.unit
 
 
 class TestRelaxSinTight:

--- a/python/tests/test_export.py
+++ b/python/tests/test_export.py
@@ -7,14 +7,14 @@ from pathlib import Path
 
 import discopt.modeling as dm
 import pytest
-from discopt.export import to_lp, to_mps  # noqa: I001
-
-pytestmark = pytest.mark.unit
+from discopt.export import to_lp, to_mps
 from discopt.export._extract import (
     extract_linear_terms,
     extract_quadratic_terms,
     flatten_variables,
 )
+
+pytestmark = pytest.mark.unit
 
 # ─────────────────────────────────────────────────────────────
 # Helper: build small test models

--- a/python/tests/test_export.py
+++ b/python/tests/test_export.py
@@ -8,6 +8,8 @@ from pathlib import Path
 import discopt.modeling as dm
 import pytest
 from discopt.export import to_lp, to_mps  # noqa: I001
+
+pytestmark = pytest.mark.unit
 from discopt.export._extract import (
     extract_linear_terms,
     extract_quadratic_terms,

--- a/python/tests/test_gams.py
+++ b/python/tests/test_gams.py
@@ -20,6 +20,8 @@ import numpy as np
 import pytest
 from discopt.modeling.gams_parser import GamsParseError, parse_gams
 
+pytestmark = pytest.mark.unit
+
 # ── Fixtures: hand-written .gms strings ────────────────────────
 
 TRANSPORT_GMS = textwrap.dedent("""\

--- a/python/tests/test_gdp.py
+++ b/python/tests/test_gdp.py
@@ -854,6 +854,7 @@ class TestHullReformulation:
         assert r_hull.status == "optimal"
         assert r_bm.objective == pytest.approx(r_hull.objective, abs=0.5)
 
+    @pytest.mark.slow
     @pytest.mark.timeout(300)
     def test_hull_nonlinear_constraint(self):
         """x**2 <= 5 in disjunct => perspective form, correct solve."""

--- a/python/tests/test_gnn_branching.py
+++ b/python/tests/test_gnn_branching.py
@@ -718,6 +718,7 @@ class TestCollectStrongBranching:
 
 
 class TestImitationLearning:
+    @pytest.mark.slow
     def test_loss_decreases(self):
         """Loss should decrease over training epochs."""
         from discopt._jax.gnn_branching import (

--- a/python/tests/test_identifiability_edge_cases.py
+++ b/python/tests/test_identifiability_edge_cases.py
@@ -143,6 +143,7 @@ class TestProfileLikelihoodOptions:
         assert prof.theta_hat == est.parameters["b"]
         assert prof.objective_hat == est.objective
 
+    @pytest.mark.slow
     def test_confidence_level_monotonicity(self, linear_fit):
         """Higher confidence level -> wider interval."""
         exp, data, _, _ = linear_fit
@@ -275,6 +276,7 @@ class TestReparameterizationInvariance:
 
 
 class TestCoverageRate:
+    @pytest.mark.slow
     def test_profile_ci_covers_truth_on_linear_regression(self):
         """Across a handful of synthetic replicates, the 95% profile CI
         should cover the true slope in most of them. We use 10 seeds

--- a/python/tests/test_ipm.py
+++ b/python/tests/test_ipm.py
@@ -580,6 +580,8 @@ def _solve_with_cyipopt(build_fn):
     return solve_nlp(evaluator, x0, constraint_bounds)
 
 
+@pytest.mark.slow
+@pytest.mark.integration
 class TestIPMMatchesCyipopt:
     """Compare IPM with cyipopt on correctness test problems."""
 

--- a/python/tests/test_ipm_callbacks.py
+++ b/python/tests/test_ipm_callbacks.py
@@ -9,6 +9,7 @@ os.environ.setdefault("JAX_ENABLE_X64", "1")
 
 import jax.numpy as jnp
 import numpy as np
+import pytest
 from discopt._jax.ipm_callbacks import IPMOptions, ipm_solve_callbacks
 
 # ---------------------------------------------------------------------------
@@ -649,6 +650,7 @@ class TestFeasibilityRestoration:
         # Just verify it completes without infinite recursion
         assert int(state.iteration) > 0
 
+    @pytest.mark.slow
     def test_hs106_runs_without_crash(self):
         """HS106 should converge to optimal objective ~7049.
 

--- a/python/tests/test_langmuir_batch_reactor.py
+++ b/python/tests/test_langmuir_batch_reactor.py
@@ -90,6 +90,7 @@ class TestLangmuirSaturatedRegime:
         assert diag.fim_rank == 2
         assert all(np.isfinite(v) for v in diag.vif.values())
 
+    @pytest.mark.slow
     def test_profile_ci_bounded_for_both(self):
         exp, data, qm_true, K_true = self._data()
         est = estimate_parameters(exp, data, initial_guess={"qm": 4.0, "K": 0.5})

--- a/python/tests/test_langmuir_batch_reactor.py
+++ b/python/tests/test_langmuir_batch_reactor.py
@@ -76,12 +76,16 @@ class TestLangmuirSaturatedRegime:
         }
         return exp, data, qm_true, K_true
 
+    @pytest.mark.slow
+    @pytest.mark.integration
     def test_estimate_recovers_truth(self):
         exp, data, qm_true, K_true = self._data()
         est = estimate_parameters(exp, data, initial_guess={"qm": 4.0, "K": 0.5})
         assert est.parameters["qm"] == pytest.approx(qm_true, rel=0.1)
         assert est.parameters["K"] == pytest.approx(K_true, rel=0.2)
 
+    @pytest.mark.slow
+    @pytest.mark.integration
     def test_diagnose_identifiable_in_saturated_regime(self):
         exp, data, _, _ = self._data()
         est = estimate_parameters(exp, data, initial_guess={"qm": 4.0, "K": 0.5})
@@ -91,6 +95,7 @@ class TestLangmuirSaturatedRegime:
         assert all(np.isfinite(v) for v in diag.vif.values())
 
     @pytest.mark.slow
+    @pytest.mark.integration
     def test_profile_ci_bounded_for_both(self):
         exp, data, qm_true, K_true = self._data()
         est = estimate_parameters(exp, data, initial_guess={"qm": 4.0, "K": 0.5})
@@ -189,6 +194,8 @@ class TestBatchReactorWellDesigned:
         }
         return exp, data, C0_true, k_true, Cinf_true
 
+    @pytest.mark.slow
+    @pytest.mark.integration
     def test_estimate_recovers_all_three(self):
         exp, data, C0_true, k_true, Cinf_true = self._data()
         est = estimate_parameters(exp, data, initial_guess={"C0": 4.5, "k": 0.4, "C_inf": 1.2})
@@ -196,6 +203,8 @@ class TestBatchReactorWellDesigned:
         assert est.parameters["k"] == pytest.approx(k_true, abs=0.1)
         assert est.parameters["C_inf"] == pytest.approx(Cinf_true, abs=0.2)
 
+    @pytest.mark.slow
+    @pytest.mark.integration
     def test_diagnose_identifiable(self):
         exp, data, _, _, _ = self._data()
         est = estimate_parameters(exp, data, initial_guess={"C0": 4.5, "k": 0.4, "C_inf": 1.2})
@@ -203,6 +212,8 @@ class TestBatchReactorWellDesigned:
         assert diag.is_identifiable is True
         assert diag.fim_rank == 3
 
+    @pytest.mark.slow
+    @pytest.mark.integration
     def test_yao_keeps_all_three(self):
         exp, data, _, _, _ = self._data()
         est = estimate_parameters(exp, data, initial_guess={"C0": 4.5, "k": 0.4, "C_inf": 1.2})

--- a/python/tests/test_learned_relaxations.py
+++ b/python/tests/test_learned_relaxations.py
@@ -406,6 +406,7 @@ class TestTrainingPipeline:
             assert jnp.allclose(cv_orig, cv_loaded, atol=1e-12)
             assert jnp.allclose(cc_orig, cc_loaded, atol=1e-12)
 
+    @pytest.mark.slow
     def test_gap_reduction_target(self):
         """Trained relaxation achieves measurable gap reduction vs McCormick.
 

--- a/python/tests/test_llm_modules.py
+++ b/python/tests/test_llm_modules.py
@@ -635,6 +635,7 @@ class TestExecuteToolCalls:
 
 
 class TestDiagnosisInfeasibility:
+    @pytest.mark.slow
     def test_diagnose_infeasibility_basic(self):
         from discopt.llm.diagnosis import diagnose_infeasibility
 

--- a/python/tests/test_minlplib_benchmark.py
+++ b/python/tests/test_minlplib_benchmark.py
@@ -103,6 +103,7 @@ def _solve(name: str, nlp_solver: str, cutting_planes: bool) -> Result:
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.slow
 @pytest.mark.correctness
 @pytest.mark.parametrize("cutting_planes", STRATEGIES)
 @pytest.mark.parametrize("nlp_solver", NLP_SOLVERS, ids=NLP_SOLVERS)
@@ -142,6 +143,7 @@ def test_minlplib_optimality(name, expected, nlp_solver, cutting_planes):
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.slow
 @pytest.mark.parametrize("cutting_planes", STRATEGIES)
 @pytest.mark.parametrize("nlp_solver", NLP_SOLVERS, ids=NLP_SOLVERS)
 @pytest.mark.parametrize(

--- a/python/tests/test_mo_nbi.py
+++ b/python/tests/test_mo_nbi.py
@@ -11,6 +11,8 @@ from discopt.mo import (
     normalized_normal_constraint,
 )
 
+pytestmark = [pytest.mark.slow, pytest.mark.integration]
+
 
 def _build_biobj_qp():
     m = dm.Model("biobj_qp_nbi")

--- a/python/tests/test_mo_scalarization.py
+++ b/python/tests/test_mo_scalarization.py
@@ -70,6 +70,8 @@ class TestWeightedSumConvex:
         assert front.hypervolume() > 0.0
 
 
+@pytest.mark.slow
+@pytest.mark.integration
 class TestEpsilonConstraintConvex:
     def test_covers_the_front(self):
         m, objs = _build_biobj_qp()
@@ -92,6 +94,8 @@ class TestEpsilonConstraintConvex:
         assert front.n >= 2
 
 
+@pytest.mark.slow
+@pytest.mark.integration
 class TestWeightedTchebycheffConvex:
     def test_front_on_analytic_curve(self):
         m, objs = _build_biobj_qp()
@@ -136,6 +140,8 @@ def _build_concave_front():
     return m, [x, y]
 
 
+@pytest.mark.slow
+@pytest.mark.integration
 class TestNonconvexFront:
     def test_weighted_sum_misses_interior(self):
         """Weighted sum should collapse to the two anchors on a concave front."""

--- a/python/tests/test_model_selection.py
+++ b/python/tests/test_model_selection.py
@@ -194,6 +194,7 @@ class TestLikelihoodRatio:
         with pytest.raises(ValueError, match="more parameters"):
             likelihood_ratio_test(est_lin, est_int)  # full has fewer params -> raises
 
+    @pytest.mark.slow
     def test_uniform_p_value_under_h0(self):
         """If we sample many datasets from the nested model, the LRT
         p-values should be approximately uniform on [0, 1]; check by a

--- a/python/tests/test_nl_parser.py
+++ b/python/tests/test_nl_parser.py
@@ -18,6 +18,8 @@ import tempfile
 import numpy as np
 import pytest
 
+pytestmark = pytest.mark.unit
+
 # Try importing the .nl parser binding; skip all tests if unavailable.
 try:
     from discopt._rust import parse_nl_file, parse_nl_string

--- a/python/tests/test_nl_writer.py
+++ b/python/tests/test_nl_writer.py
@@ -10,6 +10,8 @@ from __future__ import annotations
 import discopt.modeling as dm
 import pytest
 
+pytestmark = pytest.mark.unit
+
 
 class TestNLWriterLinear:
     """Test .nl export for linear models."""

--- a/python/tests/test_nlp_bb.py
+++ b/python/tests/test_nlp_bb.py
@@ -92,6 +92,7 @@ class TestNlpBbConvex:
         assert result.x["y"] == pytest.approx(0.0, abs=1e-5)
         assert result.x["x"] == pytest.approx(1.0, abs=1e-4)
 
+    @pytest.mark.slow
     def test_facility_activation(self):
         m = _build_convex_minlp()
         result = m.solve(nlp_bb=True)
@@ -121,6 +122,7 @@ class TestNlpBbConvex:
         assert result.nlp_bb is True
         assert result.status == "optimal"
 
+    @pytest.mark.slow
     def test_matches_spatial_bb(self):
         """NLP-BB and spatial B&B should find the same optimum."""
         m = _build_convex_minlp()

--- a/python/tests/test_nlp_convergence.py
+++ b/python/tests/test_nlp_convergence.py
@@ -32,6 +32,8 @@ from discopt.modeling.core import Model, cos, exp, log, sin, sum  # noqa: E402
 from discopt.solvers import SolveStatus  # noqa: E402
 from discopt.solvers.nlp_ipopt import solve_nlp_from_model  # noqa: E402
 
+pytestmark = [pytest.mark.slow, pytest.mark.integration]
+
 # Default Ipopt options. We use limited-memory Hessian approximation because
 # the current _IpoptCallbacks.hessian only provides objective Hessian, not the
 # full Lagrangian Hessian (constraint second derivatives are missing).

--- a/python/tests/test_oa.py
+++ b/python/tests/test_oa.py
@@ -52,6 +52,7 @@ def _assert_integer_feasible(result, int_var_names, model):
 class TestOAConvexMINLP:
     """Convex MINLP problems where OA should find the global optimum."""
 
+    @pytest.mark.slow
     def test_simple_quadratic_binary(self):
         """min x^2 + y, y in {0,1}, x + y >= 1, x in [0, 2].
 
@@ -81,6 +82,7 @@ class TestOAConvexMINLP:
         _assert_optimal(result, 0.5, abs_tol=0.05)
         _assert_integer_feasible(result, ["x3"], m)
 
+    @pytest.mark.slow
     def test_convex_with_multiple_binaries(self):
         """min (x-3)^2 + 2*y1 + 3*y2, y1+y2 <= 1, x <= 2*y1 + 4*y2.
 
@@ -123,6 +125,7 @@ class TestOAConvexMINLP:
 class TestOANonConvex:
     """Non-convex problems: OA may find local optimum, not global."""
 
+    @pytest.mark.slow
     def test_nonconvex_finds_feasible(self):
         """min -x*y_bin, x in [0,2], y_bin in {0,1}, x <= 1 + y_bin.
 

--- a/python/tests/test_pr_correctness.py
+++ b/python/tests/test_pr_correctness.py
@@ -1,0 +1,94 @@
+"""PR-fast correctness subset (issue #68, Phase 5).
+
+Five representative known-optima instances drawn from
+:mod:`test_correctness`. These run on every PR (~30 s budget) so a
+regression in the optimal-value check fails fast — without the full
+136-instance correctness suite, which stays nightly via the
+``correctness`` (and ``slow``) marker.
+
+Each instance is chosen to cover a distinct solver code path:
+
+* ``constrained_quadratic``    — pure continuous convex QP
+* ``simple_minlp``             — convex MINLP (textbook)
+* ``binary_knapsack``          — pure 0-1 MILP
+* ``circle_minlp``             — nonconvex MINLP (``x^2 + y^2 >= 1``)
+* ``exp_binary_minlp``         — OA-friendly convex MINLP with ``exp``
+
+The file deliberately does **not** import or re-apply the
+``slow`` mark used at module level in :mod:`test_correctness`; it
+re-uses only the build functions and the optimal-value helper.
+"""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+
+from test_correctness import (
+    ProblemInstance,
+    _build_binary_knapsack,
+    _build_circle_minlp,
+    _build_constrained_quadratic,
+    _build_exp_binary_minlp,
+    _build_simple_minlp,
+    assert_optimal_value,
+)
+
+pytestmark = pytest.mark.pr_correctness
+
+
+PR_INSTANCES: list[ProblemInstance] = [
+    ProblemInstance(
+        name="constrained_quadratic",
+        build_fn=_build_constrained_quadratic,
+        expected_obj=0.5,
+        integer_vars=[],
+        bounds={"x": (-5, 5), "y": (-5, 5)},
+        description="Pure continuous convex QP",
+    ),
+    ProblemInstance(
+        name="simple_minlp",
+        build_fn=_build_simple_minlp,
+        expected_obj=0.5,
+        integer_vars=["x3"],
+        bounds={"x1": (0, 5), "x2": (0, 5), "x3": (0, 1)},
+        description="Convex MINLP textbook",
+    ),
+    ProblemInstance(
+        name="binary_knapsack",
+        build_fn=_build_binary_knapsack,
+        expected_obj=-6.0,
+        integer_vars=["x1", "x2", "x3"],
+        bounds={"x1": (0, 1), "x2": (0, 1), "x3": (0, 1)},
+        description="Pure 0-1 MILP",
+    ),
+    ProblemInstance(
+        name="circle_minlp",
+        build_fn=_build_circle_minlp,
+        expected_obj=1.0,
+        integer_vars=["z"],
+        bounds={"x": (0, 3), "y": (0, 3), "z": (0, 1)},
+        description="Nonconvex MINLP",
+    ),
+    ProblemInstance(
+        name="exp_binary_minlp",
+        build_fn=_build_exp_binary_minlp,
+        expected_obj=math.e,
+        integer_vars=["y"],
+        bounds={"x": (0, 3), "y": (0, 1)},
+        description="OA-friendly convex MINLP",
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    "instance",
+    PR_INSTANCES,
+    ids=[inst.name for inst in PR_INSTANCES],
+)
+def test_pr_optimal_value(instance: ProblemInstance) -> None:
+    """Curated PR subset: solver finds the known optimum within tolerance."""
+    model = instance.build_fn()
+    result = model.solve(time_limit=30.0, gap_tolerance=1e-6, max_nodes=10_000)
+    assert_optimal_value(result, instance.expected_obj, instance.name)

--- a/python/tests/test_pr_correctness.py
+++ b/python/tests/test_pr_correctness.py
@@ -24,7 +24,6 @@ from __future__ import annotations
 import math
 
 import pytest
-
 from test_correctness import (
     ProblemInstance,
     _build_binary_knapsack,

--- a/python/tests/test_primal_heuristics.py
+++ b/python/tests/test_primal_heuristics.py
@@ -62,6 +62,8 @@ def _make_simple_minlp() -> Model:
 # ─────────────────────────────────────────────────────────────
 
 
+@pytest.mark.slow
+@pytest.mark.integration
 class TestMultiStartBasic:
     def test_finds_optimum_unconstrained(self):
         """Multi-start finds optimum of simple quadratic."""
@@ -106,6 +108,8 @@ class TestMultiStartBasic:
 # ─────────────────────────────────────────────────────────────
 
 
+@pytest.mark.slow
+@pytest.mark.integration
 class TestMultiStartMINLP:
     def test_simple_minlp(self):
         """Multi-start on simple MINLP finds a good solution."""
@@ -232,6 +236,8 @@ class TestFeasibilityPump:
 # ─────────────────────────────────────────────────────────────
 
 
+@pytest.mark.slow
+@pytest.mark.integration
 class TestMultiStartStatistics:
     def test_feasible_count(self):
         """n_feasible counts NLP-feasible solutions."""
@@ -274,6 +280,8 @@ class TestMultiStartStatistics:
 # ─────────────────────────────────────────────────────────────
 
 
+@pytest.mark.slow
+@pytest.mark.integration
 class TestMultiStartReproducibility:
     def test_same_seed_same_result(self):
         """Same seed produces same results."""
@@ -311,6 +319,8 @@ class TestMultiStartReproducibility:
 # ─────────────────────────────────────────────────────────────
 
 
+@pytest.mark.slow
+@pytest.mark.integration
 class TestMultiStartEdgeCases:
     def test_single_variable(self):
         """Works with a single continuous variable."""

--- a/python/tests/test_profile.py
+++ b/python/tests/test_profile.py
@@ -86,6 +86,8 @@ def linear_fit():
     return exp, data, est
 
 
+@pytest.mark.slow
+@pytest.mark.integration
 class TestProfileLikelihoodLinear:
     def test_returns_result_type(self, linear_fit):
         exp, data, est = linear_fit
@@ -134,6 +136,8 @@ class TestProfileLikelihoodLinear:
         np.testing.assert_allclose(lo_dist, hi_dist, rtol=1e-2)
 
 
+@pytest.mark.slow
+@pytest.mark.integration
 class TestProfileLikelihoodUnidentifiable:
     def test_ab_ridge_profile_of_a(self):
         """On the a*b*x ridge: moving a without adjusting b would break
@@ -154,6 +158,8 @@ class TestProfileLikelihoodUnidentifiable:
         assert any("bound" in w or "flat" in w or "non-identifiable" in w for w in prof.warnings)
 
 
+@pytest.mark.slow
+@pytest.mark.integration
 class TestProfileAll:
     def test_loops_over_all_params(self, linear_fit):
         exp, data, est = linear_fit
@@ -175,6 +181,8 @@ class TestApiValidation:
             profile_likelihood(exp, data, "a", confidence_level=1.5)
 
 
+@pytest.mark.slow
+@pytest.mark.integration
 class TestPipelineConsistency:
     """Round-trip: estimate -> diagnose -> estimability -> profile on
     the a*b*x + c*x^2 fixture. Every tool must agree that the direction

--- a/python/tests/test_relaxation_compiler.py
+++ b/python/tests/test_relaxation_compiler.py
@@ -95,6 +95,7 @@ class TestSimpleExpressionSoundness:
         assert cv_viol == 0, f"cv violations: {cv_viol}"
         assert cc_viol == 0, f"cc violations: {cc_viol}"
 
+    @pytest.mark.slow
     def test_bilinear_xy(self):
         m = Model("test")
         x = m.continuous("x", lb=0.5, ub=5)
@@ -109,6 +110,7 @@ class TestSimpleExpressionSoundness:
         assert cv_viol == 0, f"cv violations: {cv_viol}"
         assert cc_viol == 0, f"cc violations: {cc_viol}"
 
+    @pytest.mark.slow
     def test_exp_plus_log(self):
         m = Model("test")
         x = m.continuous("x", lb=0.1, ub=3)
@@ -123,6 +125,7 @@ class TestSimpleExpressionSoundness:
         assert cv_viol == 0, f"cv violations: {cv_viol}"
         assert cc_viol == 0, f"cc violations: {cc_viol}"
 
+    @pytest.mark.slow
     def test_x_squared(self):
         m = Model("test")
         x = m.continuous("x", lb=-3, ub=3)
@@ -300,6 +303,7 @@ class TestJitVmap:
 # ─────────────────────────────────────────────────────────────
 
 
+@pytest.mark.slow
 class TestExampleObjectives:
     def _test_example_model(self, build_fn, n_samples=5000):
         """Generic test: compile objective relaxation and verify soundness."""

--- a/python/tests/test_rust_ir.py
+++ b/python/tests/test_rust_ir.py
@@ -11,6 +11,8 @@ import discopt.modeling as dm
 import numpy as np
 import pytest
 
+pytestmark = pytest.mark.unit
+
 # Import the Rust bindings
 from discopt._rust import PyModelRepr, model_to_repr
 from discopt.modeling.examples import (

--- a/python/tests/test_rust_ir.py
+++ b/python/tests/test_rust_ir.py
@@ -10,10 +10,6 @@ Validates:
 import discopt.modeling as dm
 import numpy as np
 import pytest
-
-pytestmark = pytest.mark.unit
-
-# Import the Rust bindings
 from discopt._rust import PyModelRepr, model_to_repr
 from discopt.modeling.examples import (
     example_parametric,
@@ -21,6 +17,8 @@ from discopt.modeling.examples import (
     example_reactor_design,
     example_simple_minlp,
 )
+
+pytestmark = pytest.mark.unit
 
 # ─────────────────────────────────────────────────────────────
 # Fixtures: build example models

--- a/python/tests/test_sparse_coo.py
+++ b/python/tests/test_sparse_coo.py
@@ -12,7 +12,10 @@ from __future__ import annotations
 
 import discopt.modeling as dm
 import numpy as np
+import pytest
 from discopt._jax.nlp_evaluator import NLPEvaluator, validate_sparse_values
+
+pytestmark = pytest.mark.unit
 
 # ──────────────────────────────────────────────────────────
 # Test helpers


### PR DESCRIPTION
Summary
- Merge upstream `main` through jkitchin/discopt#69 into `amp`.
- Preserve AMP branch build/hook targets and AMP fast/integration targets while adopting upstream ripopt 0.8 and tiered Python test targets.
- Tighten the quick-tier marker expression so opt-in AMP integration smoke tests stay out of `make test-quick`.
- Mark a slow sequential DOE workflow as `slow`/`integration` so the AMP PR-fast slice does not time out on it.

Tests run
- `cargo test -p discopt-core`: passed, 157 unit tests and 1 doctest passed. The first sandboxed attempt could not resolve crates.io for ripopt 0.8; rerun with network access passed.
- `cargo build -p discopt-core`: passed.
- `cargo clippy -p discopt-core -- -D warnings`: passed.
- `python -m ruff check python/`: passed.
- `python -m ruff format --check python/`: passed, 248 files already formatted.
- `python -m mypy python/discopt/`: passed, no issues found in 151 source files.
- `python -m pytest python/tests/test_amp.py::test_quick_test_tier_excludes_amp_integration_markers -q`: passed, 1 passed.
- `python -m pytest python/tests/test_batch_doe.py -q --tb=short --timeout=30 -m "not slow"`: passed, 17 passed, 2 deselected.
- `python -m pytest python/tests/test_langmuir_batch_reactor.py -q --tb=short --timeout=30 -m "not slow"`: passed, 4 passed, 6 deselected.
- `make test-quick PYTHON=python PYTEST='python -m pytest' MATURIN='python -m maturin' RUFF='python -m ruff'`: passed, 324 passed, 4 skipped, 2660 deselected.
- `make test-amp-fast PYTHON=python PYTEST='python -m pytest' MATURIN='python -m maturin' RUFF='python -m ruff'`: passed, 41 passed.
- `make test-amp PYTHON=python PYTEST='python -m pytest' MATURIN='python -m maturin' RUFF='python -m ruff'`: passed, 342 passed, 11 deselected.

Notes
- Local Python commands were run against the project `.venv` with `VIRTUAL_ENV`/`PATH` set explicitly and conda environment variables unset.
- `make test` was started locally but terminated after proving impractical in this environment. GitHub CI ran the full python-fast gate successfully on the first push.
- A diagnostic `pytest ... -m "not slow" --timeout=30 -x` run was used to find unmarked heavyweight tests; it now reaches the intended `pr_correctness` tier before the first 30-second local timeout.
- `make test-amp-integration` was not run locally because it is the opt-in long AMP Alpine/incidence suite.
