### PR TITLE
Fix division integer root presolve

### DIFF
--- a/python/discopt/solver.py
+++ b/python/discopt/solver.py
@@ -2507,6 +2507,9 @@ def solve_model(
                         n_tightened = 0
                         flat_idx = 0
                         for bi, vinfo in enumerate(model._variables):
+                            if vinfo.size != 1:
+                                flat_idx += vinfo.size
+                                continue
                             for j in range(vinfo.size):
                                 new_lo = fbbt_lbs[bi]
                                 new_hi = fbbt_ubs[bi]

--- a/python/discopt/solver.py
+++ b/python/discopt/solver.py
@@ -1694,6 +1694,34 @@ def solve_model(
     # --- Extract variable info ---
     n_vars, lb, ub, int_offsets, int_sizes = _extract_variable_info(model)
 
+    # --- Root presolve: FBBT + integer-bound rounding before tree creation ---
+    t_rust_start = time.perf_counter()
+    from discopt.solvers._root_presolve import tighten_root_bounds_with_fbbt
+
+    lb, ub, root_infeasible, _ = tighten_root_bounds_with_fbbt(
+        model,
+        lb,
+        ub,
+        int_offsets,
+        int_sizes,
+        model_repr=_model_repr,
+    )
+    rust_time += time.perf_counter() - t_rust_start
+    if root_infeasible:
+        wall_time = time.perf_counter() - t_start
+        return SolveResult(
+            status="infeasible",
+            objective=None,
+            bound=None,
+            gap=None,
+            x=None,
+            wall_time=wall_time,
+            node_count=0,
+            rust_time=rust_time,
+            jax_time=jax_time,
+            python_time=wall_time - rust_time - jax_time,
+        )
+
     # --- Create PyTreeManager (Rust) ---
     t_rust_start = time.perf_counter()
     tree = PyTreeManager(
@@ -2783,6 +2811,35 @@ def _solve_nlp_bb(
 
     # --- Extract variable info and create tree ---
     n_vars, lb, ub, int_offsets, int_sizes = _extract_variable_info(model)
+
+    # --- Root presolve: FBBT + integer-bound rounding before tree creation ---
+    t_rust_start = time.perf_counter()
+    from discopt.solvers._root_presolve import tighten_root_bounds_with_fbbt
+
+    lb, ub, root_infeasible, _ = tighten_root_bounds_with_fbbt(
+        model,
+        lb,
+        ub,
+        int_offsets,
+        int_sizes,
+    )
+    rust_time += time.perf_counter() - t_rust_start
+    if root_infeasible:
+        wall_time = time.perf_counter() - t_start
+        return SolveResult(
+            status="infeasible",
+            objective=None,
+            bound=None,
+            gap=None,
+            x=None,
+            wall_time=wall_time,
+            node_count=0,
+            rust_time=rust_time,
+            jax_time=jax_time,
+            python_time=wall_time - rust_time - jax_time,
+            nlp_bb=True,
+            gap_certified=_gap_certified,
+        )
 
     t_rust_start = time.perf_counter()
     tree = PyTreeManager(

--- a/python/discopt/solvers/_root_presolve.py
+++ b/python/discopt/solvers/_root_presolve.py
@@ -43,6 +43,9 @@ def _flat_fbbt_bounds(
     offset = 0
     for block_idx, var in enumerate(model._variables):
         size = var.size
+        if size != 1:
+            offset += size
+            continue
         block_lb = float(fbbt_lbs[block_idx])
         block_ub = float(fbbt_ubs[block_idx])
         sl = slice(offset, offset + size)

--- a/python/discopt/solvers/_root_presolve.py
+++ b/python/discopt/solvers/_root_presolve.py
@@ -1,0 +1,110 @@
+"""Root-node presolve helpers shared by global solvers."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import numpy as np
+
+from discopt.modeling.core import Model
+
+
+def _round_integral_bounds(
+    lb: np.ndarray,
+    ub: np.ndarray,
+    int_offsets: list[int],
+    int_sizes: list[int],
+) -> None:
+    """Round integer/binary flat bounds in-place."""
+    for offset, size in zip(int_offsets, int_sizes):
+        sl = slice(offset, offset + size)
+        finite_lb = np.isfinite(lb[sl])
+        finite_ub = np.isfinite(ub[sl])
+        lb_view = lb[sl]
+        ub_view = ub[sl]
+        lb_view[finite_lb] = np.ceil(lb_view[finite_lb] - 1e-9)
+        ub_view[finite_ub] = np.floor(ub_view[finite_ub] + 1e-9)
+
+
+def _flat_fbbt_bounds(
+    model: Model,
+    fbbt_lbs: np.ndarray,
+    fbbt_ubs: np.ndarray,
+    lb: np.ndarray,
+    ub: np.ndarray,
+) -> tuple[np.ndarray, np.ndarray]:
+    """Map block-level FBBT bounds to flat solver bounds."""
+    tightened_lb = lb.copy()
+    tightened_ub = ub.copy()
+
+    if len(fbbt_lbs) != len(model._variables) or len(fbbt_ubs) != len(model._variables):
+        return tightened_lb, tightened_ub
+
+    offset = 0
+    for block_idx, var in enumerate(model._variables):
+        size = var.size
+        block_lb = float(fbbt_lbs[block_idx])
+        block_ub = float(fbbt_ubs[block_idx])
+        sl = slice(offset, offset + size)
+        if np.isfinite(block_lb):
+            tightened_lb[sl] = np.maximum(tightened_lb[sl], block_lb)
+        if np.isfinite(block_ub):
+            tightened_ub[sl] = np.minimum(tightened_ub[sl], block_ub)
+        offset += size
+
+    return tightened_lb, tightened_ub
+
+
+def tighten_root_bounds_with_fbbt(
+    model: Model,
+    lb: np.ndarray,
+    ub: np.ndarray,
+    int_offsets: list[int],
+    int_sizes: list[int],
+    *,
+    model_repr: Any | None = None,
+    max_iter: int = 20,
+    tol: float = 1e-8,
+) -> tuple[np.ndarray, np.ndarray, bool, bool]:
+    """Run root FBBT and integer-bound rounding for solver tree bounds.
+
+    Returns ``(tightened_lb, tightened_ub, infeasible, changed)``. If the Rust
+    FBBT binding is unavailable, this still performs sound integer rounding.
+    """
+    orig_lb = np.asarray(lb, dtype=np.float64)
+    orig_ub = np.asarray(ub, dtype=np.float64)
+    tightened_lb = orig_lb.copy()
+    tightened_ub = orig_ub.copy()
+
+    if model_repr is None:
+        try:
+            from discopt._rust import model_to_repr
+
+            model_repr = model_to_repr(model, getattr(model, "_builder", None))
+        except Exception:
+            model_repr = None
+
+    if model_repr is not None:
+        try:
+            fbbt_lbs, fbbt_ubs = model_repr.fbbt(max_iter=max_iter, tol=tol)
+            tightened_lb, tightened_ub = _flat_fbbt_bounds(
+                model,
+                np.asarray(fbbt_lbs, dtype=np.float64),
+                np.asarray(fbbt_ubs, dtype=np.float64),
+                tightened_lb,
+                tightened_ub,
+            )
+        except Exception:
+            pass
+
+    _round_integral_bounds(tightened_lb, tightened_ub, int_offsets, int_sizes)
+
+    infeasible = bool(np.any(tightened_lb > tightened_ub + tol))
+    close = (tightened_lb > tightened_ub) & (tightened_lb <= tightened_ub + tol)
+    if np.any(close):
+        midpoint = 0.5 * (tightened_lb[close] + tightened_ub[close])
+        tightened_lb[close] = midpoint
+        tightened_ub[close] = midpoint
+
+    changed = bool(np.any(tightened_lb > orig_lb + tol) or np.any(tightened_ub < orig_ub - tol))
+    return tightened_lb, tightened_ub, infeasible, changed

--- a/python/discopt/solvers/amp.py
+++ b/python/discopt/solvers/amp.py
@@ -1711,6 +1711,34 @@ def solve_amp(
     def _from_minimization_space(value: float) -> float:
         return -float(value) if maximize else float(value)
 
+    int_offsets: list[int] = []
+    int_sizes: list[int] = []
+    offset = 0
+    for v in model._variables:
+        if v.var_type in (VarType.BINARY, VarType.INTEGER):
+            int_offsets.append(offset)
+            int_sizes.append(v.size)
+        offset += v.size
+
+    from discopt.solvers._root_presolve import tighten_root_bounds_with_fbbt
+
+    flat_lb, flat_ub, root_infeasible, root_changed = tighten_root_bounds_with_fbbt(
+        model,
+        flat_lb,
+        flat_ub,
+        int_offsets,
+        int_sizes,
+    )
+    if root_infeasible:
+        return SolveResult(
+            status="infeasible",
+            wall_time=time.perf_counter() - t_start,
+            mip_count=0,
+            gap_certified=True,
+        )
+    if root_changed:
+        logger.info("AMP: root FBBT tightened variable bounds before relaxation")
+
     tightened_lb, tightened_ub, nonlinear_bt_stats = tighten_nonlinear_bounds(
         model, flat_lb, flat_ub
     )
@@ -1722,6 +1750,7 @@ def solve_amp(
         return SolveResult(
             status="infeasible",
             wall_time=time.perf_counter() - t_start,
+            mip_count=0,
             gap_certified=True,
         )
     if nonlinear_bt_stats.n_tightened > 0:

--- a/python/tests/data/known_failures.toml
+++ b/python/tests/data/known_failures.toml
@@ -27,13 +27,6 @@ note     = "user-defined function via JuMP.register() has no dm equivalent"
 # RESOLVED: Fixed in f6d15a5 ("Fix maximize objective sign in solver and QP
 # extractor"). All 14 entries removed after rebase confirmed they now pass.
 
-# ── NaN on division + integer (issue #7) ─────────────────────────────────────
-
-[minlptests."nlp_mi_005_010/primary"]
-category = "numerical_error"
-issue    = 7
-note     = "division constraints (1/x form) produce NaN when x integer lb=0; crashes B&B"
-
 # ── IPM iteration_limit on unbounded variables ───────────────────────────────
 # Variables without explicit bounds get lb=-1e20,ub=1e20 which causes the IPM
 # to hit iteration_limit. All 501_011 (sqrt-constraint) variants are affected,

--- a/python/tests/test_amp.py
+++ b/python/tests/test_amp.py
@@ -1647,6 +1647,34 @@ def test_oa_cut_generation_receives_convex_constraint_mask(monkeypatch):
     assert recorded_masks == [[True, False]]
 
 
+def test_amp_root_presolve_preserves_heterogeneous_array_bounds():
+    """Root FBBT must not narrow every array element to the first element's bound."""
+    m = Model("amp_heterogeneous_array_bounds")
+    x = m.continuous(
+        "x",
+        shape=(2,),
+        lb=np.array([0.0, 0.0]),
+        ub=np.array([1.0, 10.0]),
+    )
+    m.subject_to(x[0] ** 2 >= 0.0)
+    m.minimize(-x[1])
+
+    result = m.solve(
+        solver="amp",
+        apply_partitioning=False,
+        skip_convex_check=True,
+        presolve_bt=False,
+        max_iter=2,
+        time_limit=10,
+    )
+
+    assert result.status in ("optimal", "feasible")
+    assert result.x is not None
+    assert result.objective is not None
+    assert result.objective <= -9.0
+    assert result.x["x"][1] >= 9.0
+
+
 def test_small_integer_domain_fallback_enumerates_complete_domain(monkeypatch):
     """The small-domain fallback should enumerate bounded integer domains directly."""
     from discopt.solvers import amp as amp_mod

--- a/python/tests/test_fbbt_bindings.py
+++ b/python/tests/test_fbbt_bindings.py
@@ -23,6 +23,27 @@ def _make_exp_model():
     return m
 
 
+def _make_reciprocal_integer_model():
+    """MINLPTests nlp_mi_005_010 reciprocal/integer bound pattern."""
+    m = dm.Model("reciprocal_integer")
+    x = m.integer("x", lb=0)
+    y = m.continuous("y", lb=0.0)
+    m.minimize(x + y)
+    m.subject_to(y >= 1 / (x + 0.1) - 0.5)
+    m.subject_to(x >= y ** (-2) - 0.5)
+    m.subject_to(4 / (x + y + 0.1) >= 1)
+    return m
+
+
+def _flat_variable_bounds(model):
+    lbs = []
+    ubs = []
+    for var in model._variables:
+        lbs.append(var.lb.flatten())
+        ubs.append(var.ub.flatten())
+    return np.concatenate(lbs), np.concatenate(ubs)
+
+
 class TestFBBTBindings:
     """Test the PyO3 FBBT bindings on PyModelRepr."""
 
@@ -87,3 +108,27 @@ class TestFBBTBindings:
         # Infeasible => lbs > ubs (empty intervals)
         for i in range(len(lbs)):
             assert lbs[i] > ubs[i], f"Expected empty interval for var {i}"
+
+    def test_root_presolve_rounds_integer_reciprocal_bounds(self):
+        """Root presolve removes the infeasible x=0 branch for reciprocal MINLPs."""
+        from discopt.solvers._root_presolve import tighten_root_bounds_with_fbbt
+
+        model = _make_reciprocal_integer_model()
+        lb, ub = _flat_variable_bounds(model)
+        repr_ = model_to_repr(model)
+
+        tightened_lb, tightened_ub, infeasible, changed = tighten_root_bounds_with_fbbt(
+            model,
+            lb,
+            ub,
+            int_offsets=[0],
+            int_sizes=[1],
+            model_repr=repr_,
+        )
+
+        assert not infeasible
+        assert changed
+        np.testing.assert_allclose(tightened_lb[0], 1.0, atol=1e-12)
+        np.testing.assert_allclose(tightened_ub[0], 3.0, atol=1e-12)
+        np.testing.assert_allclose(tightened_lb[1], 0.0, atol=1e-12)
+        assert tightened_ub[1] < 4.0

--- a/python/tests/test_fbbt_bindings.py
+++ b/python/tests/test_fbbt_bindings.py
@@ -132,3 +132,32 @@ class TestFBBTBindings:
         np.testing.assert_allclose(tightened_ub[0], 3.0, atol=1e-12)
         np.testing.assert_allclose(tightened_lb[1], 0.0, atol=1e-12)
         assert tightened_ub[1] < 4.0
+
+    def test_root_presolve_preserves_heterogeneous_array_bounds(self):
+        """Block-level Rust FBBT bounds must not overwrite elementwise array bounds."""
+        from discopt.solvers._root_presolve import tighten_root_bounds_with_fbbt
+
+        model = dm.Model("heterogeneous_array_bounds")
+        x = model.continuous(
+            "x",
+            shape=(2,),
+            lb=np.array([0.0, 0.0]),
+            ub=np.array([1.0, 10.0]),
+        )
+        model.minimize(-x[1])
+        lb, ub = _flat_variable_bounds(model)
+        repr_ = model_to_repr(model)
+
+        tightened_lb, tightened_ub, infeasible, changed = tighten_root_bounds_with_fbbt(
+            model,
+            lb,
+            ub,
+            int_offsets=[],
+            int_sizes=[],
+            model_repr=repr_,
+        )
+
+        assert not infeasible
+        assert not changed
+        np.testing.assert_allclose(tightened_lb, [0.0, 0.0], atol=1e-12)
+        np.testing.assert_allclose(tightened_ub, [1.0, 10.0], atol=1e-12)


### PR DESCRIPTION
## Summary

- Add shared root presolve that runs Rust FBBT before solver tree construction and rounds integer bounds.
- Apply the tightened root bounds in spatial B&B, NLP-BB, and AMP so reciprocal-domain MINLPs skip infeasible integer branches such as `x = 0`.
- Remove the `nlp_mi_005_010/primary` known-failure entry and add focused FBBT/root-presolve regression coverage.

## Tests run

- `/home/bernalde/.local/bin/uv run --no-sync --python .venv/bin/python -- ruff check python/`
  - Result: `All checks passed!`
- `/home/bernalde/.local/bin/uv run --no-sync --python .venv/bin/python -- ruff format --check python/`
  - Result: `249 files already formatted`
- `/home/bernalde/.local/bin/uv run --no-sync --python .venv/bin/python -- mypy python/discopt/`
  - Result: `Success: no issues found in 152 source files`
- `JAX_PLATFORMS=cpu JAX_ENABLE_X64=1 /home/bernalde/.local/bin/uv run --no-sync --python .venv/bin/python -m pytest python/tests/test_fbbt_bindings.py python/tests/test_minlptests.py::TestMINLPTestsMI::test_optimal_value[nlp_mi_005_010] -v --tb=short -q`
  - Result: `7 passed, 1 warning in 27.74s`
- `JAX_PLATFORMS=cpu JAX_ENABLE_X64=1 /home/bernalde/.local/bin/uv run --no-sync --python .venv/bin/python -- python -c "from python.tests.test_minlptests import _build_nlp_mi_005_010; m=_build_nlp_mi_005_010(); r=m.solve(solver='amp', time_limit=60.0, gap_tolerance=1e-6); print(r.status, r.objective, r.gap, r.x)"`
  - Result: `feasible 1.8164965805489068 0.44948974266837255 {'x': array(1.), 'y': array(0.81649658)}`
- `JAX_PLATFORMS=cpu JAX_ENABLE_X64=1 /home/bernalde/.local/bin/uv run --no-sync --python .venv/bin/python -m pytest python/tests/ -v --tb=short -q --timeout=120 -m "not slow" --ignore=python/tests/test_correctness.py`
  - Result: `2263 passed, 59 skipped, 601 deselected, 2 xfailed, 10 warnings in 667.06s (0:11:07)`
- Commit hook:
  - Result before rebase: Ruff passed, Ruff format passed, mypy passed, cargo fmt skipped.

## Notes about tests not run

- Full `make test-all` / full slow MINLPTests suite was not run locally because the PR-fast suite plus the exact issue target covered this change within practical runtime.

Closes #32
