### PR TITLE
Fix nlp_cvx_105_011 false infeasible xfail

### DIFF
--- a/python/tests/data/known_failures.toml
+++ b/python/tests/data/known_failures.toml
@@ -27,11 +27,4 @@ note     = "user-defined function via JuMP.register() has no dm equivalent"
 # RESOLVED: Fixed in f6d15a5 ("Fix maximize objective sign in solver and QP
 # extractor"). All 14 entries removed after rebase confirmed they now pass.
 
-# ── False infeasible ─────────────────────────────────────────────────────────
-
-[minlptests."nlp_cvx_105_011/primary"]
-category = "numerical_error"
-issue    = 33
-note     = "false infeasible: feasible exp/log problem incorrectly declared infeasible"
-
 # ── Infeasibility detection ──────────────────────────────────────────────────

--- a/python/tests/test_convex_fast_path.py
+++ b/python/tests/test_convex_fast_path.py
@@ -260,6 +260,7 @@ class TestTranslatedSpecialConvexRegressions:
     @pytest.mark.parametrize(
         "problem_id",
         [
+            "nlp_cvx_105_011",
             "nlp_cvx_108_010",
             "nlp_cvx_108_011",
             "nlp_cvx_108_012",


### PR DESCRIPTION
## Summary

- Removes the stale MINLPTests xfail for `nlp_cvx_105_011/primary`.
- Adds `nlp_cvx_105_011` to the fast translated convex regression coverage for both default and AMP solver entry points.

Closes #35

## Tests run

- `PYTHONPATH=python:python/tests JAX_PLATFORMS=cpu JAX_ENABLE_X64=1 /home/bernalde/.pixi/bin/pixi exec --spec ipopt --spec pkg-config --spec libblas --spec liblapack .venv/bin/python -c "from test_minlptests import MINLPTESTS_CVX_BY_ID; inst=MINLPTESTS_CVX_BY_ID['nlp_cvx_105_011']; m=inst.build_fn(); r=m.solve(time_limit=60.0, gap_tolerance=1e-6); print(r.status, r.objective, r.convex_fast_path, r.x)"` -> `optimal 0.16878271367286252 True`
- `PYTHONPATH=python:python/tests JAX_PLATFORMS=cpu JAX_ENABLE_X64=1 /home/bernalde/.pixi/bin/pixi exec --spec ipopt --spec pkg-config --spec libblas --spec liblapack .venv/bin/python -c "from test_minlptests import MINLPTESTS_CVX_BY_ID; inst=MINLPTESTS_CVX_BY_ID['nlp_cvx_105_011']; m=inst.build_fn(); r=m.solve(solver='amp', nlp_solver='ipm', time_limit=60.0, gap_tolerance=1e-6); print(r.status, r.objective, r.convex_fast_path, r.x)"` -> `optimal 0.16878271367286252 True`
- `PYTHONPATH=python JAX_PLATFORMS=cpu JAX_ENABLE_X64=1 /home/bernalde/.pixi/bin/pixi exec --spec ipopt --spec pkg-config --spec libblas --spec liblapack .venv/bin/python -m pytest python/tests/test_minlptests.py::TestMINLPTestsNLPCvx::test_optimal_value[nlp_cvx_105_011] -v --tb=short -q` -> `1 passed, 1 warning in 16.38s`
- `PYTHONPATH=python JAX_PLATFORMS=cpu JAX_ENABLE_X64=1 /home/bernalde/.pixi/bin/pixi exec --spec ipopt --spec pkg-config --spec libblas --spec liblapack .venv/bin/python -m pytest python/tests/test_convex_fast_path.py::TestTranslatedSpecialConvexRegressions -v --tb=short -q` -> `18 passed, 9 warnings in 52.04s`
- `PYTHONPATH=python JAX_PLATFORMS=cpu JAX_ENABLE_X64=1 /home/bernalde/.pixi/bin/pixi exec --spec ipopt --spec pkg-config --spec libblas --spec liblapack .venv/bin/python -m pytest python/tests/test_convex_fast_path.py python/tests/test_convexity.py python/tests/test_convexity_certificate.py python/tests/test_convexity_eigenvalue.py python/tests/test_convexity_interval.py python/tests/test_convexity_interval_ad.py python/tests/test_convexity_interval_eval.py python/tests/test_convexity_lattice.py python/tests/test_convexity_node_refresh.py python/tests/test_convexity_pathological.py python/tests/test_convexity_solver_integration.py python/tests/test_convexity_soundness.py python/tests/test_convexity_wide_box.py -v --tb=short -q --timeout=120 -m "not slow and not correctness and not integration and not amp_benchmark" --ignore=python/tests/test_correctness.py` -> `324 passed, 30 deselected, 2 xfailed, 11 warnings in 193.47s`
- `/home/bernalde/.pixi/bin/pixi exec --spec python=3.12 .venv/bin/python -m ruff check python/` -> `All checks passed!`
- `/home/bernalde/.pixi/bin/pixi exec --spec python=3.12 .venv/bin/python -m ruff format --check python/` -> `249 files already formatted`
- `PYTHONPATH=python /home/bernalde/.pixi/bin/pixi exec --spec python=3.12 .venv/bin/python -m mypy python/discopt/` -> `Success: no issues found in 152 source files`
- `cargo test -p discopt-core` -> `158 passed; doc-tests 1 passed`
- `PYTHONPATH=python JAX_PLATFORMS=cpu JAX_ENABLE_X64=1 /home/bernalde/.pixi/bin/pixi exec --spec ipopt --spec pkg-config --spec libblas --spec liblapack .venv/bin/python -m pytest python/tests/ -v --tb=short -q --timeout=120 -m "not slow and not correctness and not integration and not amp_benchmark" --ignore=python/tests/test_correctness.py` -> `2236 passed, 59 skipped, 637 deselected, 2 xfailed, 11 warnings in 637.64s`

## Notes

- Full `test-all` was not run locally; the PR-fast CI-equivalent suite was run instead.
- `make test-convexity` could not be used through `pixi exec` because the Makefile build step invokes `maturin develop`, and maturin selected pixi's temporary Python shim instead of `.venv`. The same pytest selection was run directly through the uv-created `.venv` inside pixi and passed.
