### PR TITLE
Cover nonlinear contradiction proofs

### DIFF
--- a/python/tests/test_amp.py
+++ b/python/tests/test_amp.py
@@ -1489,6 +1489,45 @@ def test_amp_uses_nonlinear_tightened_partition_bounds(monkeypatch):
     assert captured["ub"] == pytest.approx([2.0])
 
 
+@pytest.mark.parametrize(
+    ("kind", "lb", "ub", "expected_rule", "expected_reason"),
+    [
+        ("quadratic", -10.0, 10.0, "sum_of_squares_upper_bound", "negative upper bound"),
+        ("sqrt", 0.0, 10.0, "monotone_function_bounds", "sqrt(argument) cannot be <="),
+        ("exp", -10.0, 10.0, "monotone_function_bounds", "exp(argument) cannot be <="),
+    ],
+)
+def test_nonlinear_tightening_reports_issue_28_contradictions(
+    kind,
+    lb,
+    ub,
+    expected_rule,
+    expected_reason,
+):
+    """Issue #28 contradictions should return an explicit infeasible status."""
+    from discopt._jax.nonlinear_bound_tightening import tighten_nonlinear_bounds
+
+    m = Model(f"issue_28_{kind}_contradiction")
+    x = m.continuous("x", lb=lb, ub=ub)
+    if kind == "quadratic":
+        m.subject_to(x**2 == -1.0)
+    elif kind == "sqrt":
+        m.subject_to(dm.sqrt(x) <= -1.0)
+    else:
+        m.subject_to(dm.exp(x) <= -1.0)
+    m.minimize(x * 0.0)
+
+    flat_lb = np.array([lb], dtype=np.float64)
+    flat_ub = np.array([ub], dtype=np.float64)
+    tightened_lb, tightened_ub, stats = tighten_nonlinear_bounds(m, flat_lb, flat_ub)
+
+    assert stats.infeasible is True
+    assert expected_rule in stats.applied_rules
+    assert expected_reason in (stats.infeasibility_reason or "")
+    np.testing.assert_allclose(tightened_lb, flat_lb)
+    np.testing.assert_allclose(tightened_ub, flat_ub)
+
+
 def test_oa_cut_recovery_drops_oldest_half(monkeypatch):
     """OA recovery should retry with the oldest half of cuts removed."""
     from discopt._jax.milp_relaxation import MilpRelaxationResult


### PR DESCRIPTION
## Summary

- Adds fast AMP regression coverage for issue #28's explicit nonlinear bound-tightening contradiction signal.
- Covers the issue examples `x**2 == -1`, `sqrt(x) <= -1`, and `exp(x) <= -1`.
- Asserts each contradiction returns `stats.infeasible`, records the expected rule, keeps an explanatory reason, and does not pass along an invalid tightened box.

## Tests run

- `/home/bernalde/.local/bin/uv venv --allow-existing --python 3.12 .venv` — created/refreshed `.venv`.
- `/home/bernalde/.local/bin/uv pip install --python .venv/bin/python -e .[dev]` — passed.
- `.venv/bin/python -m pytest python/tests/test_amp.py::test_nonlinear_tightening_reports_issue_28_contradictions -q --timeout=120` — 3 passed.
- `.venv/bin/python -m pytest python/tests/test_amp.py::test_amp_uses_nonlinear_tightened_partition_bounds python/tests/test_amp.py::test_nonlinear_tightening_reports_issue_28_contradictions python/tests/test_amp.py::test_amp_returns_infeasible_for_nonlinear_tightening_contradiction -q --timeout=120` — 5 passed.
- `.venv/bin/python -m pytest python/tests/test_amp.py -q --timeout=120` — 54 passed.
- `.venv/bin/python -m ruff check python/` — passed.
- `.venv/bin/python -m ruff format --check python/` — 248 files already formatted.
- `.venv/bin/python -m mypy python/discopt/` — success, no issues found in 151 source files.
- `.venv/bin/python -m pytest python/tests/ -q --tb=short --timeout=120 -m "not slow and not correctness and not integration and not amp_benchmark" --ignore=python/tests/test_correctness.py` — 2231 passed, 59 skipped, 632 deselected, 2 xfailed.

## Notes about tests not run

- Did not run the full slow, correctness, integration, or `amp_benchmark`/incidence suites locally; the PR-fast marker selection intentionally excludes them.
- Verified `pixi 0.67.1` is available, but this repo has no `pixi.toml`, so no pixi project files or new dependencies were added for this test-only change.

Closes #28
