### PR TITLE
Right-size PR correctness runtime

### DIFF
--- a/python/tests/test_pr_correctness.py
+++ b/python/tests/test_pr_correctness.py
@@ -107,6 +107,9 @@ def test_pr_optimal_value(instance: ProblemInstance) -> None:
     model = instance.build_fn()
     result = model.solve(time_limit=10.0, gap_tolerance=1e-6, max_nodes=10_000)
     assert_optimal_value(result, instance.expected_obj, instance.name)
+    if instance.name == "binary_circle_minlp":
+        assert result.convex_fast_path is False
+        assert result.nlp_bb is False
 
 
 def test_pr_subset_keeps_small_nonconvex_minlp() -> None:

--- a/python/tests/test_pr_correctness.py
+++ b/python/tests/test_pr_correctness.py
@@ -11,16 +11,18 @@ Each instance is chosen to cover a distinct solver code path:
 * ``constrained_quadratic``    — pure continuous convex QP
 * ``simple_minlp``             — convex MINLP (textbook)
 * ``binary_knapsack``          — pure 0-1 MILP
-* ``binary_circle_minlp``      — tiny nonconvex MINLP (Alpine ``circlebin``-style)
+* ``binary_circle_minlp``      — tiny mixed continuous/binary nonconvex MINLP
 * ``exp_binary_minlp``         — OA-friendly convex MINLP with ``exp``
 
 The full ``circle_minlp`` case stays in the nightly correctness suite. It
 exercises the same nonconvex circle superlevel shape, but it is too expensive
-for this PR-fast tier in cold/local runs.
+for this PR-fast tier in cold/local runs. This file keeps cheaper PR coverage
+with a local Alpine ``circle``/``circlebin``-style replacement.
 
 The file deliberately does **not** import or re-apply the
 ``slow`` mark used at module level in :mod:`test_correctness`; it
-re-uses only the build functions and the optimal-value helper.
+re-uses shared build functions where practical, defines one local replacement,
+and shares the optimal-value helper.
 """
 
 from __future__ import annotations
@@ -42,12 +44,12 @@ pytestmark = pytest.mark.pr_correctness
 
 
 def _build_binary_circle_minlp() -> dm.Model:
-    """Alpine ``circlebin``-style nonconvex MINLP with a known optimum of 2."""
+    """Alpine circle-style nonconvex MINLP with a known optimum of 1."""
     m = dm.Model("binary_circle_minlp")
-    x1 = m.binary("x1")
-    x2 = m.binary("x2")
-    m.minimize(x1 + x2)
-    m.subject_to(x1**2 + x2**2 >= 2)
+    x = m.continuous("x", lb=0, ub=1)
+    y = m.binary("y")
+    m.minimize(x + 1.5 * y)
+    m.subject_to(x**2 + y**2 >= 1)
     return m
 
 
@@ -79,10 +81,10 @@ PR_INSTANCES: list[ProblemInstance] = [
     ProblemInstance(
         name="binary_circle_minlp",
         build_fn=_build_binary_circle_minlp,
-        expected_obj=2.0,
-        integer_vars=["x1", "x2"],
-        bounds={"x1": (0, 1), "x2": (0, 1)},
-        description="Tiny nonconvex binary-circle MINLP",
+        expected_obj=1.0,
+        integer_vars=["y"],
+        bounds={"x": (0, 1), "y": (0, 1)},
+        description="Tiny mixed continuous/binary nonconvex circle MINLP",
     ),
     ProblemInstance(
         name="exp_binary_minlp",
@@ -109,6 +111,14 @@ def test_pr_optimal_value(instance: ProblemInstance) -> None:
 
 def test_pr_subset_keeps_small_nonconvex_minlp() -> None:
     """Guard the issue #43 coverage contract for the PR-fast subset."""
+    from discopt._jax.convexity import classify_model
+    from discopt._jax.problem_classifier import ProblemClass, classify_problem
+
     instance_names = {inst.name for inst in PR_INSTANCES}
     assert "binary_circle_minlp" in instance_names
     assert "circle_minlp" not in instance_names
+
+    model = _build_binary_circle_minlp()
+    assert classify_problem(model) is ProblemClass.MINLP
+    is_convex, _ = classify_model(model, use_certificate=True)
+    assert not is_convex

--- a/python/tests/test_pr_correctness.py
+++ b/python/tests/test_pr_correctness.py
@@ -11,8 +11,12 @@ Each instance is chosen to cover a distinct solver code path:
 * ``constrained_quadratic``    — pure continuous convex QP
 * ``simple_minlp``             — convex MINLP (textbook)
 * ``binary_knapsack``          — pure 0-1 MILP
-* ``circle_minlp``             — nonconvex MINLP (``x^2 + y^2 >= 1``)
+* ``binary_circle_minlp``      — tiny nonconvex MINLP (Alpine ``circlebin``-style)
 * ``exp_binary_minlp``         — OA-friendly convex MINLP with ``exp``
