### PR TITLE
Fix AMP fast test split

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,12 +28,15 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"
+      - name: Install system dependencies (Ipopt)
+        run: |
+          sudo apt-get update && sudo apt-get install -y coinor-libipopt-dev liblapack-dev libblas-dev gfortran
       - name: Install Python dependencies
         run: |
           python -m venv .venv
           source .venv/bin/activate
           pip install maturin
-          pip install jax jaxlib numpy scipy highspy pytest pytest-timeout "ruff==0.14.6" mypy
+          pip install jax jaxlib numpy scipy highspy cyipopt pytest pytest-timeout "ruff==0.14.6" mypy
           maturin develop
       - name: Lint
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,15 +28,12 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"
-      - name: Install system dependencies (Ipopt)
-        run: |
-          sudo apt-get update && sudo apt-get install -y coinor-libipopt-dev liblapack-dev libblas-dev gfortran
       - name: Install Python dependencies
         run: |
           python -m venv .venv
           source .venv/bin/activate
           pip install maturin
-          pip install jax jaxlib numpy scipy highspy cyipopt pytest pytest-timeout "ruff==0.14.6" mypy
+          pip install jax jaxlib numpy scipy highspy pytest pytest-timeout "ruff==0.14.6" mypy
           maturin develop
       - name: Lint
         run: |
@@ -47,11 +44,11 @@ jobs:
         run: |
           source .venv/bin/activate
           mypy python/discopt/
-      - name: Test with coverage (PR-fast, matches `make test`, excludes slow + correctness)
+      - name: Test with coverage (PR-fast, matches `make test`)
         run: |
           source .venv/bin/activate
           pip install pytest-cov
-          pytest python/tests/ -v --timeout=120 -m "not slow and not correctness and not integration and not amp_benchmark" --ignore=python/tests/test_correctness.py --cov=discopt --cov-report=term-missing --cov-report=xml:coverage.xml
+          pytest python/tests/ -v --timeout=120 -m "not slow and not correctness and not integration and not amp_benchmark and not requires_cyipopt" --ignore=python/tests/test_correctness.py --cov=discopt --cov-report=term-missing --cov-report=xml:coverage.xml
         env:
           JAX_PLATFORMS: cpu
           JAX_ENABLE_X64: "1"
@@ -72,20 +69,17 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"
-      - name: Install system dependencies (Ipopt)
-        run: |
-          sudo apt-get update && sudo apt-get install -y coinor-libipopt-dev liblapack-dev libblas-dev gfortran
       - name: Install Python dependencies
         run: |
           python -m venv .venv
           source .venv/bin/activate
           pip install maturin
-          pip install jax jaxlib numpy scipy highspy cyipopt pytest pytest-timeout pytest-cov "ruff==0.14.6"
+          pip install jax jaxlib numpy scipy highspy pytest pytest-timeout pytest-cov "ruff==0.14.6"
           maturin develop
       - name: Test AMP fast battery with coverage
         run: |
           source .venv/bin/activate
-          pytest python/tests/test_amp.py -v --timeout=120 --cov=discopt --cov-report=term-missing --cov-report=xml:coverage-amp.xml
+          pytest python/tests/test_amp.py -v --timeout=120 -m "not slow and not integration and not amp_benchmark and not requires_cyipopt" --cov=discopt --cov-report=term-missing --cov-report=xml:coverage-amp.xml
         env:
           JAX_PLATFORMS: cpu
           JAX_ENABLE_X64: "1"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,8 +37,8 @@ Prefer the Make targets — they pin flags consistent with CI.
 # Rust tests
 cargo test -p discopt-core
 
-# PR-fast (matches CI; excludes slow/correctness/integration/manual markers,
-# includes pr_correctness; target <10 min).
+# PR-fast (matches CI; excludes slow/correctness/integration/manual/cyipopt
+# markers, includes pr_correctness; target <10 min).
 make test
 
 # Dev inner loop: unit + smoke markers only (~60 s).
@@ -73,6 +73,7 @@ pytest python/tests/ --cov=discopt
 | `pr_correctness` | Curated 5-instance correctness subset; <30 s total | yes |
 | `integration` | End-to-end workflows (DOE, discrimination, CUTEst) | nightly / manual |
 | `amp_benchmark` | AMP Alpine, MINLPTests, or incidence benchmark coverage | manual |
