### PR TITLE
Port AMP term classification to Rust

### DIFF
--- a/crates/discopt-core/src/amp.rs
+++ b/crates/discopt-core/src/amp.rs
@@ -1,0 +1,401 @@
+//! AMP helpers backed by the Rust expression representation.
+//!
+//! These routines keep the high-level AMP algorithm in Python while moving
+//! repeated expression-tree walks into Rust.
+
+use std::collections::{BTreeMap, BTreeSet};
+
+use crate::expr::{BinOp, ExprId, ExprNode, IndexElem, IndexSpec, ModelRepr, UnOp};
+
+/// Classified nonlinear terms used by AMP partition selection and relaxation.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct AmpNonlinearTerms {
+    /// Distinct bilinear terms as sorted pairs of flat variable indices.
+    pub bilinear: Vec<(usize, usize)>,
+    /// Distinct trilinear terms as sorted triples of flat variable indices.
+    pub trilinear: Vec<(usize, usize, usize)>,
+    /// Distinct higher-order multilinear terms as sorted flat variable indices.
+    pub multilinear: Vec<Vec<usize>>,
+    /// Distinct monomial terms as `(flat_variable_index, exponent)`.
+    pub monomial: Vec<(usize, usize)>,
+    /// Number of general nonlinear expression nodes encountered.
+    pub general_nl_count: usize,
+    /// Variable-to-product-term incidence map.
+    pub term_incidence: BTreeMap<usize, BTreeSet<usize>>,
+    /// Sorted variables that appear in bilinear or multilinear product terms.
+    pub partition_candidates: Vec<usize>,
+}
+
+/// Classify nonlinear terms in a model using the Rust expression arena.
+pub fn classify_nonlinear_terms(model: &ModelRepr) -> AmpNonlinearTerms {
+    let mut classifier = TermClassifier::new(model);
+    classifier.classify_node(model.objective);
+    for constraint in &model.constraints {
+        classifier.classify_node(constraint.body);
+    }
+    classifier.finish()
+}
+
+struct TermClassifier<'a> {
+    model: &'a ModelRepr,
+    result: AmpNonlinearTerms,
+    seen_bilinear: BTreeSet<(usize, usize)>,
+    seen_trilinear: BTreeSet<(usize, usize, usize)>,
+    seen_multilinear: BTreeSet<Vec<usize>>,
+    seen_monomial: BTreeSet<(usize, usize)>,
+}
+
+impl<'a> TermClassifier<'a> {
+    fn new(model: &'a ModelRepr) -> Self {
+        Self {
+            model,
+            result: AmpNonlinearTerms::default(),
+            seen_bilinear: BTreeSet::new(),
+            seen_trilinear: BTreeSet::new(),
+            seen_multilinear: BTreeSet::new(),
+            seen_monomial: BTreeSet::new(),
+        }
+    }
+
+    fn finish(mut self) -> AmpNonlinearTerms {
+        let mut candidates = BTreeSet::new();
+        for (i, j) in &self.result.bilinear {
+            candidates.insert(*i);
+            candidates.insert(*j);
+        }
+        for (i, j, k) in &self.result.trilinear {
+            candidates.insert(*i);
+            candidates.insert(*j);
+            candidates.insert(*k);
+        }
+        for term in &self.result.multilinear {
+            candidates.extend(term.iter().copied());
+        }
+        self.result.partition_candidates = candidates.into_iter().collect();
+        self.result
+    }
+
+    fn next_product_term_idx(&self) -> usize {
+        self.result.bilinear.len() + self.result.trilinear.len() + self.result.multilinear.len()
+    }
+
+    fn record_bilinear(&mut self, i: usize, j: usize) {
+        let key = if i <= j { (i, j) } else { (j, i) };
+        if self.seen_bilinear.insert(key) {
+            let term_idx = self.next_product_term_idx();
+            self.result.bilinear.push(key);
+            for var in [key.0, key.1] {
+                self.result
+                    .term_incidence
+                    .entry(var)
+                    .or_default()
+                    .insert(term_idx);
+            }
+        }
+    }
+
+    fn record_trilinear(&mut self, i: usize, j: usize, k: usize) {
+        let mut values = [i, j, k];
+        values.sort_unstable();
+        let key = (values[0], values[1], values[2]);
+        if self.seen_trilinear.insert(key) {
+            let term_idx = self.next_product_term_idx();
+            self.result.trilinear.push(key);
+            for var in [key.0, key.1, key.2] {
+                self.result
+                    .term_incidence
+                    .entry(var)
+                    .or_default()
+                    .insert(term_idx);
+            }
+        }
+    }
+
+    fn record_multilinear(&mut self, indices: &[usize]) {
+        let mut key = indices.to_vec();
+        key.sort_unstable();
+        if key.len() < 4 {
+            return;
+        }
+        if self.seen_multilinear.insert(key.clone()) {
+            let term_idx = self.next_product_term_idx();
+            self.result.multilinear.push(key.clone());
+            for var in key {
+                self.result
+                    .term_incidence
+                    .entry(var)
+                    .or_default()
+                    .insert(term_idx);
+            }
+        }
+    }
+
+    fn record_monomial(&mut self, var_idx: usize, exp: usize) {
+        let key = (var_idx, exp);
+        if self.seen_monomial.insert(key) {
+            self.result.monomial.push(key);
+        }
+    }
+
+    fn classify_node(&mut self, id: ExprId) {
+        match self.model.arena.get(id).clone() {
+            ExprNode::Constant(_) | ExprNode::ConstantArray(_, _) | ExprNode::Parameter { .. } => {}
+            ExprNode::Variable { .. } => {}
+            ExprNode::Index { base, .. } => {
+                if !matches!(self.model.arena.get(base), ExprNode::Variable { .. }) {
+                    self.classify_node(base);
+                }
+            }
+            ExprNode::BinaryOp { op, left, right } => match op {
+                BinOp::Pow => self.classify_power(left, right),
+                BinOp::Mul => self.classify_product(id, left, right),
+                BinOp::Add | BinOp::Sub => {
+                    self.classify_node(left);
+                    self.classify_node(right);
+                }
+                BinOp::Div => {
+                    if self.constant_value(right).is_some() {
+                        self.classify_node(left);
+                    } else {
+                        self.result.general_nl_count += 1;
+                    }
+                }
+            },
+            ExprNode::UnaryOp { op, operand } => match op {
+                UnOp::Neg => self.classify_node(operand),
+                UnOp::Abs => self.result.general_nl_count += 1,
+            },
+            ExprNode::FunctionCall { args, .. } => {
+                self.result.general_nl_count += 1;
+                for arg in args {
+                    self.classify_node(arg);
+                }
+            }
+            ExprNode::Sum { operand, .. } => self.classify_node(operand),
+            ExprNode::SumOver { terms } => {
+                for term in terms {
+                    self.classify_node(term);
+                }
+            }
+            ExprNode::MatMul { left, right } => {
+                self.classify_node(left);
+                self.classify_node(right);
+            }
+        }
+    }
+
+    fn classify_power(&mut self, left: ExprId, right: ExprId) {
+        if let Some(flat) = self.flat_index(left) {
+            if let Some(exp_val) = self.constant_value(right) {
+                if exp_val >= 2.0
+                    && exp_val.is_finite()
+                    && (exp_val - exp_val.round()).abs() <= 1e-12
+                {
+                    self.record_monomial(flat, exp_val.round() as usize);
+                    return;
+                }
+                if (exp_val - 1.0).abs() > 1e-12 {
+                    self.result.general_nl_count += 1;
+                    return;
+                }
+            }
+        }
+
+        self.classify_node(left);
+        self.classify_node(right);
+    }
+
+    fn classify_product(&mut self, id: ExprId, left: ExprId, right: ExprId) {
+        if let Some(factors) = self.collect_product_factors(id) {
+            let mut unique_vars = Vec::new();
+            for factor in &factors {
+                if !unique_vars.contains(factor) {
+                    unique_vars.push(*factor);
+                }
+            }
+
+            if unique_vars.len() == 1 {
+                let exp = factors.iter().filter(|idx| **idx == unique_vars[0]).count();
+                self.record_monomial(unique_vars[0], exp);
+                return;
+            }
+
+            if unique_vars
+                .iter()
+                .any(|var| factors.iter().filter(|idx| *idx == var).count() >= 2)
+            {
+                self.result.general_nl_count += 1;
+                self.classify_node(left);
+                self.classify_node(right);
+                return;
+            }
+
+            match unique_vars.len() {
+                2 => self.record_bilinear(unique_vars[0], unique_vars[1]),
+                3 => self.record_trilinear(unique_vars[0], unique_vars[1], unique_vars[2]),
+                _ => self.record_multilinear(&unique_vars),
+            }
+            return;
+        }
+
+        self.classify_node(left);
+        self.classify_node(right);
+    }
+
+    fn collect_product_factors(&self, id: ExprId) -> Option<Vec<usize>> {
+        let mut indices = Vec::new();
+        if self.collect_product_factors_inner(id, &mut indices) && indices.len() >= 2 {
+            Some(indices)
+        } else {
+            None
+        }
+    }
+
+    fn collect_product_factors_inner(&self, id: ExprId, out: &mut Vec<usize>) -> bool {
+        match self.model.arena.get(id) {
+            ExprNode::BinaryOp {
+                op: BinOp::Mul,
+                left,
+                right,
+            } => {
+                self.collect_product_factors_inner(*left, out)
+                    && self.collect_product_factors_inner(*right, out)
+            }
+            ExprNode::Constant(_) => true,
+            _ => {
+                if let Some(flat) = self.flat_index(id) {
+                    out.push(flat);
+                    true
+                } else {
+                    false
+                }
+            }
+        }
+    }
+
+    fn flat_index(&self, id: ExprId) -> Option<usize> {
+        match self.model.arena.get(id) {
+            ExprNode::Variable { index, size, .. } => {
+                if *size == 1 {
+                    self.model.variables.get(*index).map(|var| var.offset)
+                } else {
+                    None
+                }
+            }
+            ExprNode::Index { base, index } => {
+                if let ExprNode::Variable {
+                    index: var_block_idx,
+                    ..
+                } = self.model.arena.get(*base)
+                {
+                    let local = scalar_index(index)?;
+                    self.model
+                        .variables
+                        .get(*var_block_idx)
+                        .map(|var| var.offset + local)
+                } else {
+                    None
+                }
+            }
+            _ => None,
+        }
+    }
+
+    fn constant_value(&self, id: ExprId) -> Option<f64> {
+        match self.model.arena.get(id) {
+            ExprNode::Constant(value) => Some(*value),
+            _ => None,
+        }
+    }
+}
+
+fn scalar_index(index: &IndexSpec) -> Option<usize> {
+    match index {
+        IndexSpec::Scalar(i) => Some(*i),
+        IndexSpec::Tuple(indices) if indices.len() == 1 => Some(indices[0]),
+        IndexSpec::Multi(elems) if elems.len() == 1 => match &elems[0] {
+            IndexElem::Scalar(i) => Some(*i),
+            IndexElem::Slice { .. } => None,
+        },
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::expr::{
+        ConstraintRepr, ConstraintSense, ExprArena, ExprNode, ModelRepr, ObjectiveSense, VarInfo,
+        VarType,
+    };
+
+    fn bilinear_model() -> ModelRepr {
+        let mut arena = ExprArena::new();
+        let x = arena.add(ExprNode::Variable {
+            name: "x".to_string(),
+            index: 0,
+            size: 3,
+            shape: vec![3],
+        });
+        let x0 = arena.add(ExprNode::Index {
+            base: x,
+            index: IndexSpec::Scalar(0),
+        });
+        let x1 = arena.add(ExprNode::Index {
+            base: x,
+            index: IndexSpec::Scalar(1),
+        });
+        let x2 = arena.add(ExprNode::Index {
+            base: x,
+            index: IndexSpec::Scalar(2),
+        });
+        let prod01 = arena.add(ExprNode::BinaryOp {
+            op: BinOp::Mul,
+            left: x0,
+            right: x1,
+        });
+        let prod02 = arena.add(ExprNode::BinaryOp {
+            op: BinOp::Mul,
+            left: x0,
+            right: x2,
+        });
+        let objective = arena.add(ExprNode::BinaryOp {
+            op: BinOp::Add,
+            left: prod01,
+            right: prod02,
+        });
+
+        ModelRepr {
+            arena,
+            objective,
+            objective_sense: ObjectiveSense::Minimize,
+            constraints: vec![ConstraintRepr {
+                body: x0,
+                sense: ConstraintSense::Ge,
+                rhs: 0.0,
+                name: None,
+            }],
+            variables: vec![VarInfo {
+                name: "x".to_string(),
+                var_type: VarType::Continuous,
+                offset: 0,
+                size: 3,
+                shape: vec![3],
+                lb: vec![0.0; 3],
+                ub: vec![10.0; 3],
+            }],
+            n_vars: 3,
+        }
+    }
+
+    #[test]
+    fn classifies_bilinear_terms_and_incidence() {
+        let terms = classify_nonlinear_terms(&bilinear_model());
+
+        assert_eq!(terms.bilinear, vec![(0, 1), (0, 2)]);
+        assert_eq!(terms.partition_candidates, vec![0, 1, 2]);
+        assert_eq!(terms.term_incidence.get(&0).unwrap().len(), 2);
+        assert_eq!(terms.term_incidence.get(&1).unwrap().len(), 1);
+        assert_eq!(terms.term_incidence.get(&2).unwrap().len(), 1);
+    }
+}

--- a/crates/discopt-core/src/lib.rs
+++ b/crates/discopt-core/src/lib.rs
@@ -5,6 +5,7 @@
 
 #![deny(missing_docs)]
 
+pub mod amp;
 pub mod bnb;
 pub mod expr;
 pub mod nl_parser;

--- a/crates/discopt-python/src/expr_bindings.rs
+++ b/crates/discopt-python/src/expr_bindings.rs
@@ -361,6 +361,28 @@ impl PyModelRepr {
         let ub_arr = numpy::PyArray1::from_vec(py, ubs);
         Ok((lb_arr.into_any().unbind(), ub_arr.into_any().unbind()))
     }
+
+    /// Classify AMP nonlinear product terms using the Rust expression arena.
+    fn classify_nonlinear_terms(&self, py: Python<'_>) -> PyResult<PyObject> {
+        let terms = discopt_core::amp::classify_nonlinear_terms(&self.inner);
+        let dict = PyDict::new(py);
+
+        dict.set_item("bilinear", terms.bilinear)?;
+        dict.set_item("trilinear", terms.trilinear)?;
+        dict.set_item("multilinear", terms.multilinear)?;
+        dict.set_item("monomial", terms.monomial)?;
+        dict.set_item("general_nl_count", terms.general_nl_count)?;
+        dict.set_item("partition_candidates", terms.partition_candidates)?;
+
+        let incidence = PyDict::new(py);
+        for (var_idx, term_ids) in terms.term_incidence {
+            let ids: Vec<usize> = term_ids.into_iter().collect();
+            incidence.set_item(var_idx, ids)?;
+        }
+        dict.set_item("term_incidence", incidence)?;
+
+        Ok(dict.into())
+    }
 }
 
 // ─────────────────────────────────────────────────────────────