+
+The full ``circle_minlp`` case stays in the nightly correctness suite. It
+exercises the same nonconvex circle superlevel shape, but it is too expensive
+for this PR-fast tier in cold/local runs.
 
 The file deliberately does **not** import or re-apply the
 ``slow`` mark used at module level in :mod:`test_correctness`; it
@@ -23,11 +27,11 @@ from __future__ import annotations
 
 import math
 
+import discopt.modeling as dm
 import pytest
 from test_correctness import (
     ProblemInstance,
     _build_binary_knapsack,
-    _build_circle_minlp,
     _build_constrained_quadratic,
     _build_exp_binary_minlp,
     _build_simple_minlp,
@@ -35,6 +39,16 @@ from test_correctness import (
 )
 
 pytestmark = pytest.mark.pr_correctness
+
+
+def _build_binary_circle_minlp() -> dm.Model:
+    """Alpine ``circlebin``-style nonconvex MINLP with a known optimum of 2."""
+    m = dm.Model("binary_circle_minlp")
+    x1 = m.binary("x1")
+    x2 = m.binary("x2")
+    m.minimize(x1 + x2)
+    m.subject_to(x1**2 + x2**2 >= 2)
+    return m
 
 
 PR_INSTANCES: list[ProblemInstance] = [
@@ -63,12 +77,12 @@ PR_INSTANCES: list[ProblemInstance] = [
         description="Pure 0-1 MILP",
     ),
     ProblemInstance(
-        name="circle_minlp",
-        build_fn=_build_circle_minlp,
-        expected_obj=1.0,
-        integer_vars=["z"],
-        bounds={"x": (0, 3), "y": (0, 3), "z": (0, 1)},
-        description="Nonconvex MINLP",
+        name="binary_circle_minlp",
+        build_fn=_build_binary_circle_minlp,
+        expected_obj=2.0,
+        integer_vars=["x1", "x2"],
+        bounds={"x1": (0, 1), "x2": (0, 1)},
+        description="Tiny nonconvex binary-circle MINLP",
     ),
     ProblemInstance(
         name="exp_binary_minlp",
@@ -89,5 +103,12 @@ PR_INSTANCES: list[ProblemInstance] = [
 def test_pr_optimal_value(instance: ProblemInstance) -> None:
     """Curated PR subset: solver finds the known optimum within tolerance."""
     model = instance.build_fn()
-    result = model.solve(time_limit=30.0, gap_tolerance=1e-6, max_nodes=10_000)
+    result = model.solve(time_limit=10.0, gap_tolerance=1e-6, max_nodes=10_000)
     assert_optimal_value(result, instance.expected_obj, instance.name)
+
+
+def test_pr_subset_keeps_small_nonconvex_minlp() -> None:
+    """Guard the issue #43 coverage contract for the PR-fast subset."""
+    instance_names = {inst.name for inst in PR_INSTANCES}
+    assert "binary_circle_minlp" in instance_names
+    assert "circle_minlp" not in instance_names


### PR DESCRIPTION
## Summary

- Replace the slow `circle_minlp` PR-fast correctness case with a small Alpine `circlebin`-style nonconvex MINLP.
- Keep the PR-fast tier's nonconvex MINLP coverage while leaving the full `circle_minlp` case in the nightly correctness suite.
- Lower the per-instance PR correctness solve budget from 30 seconds to 10 seconds and add a guard that prevents `circle_minlp` from drifting back into the PR-fast subset.

## Tests run

- `/home/bernalde/.pixi/bin/pixi exec --no-progress -s ipopt -s pkg-config -- .venv/bin/python -m pytest python/tests/test_pr_correctness.py -q --tb=short --timeout=120 --durations=10`
  - Result: `6 passed in 13.60s`
  - Slowest updated case: `binary_circle_minlp` at `5.75s`
- `.venv/bin/python -m ruff check python/tests/test_pr_correctness.py`
  - Result: `All checks passed!`
- `.venv/bin/python -m ruff format --check python/tests/test_pr_correctness.py`
  - Result: `1 file already formatted`
- `/home/bernalde/.pixi/bin/pixi exec --no-progress -s ipopt -s pkg-config -- env -u CONDA_PREFIX VIRTUAL_ENV=/home/bernalde/repos/discopt/.venv PATH="/home/bernalde/repos/discopt/.venv/bin:$PATH" make test PYTHON=.venv/bin/python PYTEST=".venv/bin/python -m pytest" MATURIN=".venv/bin/python -m maturin" RUFF=".venv/bin/python -m ruff"`
  - Result: `2242 passed, 59 skipped, 637 deselected, 2 xfailed, 11 warnings in 517.85s (0:08:37)`
- `.venv/bin/python -m ruff check python/`
  - Result: `All checks passed!`
- `.venv/bin/python -m ruff format --check python/`
  - Result: `249 files already formatted`
- `.venv/bin/python -m mypy python/discopt/`
  - Result: `Success: no issues found in 152 source files`

## Notes about tests not run

- Did not run `make test-all`, `make test-slow`, or `make test-correctness`; this change only retargets the PR-fast correctness subset, and the documented PR-fast suite passed locally.

Closes #43