+| `requires_cyipopt` | Requires the optional cyipopt/Ipopt solver stack | manual |
 
 When adding a test, default to no marker for normal feature tests; add
 `slow` if it routinely costs more than ~3 s, and `unit` or `smoke` if it

--- a/Makefile
+++ b/Makefile
@@ -175,7 +175,8 @@ hooks:
 #
 # Tiers (issue #68):
 #   test          - PR-fast: matches CI python-fast job. Excludes `slow`,
-#                   `correctness`, `integration`, and `amp_benchmark` while
+#                   `correctness`, `integration`, `amp_benchmark`, and
+#                   `requires_cyipopt` while
 #                   keeping the curated `pr_correctness` subset. Target <10 min.
 #   test-all      - everything, including slow + correctness. Target ~20 min.
 #   test-quick    - unit + smoke only, dev inner loop. Target <60 s.
@@ -187,10 +188,12 @@ hooks:
 # These exclusions keep the PR gate focused on ordinary feature tests plus the
 # curated `pr_correctness` subset. Full correctness, integration, and benchmark
 # coverage stay available through the explicit targets below.
-PYTEST_FAST_FLAGS := --timeout=120 -m "not slow and not correctness and not integration and not amp_benchmark" \
+PYTEST_FAST_FLAGS := --timeout=120 -m "not slow and not correctness and not integration and not amp_benchmark and not requires_cyipopt" \
     --ignore=python/tests/test_correctness.py
 
-PYTEST_QUICK_FLAGS := --timeout=60 -m "(unit or smoke) and not slow and not integration and not amp_benchmark"
+PYTEST_QUICK_FLAGS := --timeout=60 -m "(unit or smoke) and not slow and not integration and not amp_benchmark and not requires_cyipopt"
+
+PYTEST_AMP_FAST_FLAGS := --timeout=120 -m "not slow and not integration and not amp_benchmark and not requires_cyipopt"
 
 # File groups for slice targets. A test file may appear in more than one group.
 TEST_MODELING := \
@@ -331,12 +334,12 @@ test-amp: build
 
 test-amp-fast: build
 	@echo "==> Running fast AMP regression tests..."
-	$(PYTEST) python/tests/test_amp.py -v --tb=short -q
+	$(PYTEST) python/tests/test_amp.py -v --tb=short -q $(PYTEST_AMP_FAST_FLAGS)
 	@echo "==> Fast AMP tests passed"
 
 test-amp-integration: build
 	@echo "==> Running opt-in AMP Alpine/incidence tests..."
-	$(PYTEST) python/tests/test_amp_integration.py -v --tb=short -q -m "slow or integration or amp_benchmark"
+	$(PYTEST) python/tests/test_amp_integration.py -v --tb=short -q -m "slow or integration or amp_benchmark or requires_cyipopt"
 	@echo "==> AMP integration tests passed"
 
 test-nn: build

--- a/README.md
+++ b/README.md
@@ -134,15 +134,16 @@ remain available through the explicit Make targets.
 ### AMP Test Suites
 
 Routine AMP development uses a fast default regression battery. The fast
-environment includes HiGHS and cyipopt, but excludes the longer Alpine,
-MINLPTests, and incidence-style AMP benchmark suite:
+environment uses solver-independent checks plus HiGHS-backed MILP relaxations,
+and excludes optional cyipopt, longer Alpine, MINLPTests, and incidence-style
+AMP benchmark coverage:
 
 ```bash
 make test-amp-fast
 ```
 
