### PR TITLE
Fix sqrt_nlp expected optimum

### DIFF
--- a/python/tests/test_correctness.py
+++ b/python/tests/test_correctness.py
@@ -232,10 +232,12 @@ def _build_log_nlp() -> Model:
 def _build_sqrt_nlp() -> Model:
     """min sqrt(x+1) + sqrt(y+1) s.t. x+y>=2, x,y in [0,5].
 
-    sqrt is concave and increasing. On x+y=2:
+    sqrt is concave and increasing, so the minimum occurs on the active
+    constraint at a boundary point. On x+y=2:
     f(x) = sqrt(x+1) + sqrt(3-x). f'(x) = 1/(2*sqrt(x+1)) - 1/(2*sqrt(3-x)) = 0
     => sqrt(3-x) = sqrt(x+1) => 3-x = x+1 => x=1, y=1.
-    obj = sqrt(2) + sqrt(2) = 2*sqrt(2) ~= 2.8284.
+    Since f is concave, that stationary point is the maximum. The minima are
+    at (x, y) = (0, 2) and (2, 0), with obj = 1 + sqrt(3) ~= 2.7321.
     """
     m = dm.Model("sqrt_nlp")
     x = m.continuous("x", lb=0, ub=5)
@@ -562,7 +564,7 @@ INSTANCES: list[ProblemInstance] = [
     ProblemInstance(
         name="sqrt_nlp",
         build_fn=_build_sqrt_nlp,
-        expected_obj=2.0 * math.sqrt(2.0),
+        expected_obj=1.0 + math.sqrt(3.0),
         integer_vars=[],
         bounds={"x": (0, 5), "y": (0, 5)},
         description="min sqrt(x+1)+sqrt(y+1) s.t. x+y>=2",


### PR DESCRIPTION
## Summary

- Correct the analytical expected objective for `sqrt_nlp` in the known-optima correctness suite.
- The stationary point `(1, 1)` gives `2 * sqrt(2)`, but because the objective is concave on the active line `x + y = 2`, that point is the maximum, not the minimum.
- The minimum is at `(0, 2)` or `(2, 0)`, with objective `1 + sqrt(3) ~= 2.73205081`, matching the solver result reported in #55.

## Tests run

- `/home/bernalde/.pixi/bin/pixi exec --no-progress -s python=3.12 -s ipopt -s pkg-config -s c-compiler -s cxx-compiler -s gfortran -- uv venv --allow-existing .venv`
  - Result: created/refreshed `.venv`.
- `/home/bernalde/.pixi/bin/pixi exec --no-progress -s python=3.12 -s ipopt -s pkg-config -s c-compiler -s cxx-compiler -s gfortran -- uv pip install maturin pytest pytest-timeout numpy scipy jax jaxlib highspy cyipopt "ruff==0.14.6" mypy pytest-cov`
  - Result: dependencies audited/available.
- `/home/bernalde/.pixi/bin/pixi exec --no-progress -s python=3.12 -s ipopt -s pkg-config -s c-compiler -s cxx-compiler -s gfortran -- uv pip install -e ".[dev,ipopt,highs]"`
  - Result: editable install succeeded.
- `/home/bernalde/.pixi/bin/pixi exec --no-progress -s python=3.12 -s ipopt -s pkg-config -s c-compiler -s cxx-compiler -s gfortran -- env -u CONDA_PREFIX VIRTUAL_ENV=/home/bernalde/repos/discopt/.venv .venv/bin/python -m maturin develop`
  - Result: Rust extension built and installed into `.venv`.
- `/home/bernalde/.pixi/bin/pixi exec --no-progress -s python=3.12 -s ipopt -s pkg-config -- env -u CONDA_PREFIX VIRTUAL_ENV=/home/bernalde/repos/discopt/.venv JAX_PLATFORMS=cpu JAX_ENABLE_X64=1 .venv/bin/python -m pytest 'python/tests/test_correctness.py::TestObjectiveCorrectness::test_optimal_value[sqrt_nlp]' -q --tb=short --timeout=120 --durations=10`
  - Result: `1 passed in 91.32s`.
- `/home/bernalde/.pixi/bin/pixi exec --no-progress -s python=3.12 -s ipopt -s pkg-config -s c-compiler -s cxx-compiler -s gfortran -- env -u CONDA_PREFIX VIRTUAL_ENV=/home/bernalde/repos/discopt/.venv JAX_PLATFORMS=cpu JAX_ENABLE_X64=1 make test-correctness PYTHON=.venv/bin/python PYTEST=.venv/bin/python\ -m\ pytest MATURIN=.venv/bin/python\ -m\ maturin RUFF=.venv/bin/python\ -m\ ruff`
  - Result: `80 passed, 3 failed in 2300.23s (0:38:20)`.
  - Failures: `TestContinuousNLP::test_nonlinear_equality_solution_point`, `TestConstraintSatisfaction::test_nonlinear_equality_satisfied`, and `TestCorrectnessGate::test_zero_incorrect_results`, all due to pytest-timeout after 300s during JAX compilation in the nonlinear equality path. The targeted `sqrt_nlp` case passed.
- `/home/bernalde/.pixi/bin/pixi exec --no-progress -s python=3.12 -s ipopt -s pkg-config -- env -u CONDA_PREFIX VIRTUAL_ENV=/home/bernalde/repos/discopt/.venv make lint PYTHON=.venv/bin/python RUFF=.venv/bin/python\ -m\ ruff`
  - Result: passed (`ruff check python/`; `ruff format --check python/`).
- `/home/bernalde/.pixi/bin/pixi exec --no-progress -s python=3.12 -s ipopt -s pkg-config -- env -u CONDA_PREFIX VIRTUAL_ENV=/home/bernalde/repos/discopt/.venv .venv/bin/python -m mypy python/discopt/`
  - Result: passed (`Success: no issues found in 152 source files`).
- `/home/bernalde/.pixi/bin/pixi exec --no-progress -s python=3.12 -s ipopt -s pkg-config -s c-compiler -s cxx-compiler -s gfortran -- env -u CONDA_PREFIX VIRTUAL_ENV=/home/bernalde/repos/discopt/.venv JAX_PLATFORMS=cpu JAX_ENABLE_X64=1 make test PYTHON=.venv/bin/python PYTEST=.venv/bin/python\ -m\ pytest MATURIN=.venv/bin/python\ -m\ maturin RUFF=.venv/bin/python\ -m\ ruff`
  - Result: passed (`2242 passed, 59 skipped, 637 deselected, 2 xfailed, 11 warnings in 523.30s`).
- `cargo build -p discopt-core`
  - Result: passed.
- `cargo test -p discopt-core`
  - Result: passed (`158 passed`; doc-tests `1 passed`).
- `cargo clippy -p discopt-core -- -D warnings`
  - Result: passed.

## Notes

- `origin/main` was synced before starting. The PR branch is based on `origin/amp` because the requested PR target is `amp` and `origin/main`/`origin/amp` are substantially divergent.
- The local Alpine checkout was checked for sqrt-related references; it contains a different concave-boundary sqrt case, not this exact `sqrt_nlp` formulation.
- Pre-existing untracked local files `.codex`, `plans/`, and `uv.lock` were left untouched and are not part of this PR.

Closes #55
