### PR TITLE
Fix AMP quadratic superlevel bounds

### DIFF
--- a/python/discopt/_jax/milp_relaxation.py
+++ b/python/discopt/_jax/milp_relaxation.py
@@ -5,15 +5,15 @@ Builds a linear programming relaxation of the original MINLP by:
   1. Replacing bilinear terms x_i*x_j with auxiliary variables w_ij and
      adding standard McCormick envelope constraints.
   2. Replacing monomial terms x_i^n with auxiliary variables s_i and adding
-     piecewise tangent-cut underestimators (using disc_state partition intervals)
-     and a global secant overestimator.
+     piecewise tangent-cut underestimators plus partition-activated secant
+     overestimators when the variable is discretized.
   3. Linearizing the original objective and constraints.
 
 The LP relaxation gives a valid lower bound:
   LP_opt ≤ global NLP_opt
 
-As the partition becomes finer (more intervals in disc_state), more tangent cuts
-are added for monomials in the objective, tightening the lower bound.
+As the partition becomes finer (more intervals in disc_state), more tangent and
+local secant cuts are added for monomials, tightening the lower bound.
 
 Theory: Nagarajan et al., JOGO 2018, Section 4 (piecewise McCormick relaxation).
 """
@@ -223,6 +223,11 @@ def _power_secant_line(lb: float, ub: float, n: int) -> tuple[float, float]:
     slope = float((ub**n - lb**n) / (ub - lb))
     intercept = float(lb**n - slope * lb)
     return slope, intercept
+
+
+def _power_is_convex_on_box(n: int, lb: float) -> bool:
+    """Return True when x**n is convex on the current box."""
+    return n % 2 == 0 or lb >= 0.0
 
 
 def _monomial_breakpoints(
@@ -957,6 +962,35 @@ def build_milp_relaxation(
         integrality_flags.append(0)
         col_idx += 1
 
+    monomial_pw_map: dict[tuple[int, int], list[tuple[int, float, float]]] = {}
+    for var_idx, n in terms.monomial:
+        lb_i = float(flat_lb[var_idx])
+        ub_i = float(flat_ub[var_idx])
+        if (
+            var_idx not in disc_state.partitions
+            or not _power_is_convex_on_box(n, lb_i)
+            or not np.isfinite(lb_i)
+            or not np.isfinite(ub_i)
+        ):
+            continue
+
+        breakpoints = _monomial_breakpoints(var_idx, lb_i, ub_i, disc_state)
+        if len(breakpoints) < 3:
+            continue
+
+        monomial_intervals: list[tuple[int, float, float]] = []
+        for a_k, b_k in zip(breakpoints[:-1], breakpoints[1:]):
+            if b_k <= a_k:
+                continue
+            delta_col = col_idx
+            all_bounds.append((0.0, 1.0))
+            integrality_flags.append(1)
+            col_idx += 1
+            monomial_intervals.append((delta_col, float(a_k), float(b_k)))
+
+        if monomial_intervals:
+            monomial_pw_map[(var_idx, n)] = monomial_intervals
+
     univariate_relaxations, univariate_var_map, univariate_bounds = _collect_univariate_relaxations(
         model,
         n_orig,
@@ -1348,6 +1382,47 @@ def build_milp_relaxation(
             row[j] -= xi_lb_g
             _add_row(row, -xi_lb_g * xj_ub_g)
 
+    # Binary interval selectors for partitioned convex monomial overestimators.
+    # A local secant is valid only on its own interval, so the selector links the
+    # original variable to one active interval before applying that secant.
+    for (var_idx, n), monomial_intervals in monomial_pw_map.items():
+        if not monomial_intervals:
+            continue
+        s_col = monomial_var_map[(var_idx, n)]
+        x_lb, x_ub = [float(v) for v in all_bounds[var_idx]]
+        _s_lb, s_ub = [float(v) for v in all_bounds[s_col]]
+
+        row_sum = np.zeros(n_total)
+        for delta_col, _, _ in monomial_intervals:
+            row_sum[delta_col] = -1.0
+        _add_row(row_sum, -1.0)
+        _add_row(-row_sum, 1.0)
+
+        for delta_col, a_k, b_k in monomial_intervals:
+            lower_m = max(0.0, a_k - x_lb)
+            row = np.zeros(n_total)
+            row[var_idx] = -1.0
+            row[delta_col] = lower_m
+            _add_row(row, lower_m - a_k)
+
+            upper_m = max(0.0, x_ub - b_k)
+            row = np.zeros(n_total)
+            row[var_idx] = 1.0
+            row[delta_col] = upper_m
+            _add_row(row, b_k + upper_m)
+
+            slope, intercept = _power_secant_line(a_k, b_k, n)
+            line_at_lb = slope * x_lb + intercept
+            line_at_ub = slope * x_ub + intercept
+            line_min = min(line_at_lb, line_at_ub)
+            secant_m = max(0.0, s_ub - line_min)
+
+            row = np.zeros(n_total)
+            row[s_col] = 1.0
+            row[var_idx] = -slope
+            row[delta_col] = secant_m
+            _add_row(row, intercept + secant_m)
+
     # Monomial constraints
     for var_idx, n in terms.monomial:
         lb_i = float(flat_lb[var_idx])
@@ -1383,7 +1458,7 @@ def build_milp_relaxation(
             row[var_idx] = -slope
             _add_row(row, intercept)
 
-        if n % 2 == 0 or lb_i >= 0.0:
+        if _power_is_convex_on_box(n, lb_i):
             # Convex on the full domain: tangents underestimate and the secant
             # overestimates. Using all breakpoints makes the relaxation tighten
             # monotonically as the partition is refined.
@@ -1577,6 +1652,7 @@ def build_milp_relaxation(
         "multilinear": multilinear_var_map,
         "multilinear_stages": multilinear_stage_map,
         "monomial": monomial_var_map,
+        "monomial_pw": monomial_pw_map,
         "univariate": univariate_var_map,
         "univariate_relaxations": univariate_relaxations,
         "bilinear_pw": bilinear_pw_map,

--- a/python/tests/test_amp.py
+++ b/python/tests/test_amp.py
@@ -26,6 +26,14 @@ def _make_nlp1() -> Model:
     return m
 
 
+def _make_circle() -> Model:
+    m = Model("circle")
+    x = m.continuous("x", lb=0, ub=2, shape=(2,))
+    m.subject_to(x[0] ** 2 + x[1] ** 2 >= 2)
+    m.minimize(x[0] + x[1])
+    return m
+
+
 def _make_obbt_demo() -> Model:
     m = Model("obbt_demo")
     x = m.continuous("x", lb=0, ub=10)
@@ -40,13 +48,14 @@ def _build_relaxation_for_test(
     part_vars: list[int] | None = None,
     lbs: list[float] | None = None,
     ubs: list[float] | None = None,
+    n_init: int = 2,
 ):
     from discopt._jax.discretization import initialize_partitions
     from discopt._jax.milp_relaxation import build_milp_relaxation
     from discopt._jax.term_classifier import classify_nonlinear_terms
 
     terms = classify_nonlinear_terms(model)
-    state = initialize_partitions(part_vars or [], lb=lbs or [], ub=ubs or [], n_init=2)
+    state = initialize_partitions(part_vars or [], lb=lbs or [], ub=ubs or [], n_init=n_init)
     return build_milp_relaxation(model, terms, state, incumbent=None)
 
 
@@ -168,6 +177,35 @@ def test_weymouth_like_squares_extend_builtin_partition_selection():
     assert (3, 2) in terms.monomial
     assert set(terms.partition_candidates) == {0, 1}
     assert set(amp_mod._equality_square_monomial_partition_candidates(m, terms)) == {2, 3}
+
+
+def test_partitioned_square_secants_tighten_circle_superlevel_bound():
+    """Local square secants should close the Alpine circle MILP lower bound."""
+    m = _make_circle()
+    part_vars = [0, 1]
+    coarse_model, _ = _build_relaxation_for_test(
+        m,
+        part_vars=part_vars,
+        lbs=[0.0, 0.0],
+        ubs=[2.0, 2.0],
+        n_init=2,
+    )
+    fine_model, fine_varmap = _build_relaxation_for_test(
+        m,
+        part_vars=part_vars,
+        lbs=[0.0, 0.0],
+        ubs=[2.0, 2.0],
+        n_init=64,
+    )
+
+    coarse = coarse_model.solve()
+    fine = fine_model.solve()
+
+    assert set(fine_varmap["monomial_pw"]) == {(0, 2), (1, 2)}
+    assert coarse.objective is not None
+    assert fine.objective is not None
+    assert fine.objective >= coarse.objective + 0.05
+    assert fine.objective == pytest.approx(np.sqrt(2.0), abs=1e-4)
 
 
 def test_solve_nlp_subproblem_retries_ipopt_and_restores_bounds(monkeypatch):

--- a/python/tests/test_amp_integration.py
+++ b/python/tests/test_amp_integration.py
@@ -1083,6 +1083,22 @@ class TestMilpRelaxation:
                 f"MILP LB {result.objective:.6f} exceeds known global optimum √2"
             )
 
+    def test_partitioned_circle_monomial_lb_uses_local_secants(self):
+        """Partitioned square overestimators should certify the Alpine circle bound."""
+        m = _make_circle()
+        terms = self.classify(m)
+        square_vars = sorted(var_idx for var_idx, exp in terms.monomial if exp == 2)
+        state = self.init_partitions(square_vars, lb=[0.0, 0.0], ub=[2.0, 2.0], n_init=64)
+
+        milp_model, varmap = self.build_milp(m, terms, state, incumbent=None)
+        result = milp_model.solve()
+
+        assert set(varmap["monomial_pw"]) == {(0, 2), (1, 2)}
+        assert result.status == "optimal"
+        assert result.objective is not None
+        assert result.objective <= CIRCLE_OPTIMUM + 1e-4
+        assert result.objective >= CIRCLE_OPTIMUM - 1e-4
+
     def test_milp_lb_tightens_with_finer_partitions(self):
         """LB must be non-decreasing as partition count increases (key paper claim)."""
         m = _make_nlp1()
@@ -1580,11 +1596,8 @@ class TestAmpEndToEnd:
         """circle: x₀²+x₁²≥2 minimized to global optimum √2."""
         m = _make_circle()
         result = m.solve(solver="amp", rel_gap=1e-4, time_limit=60)
-        assert result.status in ("optimal", "feasible", "time_limit")
-        if result.status == "optimal":
-            assert result.gap_certified is True
-        else:
-            assert result.gap_certified is False
+        assert result.status == "optimal"
+        assert result.gap_certified is True
         assert result.objective is not None
         assert abs(result.objective - CIRCLE_OPTIMUM) <= 1e-3, (
             f"Objective {result.objective:.6f} too far from √2={CIRCLE_OPTIMUM}"


### PR DESCRIPTION
## Summary

- Strengthens AMP's lifted convex monomial relaxation with partition-activated local secant overestimators.
- Keeps the nonconvex-superlevel OA soundness behavior intact while tightening the circle lower bound enough for AMP to certify the Alpine circle example.
- Adds fast and opt-in integration regression coverage for the partitioned square lower bound and updates the circle end-to-end test to require `status="optimal"` with `gap_certified=True`.

## Tests run

- `JAX_PLATFORMS=cpu JAX_ENABLE_X64=1 .venv/bin/python -m pytest python/tests/test_amp.py::test_partitioned_square_secants_tighten_circle_superlevel_bound python/tests/test_amp_integration.py::TestMilpRelaxation::test_partitioned_circle_monomial_lb_uses_local_secants python/tests/test_amp_integration.py::TestAmpEndToEnd::test_circle_bilinear_global_optimum -q` - passed, 3 passed in 20.56s
- `JAX_PLATFORMS=cpu JAX_ENABLE_X64=1 .venv/bin/python -m pytest python/tests/test_amp.py -v --tb=short -q` - passed, 51 passed in 21.54s
- `JAX_PLATFORMS=cpu JAX_ENABLE_X64=1 .venv/bin/python -m pytest python/tests/ -v --tb=short -q --timeout=120 -m "not slow and not correctness and not integration and not amp_benchmark" --ignore=python/tests/test_correctness.py` - passed, 2228 passed, 59 skipped, 632 deselected, 2 xfailed, 10 warnings in 674.37s
- `.venv/bin/python -m ruff check python/discopt/_jax/milp_relaxation.py python/tests/test_amp.py python/tests/test_amp_integration.py` - passed
- `.venv/bin/python -m ruff format --check python/discopt/_jax/milp_relaxation.py python/tests/test_amp.py python/tests/test_amp_integration.py` - passed
- `.venv/bin/python -m mypy python/discopt/` - passed, no issues found in 151 source files
- `git diff --check` - passed
- Commit hooks: `ruff`, `ruff format`, `mypy` - passed

## Notes

- The test environment used the project `.venv` rebound with `uv pip install --python .venv/bin/python -e ".[dev,highs,ipopt]"`; `pixi` is installed and accessible, but this repo has no pixi project manifest.
- Rust CI commands were not run locally because this is a Python-only relaxation change.

Closes #25