-Alpine-reference, MINLPTests, and incidence-style AMP checks are opt-in because
-they can require optional solvers and longer solve budgets:
+Alpine-reference, MINLPTests, cyipopt, and incidence-style AMP checks are
+opt-in because they can require optional solvers and longer solve budgets:
 
 ```bash
 # Uses a fresh .venv and pixi-provided solver libraries rather than a local Python env.

--- a/python/tests/test_amp.py
+++ b/python/tests/test_amp.py
@@ -66,6 +66,7 @@ def test_amp_integration_suite_is_opt_in():
     assert "pytest.mark.slow" in text
     assert "pytest.mark.integration" in text
     assert "pytest.mark.amp_benchmark" in text
+    assert "pytest.mark.requires_cyipopt" in text
 
 
 def _make_dry_run(target: str) -> str:
@@ -92,37 +93,30 @@ def test_quick_test_tier_excludes_amp_integration_markers():
     """The quick tier must not select opt-in AMP smoke tests."""
     output = _make_dry_run("test-quick")
 
-    assert '-m "(unit or smoke) and not slow and not integration and not amp_benchmark"' in output
+    assert (
+        '-m "(unit or smoke) and not slow and not integration '
+        'and not amp_benchmark and not requires_cyipopt"'
+    ) in output
 
 
 def test_pr_fast_tier_excludes_heavy_manual_markers():
     """The PR-fast tier should keep nightly/manual markers out of make test."""
     output = _make_dry_run("test")
 
-    assert '-m "not slow and not correctness and not integration and not amp_benchmark"' in output
+    assert (
+        '-m "not slow and not correctness and not integration '
+        'and not amp_benchmark and not requires_cyipopt"'
+    ) in output
     assert "--ignore=python/tests/test_correctness.py" in output
 
 
-@pytest.mark.requires_cyipopt
-def test_fast_amp_environment_includes_working_cyipopt():
-    """The fast AMP/CI environment should include a usable Ipopt Python backend."""
-    import cyipopt  # noqa: F401
-    from discopt.solvers import SolveStatus
-    from discopt.solvers.nlp_ipopt import solve_nlp_from_model
+def test_amp_fast_tier_excludes_optional_solver_markers():
+    """The local AMP fast target should not require optional NLP solver stacks."""
+    output = _make_dry_run("test-amp-fast")
 
-    m = Model("cyipopt_fast_smoke")
-    x = m.continuous("x", lb=-2.0, ub=2.0)
-    m.minimize((x - 0.25) ** 2)
-
-    result = solve_nlp_from_model(
-        m,
-        x0=np.array([1.5], dtype=np.float64),
-        options={"print_level": 0, "max_iter": 50},
-    )
-
-    assert result.status == SolveStatus.OPTIMAL
-    assert result.objective == pytest.approx(0.0, abs=1e-7)
-    assert float(result.x[0]) == pytest.approx(0.25, abs=1e-5)
+    assert (
+        '-m "not slow and not integration and not amp_benchmark and not requires_cyipopt"'
+    ) in output
 
 
 def test_amp_helper_defaults_cover_semifinite_domains():

--- a/python/tests/test_amp_integration.py
+++ b/python/tests/test_amp_integration.py
@@ -67,6 +67,32 @@ MINLPTESTS_NLP_BY_ID = {
     instance.problem_id: instance for instance in map(_unwrap_minlptests_case, NLP_INSTANCES)
 }
 
+
+@pytest.mark.requires_cyipopt
+def test_amp_integration_environment_includes_working_cyipopt():
+    """The opt-in AMP integration environment should include a usable Ipopt backend."""
+    if not HAS_CYIPOPT:
+        pytest.skip("requires cyipopt/Ipopt")
+
+    import cyipopt  # noqa: F401
+    from discopt.solvers import SolveStatus
+    from discopt.solvers.nlp_ipopt import solve_nlp_from_model
+
+    m = Model("cyipopt_integration_smoke")
+    x = m.continuous("x", lb=-2.0, ub=2.0)
+    m.minimize((x - 0.25) ** 2)
+
+    result = solve_nlp_from_model(
+        m,
+        x0=np.array([1.5], dtype=np.float64),
+        options={"print_level": 0, "max_iter": 50},
+    )
+
+    assert result.status == SolveStatus.OPTIMAL
+    assert result.objective == pytest.approx(0.0, abs=1e-7)
+    assert float(result.x[0]) == pytest.approx(0.25, abs=1e-5)
+
+
 # ---------------------------------------------------------------------------
 # Shared helpers / problem builders
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Exclude `requires_cyipopt` from the default PR-fast, quick, and AMP-fast marker selections.
- Move the AMP cyipopt smoke check from `python/tests/test_amp.py` into the opt-in AMP integration suite.
- Update CI and docs so the fast AMP battery is solver-independent while Alpine, MINLPTests, incidence, and cyipopt coverage stay explicit.

## Tests run

- `/home/bernalde/.pixi/bin/pixi exec -s python=3.12 -s ipopt -s pkg-config -s c-compiler -s cxx-compiler -s gfortran -- /home/bernalde/.local/bin/uv venv --allow-existing .venv` - passed
- `/home/bernalde/.pixi/bin/pixi exec -s python=3.12 -s ipopt -s pkg-config -s c-compiler -s cxx-compiler -s gfortran -- /home/bernalde/.local/bin/uv pip install --python .venv/bin/python maturin pytest pytest-timeout pytest-cov numpy scipy jax jaxlib highspy cyipopt ruff==0.14.6 mypy` - passed
- `/home/bernalde/.pixi/bin/pixi exec -s python=3.12 -s ipopt -s pkg-config -s c-compiler -s cxx-compiler -s gfortran -- /home/bernalde/.local/bin/uv pip install --python .venv/bin/python -e .[dev,ipopt,highs]` - passed
- `/home/bernalde/.pixi/bin/pixi exec -s python=3.12 -s ipopt -s pkg-config -s c-compiler -s cxx-compiler -s gfortran -- .venv/bin/python -m maturin develop --release --uv` - passed
- `/home/bernalde/.pixi/bin/pixi exec -s python=3.12 -s ipopt -s pkg-config -s c-compiler -s cxx-compiler -s gfortran -- .venv/bin/python -m pytest python/tests/test_amp.py -q -k "test_amp_integration_suite_is_opt_in or test_quick_test_tier_excludes_amp_integration_markers or test_pr_fast_tier_excludes_heavy_manual_markers or test_amp_fast_tier_excludes_optional_solver_markers"` - 4 passed, 51 deselected
- `/home/bernalde/.pixi/bin/pixi exec -s python=3.12 -s ipopt -s pkg-config -s c-compiler -s cxx-compiler -s gfortran -- .venv/bin/python -m pytest python/tests/test_amp_integration.py::test_amp_integration_environment_includes_working_cyipopt -q` - 1 passed
- `/home/bernalde/.pixi/bin/pixi exec -s python=3.12 -s ipopt -s pkg-config -s c-compiler -s cxx-compiler -s gfortran -- make test-amp-fast PYTHON=.venv/bin/python PYTEST=".venv/bin/python -m pytest" MATURIN=".venv/bin/python -m maturin"` - 55 passed
- `/home/bernalde/.pixi/bin/pixi exec -s python=3.12 -s ipopt -s pkg-config -s c-compiler -s cxx-compiler -s gfortran -- make test PYTHON=.venv/bin/python PYTEST=".venv/bin/python -m pytest" MATURIN=".venv/bin/python -m maturin"` - 2242 passed, 59 skipped, 638 deselected, 2 xfailed
- `/home/bernalde/.pixi/bin/pixi exec -s python=3.12 -s ipopt -s pkg-config -s c-compiler -s cxx-compiler -s gfortran -- .venv/bin/python -m ruff check python/` - passed
- `/home/bernalde/.pixi/bin/pixi exec -s python=3.12 -s ipopt -s pkg-config -s c-compiler -s cxx-compiler -s gfortran -- .venv/bin/python -m ruff format --check python/` - 249 files already formatted
- `/home/bernalde/.pixi/bin/pixi exec -s python=3.12 -s ipopt -s pkg-config -s c-compiler -s cxx-compiler -s gfortran -- .venv/bin/python -m mypy python/discopt/` - success, no issues in 152 source files
- `cargo fmt --check` - passed
- `cargo test -p discopt-core` - 158 unit tests passed; 1 doctest passed
- `cargo clippy -p discopt-core -- -D warnings` - passed

## Notes about tests not run

- Did not run `make test-all`; it includes slow/correctness/manual coverage beyond the PR-fast gate.
- Did not run the full `make test-amp-integration`; the moved cyipopt integration smoke was run in the requested pixi/uv `.venv`, while the full target remains opt-in benchmark/incidence coverage.

Closes #38