--- a/python/discopt/_jax/term_classifier.py
+++ b/python/discopt/_jax/term_classifier.py
@@ -22,6 +22,7 @@ Theory references:
 from __future__ import annotations
 
 from dataclasses import dataclass, field
+from typing import Any
 
 from discopt.modeling.core import (
     BinaryOp,
@@ -159,6 +160,56 @@ def _collect_product_factors(expr: Expression, model: Model) -> list[int] | None
 
 
 def classify_nonlinear_terms(model: Model) -> NonlinearTerms:
+    """Walk the model's expression DAG and catalog nonlinear term structure.
+
+    Uses the Rust expression-arena classifier for polynomial/product models when
+    available, falling back to the Python implementation for unsupported models
+    and for cases that need concrete ``general_nl`` expression objects.
+    """
+    rust_terms = _classify_nonlinear_terms_rust(model)
+    if rust_terms is not None:
+        return rust_terms
+    return _classify_nonlinear_terms_python(model)
+
+
+def _classify_nonlinear_terms_rust(model: Model) -> NonlinearTerms | None:
+    """Return Rust-classified terms when the fast path can preserve the API."""
+    try:
+        from discopt._rust import model_to_repr
+    except Exception:
+        return None
+
+    try:
+        payload = model_to_repr(model).classify_nonlinear_terms()
+    except Exception:
+        return None
+
+    # The public API exposes the actual Python expression objects for general_nl.
+    # The Rust arena sees only node ids, so keep those models on the Python path.
+    if int(payload.get("general_nl_count", 0)) != 0:
+        return None
+
+    return _terms_from_rust_payload(payload)
+
+
+def _terms_from_rust_payload(payload: dict[str, Any]) -> NonlinearTerms:
+    """Convert the PyO3 classifier payload into the public dataclass."""
+    incidence_payload = payload.get("term_incidence", {})
+    return NonlinearTerms(
+        bilinear=[(int(i), int(j)) for i, j in payload.get("bilinear", [])],
+        trilinear=[(int(i), int(j), int(k)) for i, j, k in payload.get("trilinear", [])],
+        multilinear=[tuple(int(idx) for idx in term) for term in payload.get("multilinear", [])],
+        monomial=[(int(var_idx), int(exp)) for var_idx, exp in payload.get("monomial", [])],
+        general_nl=[],
+        term_incidence={
+            int(var_idx): {int(term_idx) for term_idx in term_ids}
+            for var_idx, term_ids in incidence_payload.items()
+        },
+        partition_candidates=[int(var_idx) for var_idx in payload.get("partition_candidates", [])],
+    )
+
+
+def _classify_nonlinear_terms_python(model: Model) -> NonlinearTerms:
     """Walk the model's expression DAG and catalog nonlinear term structure.
 
     Scans all constraints and the objective.  Each unique bilinear/trilinear/monomial

--- a/python/tests/test_rust_ir.py
+++ b/python/tests/test_rust_ir.py
@@ -225,6 +225,54 @@ class TestStructureDetection:
 
 
 # ─────────────────────────────────────────────────────────────
+# Test: AMP term classification
+# ─────────────────────────────────────────────────────────────
+
+
+class TestAmpTermClassification:
+    def test_rust_classifier_matches_python_terms_and_incidence(self):
+        from discopt._jax.term_classifier import (
+            _classify_nonlinear_terms_python,
+            _classify_nonlinear_terms_rust,
+            classify_nonlinear_terms,
+        )
+
+        m = dm.Model("amp_terms")
+        x = m.continuous("x", shape=(4,), lb=0, ub=10)
+        m.minimize(x[0] * x[1] + (x[0] * x[1] * x[2]) + x[3] ** 3)
+        m.subject_to(x[0] * x[1] * x[2] * x[3] <= 100)
+
+        rust_terms = _classify_nonlinear_terms_rust(m)
+        python_terms = _classify_nonlinear_terms_python(m)
+
+        assert rust_terms is not None
+        assert rust_terms == python_terms
+        assert classify_nonlinear_terms(m) == rust_terms
+        assert rust_terms.term_incidence[0] == {0, 1, 2}
+        assert rust_terms.partition_candidates == [0, 1, 2, 3]
+
+    def test_public_classifier_falls_back_for_general_nonlinear_objects(self):
+        from discopt._jax.term_classifier import (
+            _classify_nonlinear_terms_python,
+            _classify_nonlinear_terms_rust,
+            classify_nonlinear_terms,
+        )
+
+        m = dm.Model("general_nl")
+        x = m.continuous("x", lb=0.1, ub=2.0)
+        y = m.continuous("y", lb=0.1, ub=2.0)
+        m.minimize(dm.sin(x) + x * y)
+
+        assert _classify_nonlinear_terms_rust(m) is None
+
+        terms = classify_nonlinear_terms(m)
+        python_terms = _classify_nonlinear_terms_python(m)
+        assert terms == python_terms
+        assert terms.general_nl
+        assert terms.bilinear == [(0, 1)]
+
+
+# ─────────────────────────────────────────────────────────────
 # Test: Evaluation
 # ─────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

- Added a Rust AMP term classifier over `ModelRepr` for bilinear, trilinear, multilinear, monomial, partition-candidate, and incidence data.
- Exposed the classifier through the existing PyO3 `_rust` bindings and routed `classify_nonlinear_terms()` through it when the public Python API can be preserved.
- Kept the Python classifier as the fallback for unsupported cases and for models with concrete `general_nl` expression objects.
- Added Rust/Python parity tests for AMP term classification and fallback behavior.

## Tests run

- `cargo test -p discopt-core` — passed; 158 Rust tests and 1 doctest passed.
- `cargo fmt --check` — passed.
- `env -u CONDA_PREFIX UV_CACHE_DIR=/tmp/uv-cache VIRTUAL_ENV=/home/bernalde/repos/discopt/.venv "PATH=/home/bernalde/repos/discopt/.venv/bin:$PATH" make RUFF=.venv/bin/ruff lint` — passed.
- `env -u CONDA_PREFIX VIRTUAL_ENV=/home/bernalde/repos/discopt/.venv "PATH=/home/bernalde/repos/discopt/.venv/bin:$PATH" .venv/bin/mypy python/discopt/` — passed; no issues found.
- `JAX_PLATFORMS=cpu JAX_ENABLE_X64=1 .venv/bin/python -m pytest python/tests/test_rust_ir.py::TestAmpTermClassification python/tests/test_amp_integration.py::TestTermClassifier python/tests/test_amp_integration.py::TestAlpinePortedPartitionSelection -q` — passed; 15 passed.
- `env -u CONDA_PREFIX UV_CACHE_DIR=/tmp/uv-cache VIRTUAL_ENV=/home/bernalde/repos/discopt/.venv "PATH=/home/bernalde/repos/discopt/.venv/bin:$PATH" make PYTHON=.venv/bin/python MATURIN=.venv/bin/maturin 'PYTEST=.venv/bin/python -m pytest' test-amp-fast` — passed; 42 passed in 6.62s.
- `env -u CONDA_PREFIX UV_CACHE_DIR=/tmp/uv-cache VIRTUAL_ENV=/home/bernalde/repos/discopt/.venv "PATH=/home/bernalde/repos/discopt/.venv/bin:$PATH" make PYTHON=.venv/bin/python MATURIN=.venv/bin/maturin 'PYTEST=.venv/bin/python -m pytest' test-amp-integration` — passed; 160 passed, 2 xfailed in 937.36s.
- `env -u CONDA_PREFIX UV_CACHE_DIR=/tmp/uv-cache VIRTUAL_ENV=/home/bernalde/repos/discopt/.venv "PATH=/home/bernalde/repos/discopt/.venv/bin:$PATH" make PYTHON=.venv/bin/python MATURIN=.venv/bin/maturin 'PYTEST=.venv/bin/python -m pytest' test` — passed; 2219 passed, 59 skipped, 628 deselected, 2 xfailed, 10 warnings in 427.57s.

## Benchmark notes

- `PYTHONPATH=python/tests .venv/bin/python - <<'PY' ...` comparing `_classify_nonlinear_terms_python()` and `_classify_nonlinear_terms_rust()` on Alpine-style partition fixtures:
  - `castro2m2`: Python 35.8 us/call, Rust path 234.5 us/call, 0.15x. This small case is dominated by Python-to-Rust model conversion overhead.
  - `blend029_gl`: Python 14211.5 us/call, Rust path 1968.8 us/call, 7.22x.

## Notes about tests not run

- Did not run `make test-all`; the PR-fast suite, Rust core suite, lint, mypy, AMP fast suite, and opt-in AMP Alpine/incidence suite all passed locally.

Closes #20
