### PR TITLE
[codex] Enforce hard category benchmark timeouts

### DIFF
--- a/discopt_benchmarks/README.md
+++ b/discopt_benchmarks/README.md
@@ -85,6 +85,15 @@ result = model.solve(
 )
 ```
 
+Category benchmarks default to the NLP-BB backends (`ipm`, `ripopt`, `ipopt`).
+For an AMP-specific benchmark over the same problem categories, select AMP
+explicitly:
+
+```bash
+python run_category_benchmarks.py --category minlp --level smoke --solvers amp --time-limit 60 --report --html
+python run_category_benchmarks.py --category global_opt --level smoke --solvers amp --time-limit 60 --report --html
+```
+
 For local Alpine/incidence checks, use the repository's documented pixi plus uv
 `.venv` workflow before running `make test-amp-integration`; avoid reusing an
 uncontrolled local Python environment for those solver-dependent examples.

--- a/discopt_benchmarks/category_runner.py
+++ b/discopt_benchmarks/category_runner.py
@@ -6,10 +6,14 @@ validates correctness, and collects performance metrics.
 
 from __future__ import annotations
 
+import json
+import subprocess
 import sys
+import tempfile
 import time
 import traceback
 from datetime import datetime
+from pathlib import Path
 
 from benchmarks.metrics import (
     BenchmarkResults,
@@ -41,11 +45,15 @@ class CategoryBenchmarkRunner:
         level: str = "smoke",
         time_limit: float = 300.0,
         num_runs: int = 1,
+        hard_timeout_grace: float | None = 2.0,
     ):
         self.category = category
         self.level = level
         self.time_limit = time_limit
         self.num_runs = num_runs
+        self.hard_timeout_grace = (
+            None if hard_timeout_grace is None else max(0.0, float(hard_timeout_grace))
+        )
         self.results = BenchmarkResults(
             suite=f"{category}_{level}",
             timestamp=datetime.now().isoformat(),
@@ -56,10 +64,7 @@ class CategoryBenchmarkRunner:
         """Run all problems for the category against all solvers."""
         problems = get_problems(self.category, self.level)
         if not problems:
-            print(
-                f"No problems found for category={self.category} "
-                f"level={self.level}"
-            )
+            print(f"No problems found for category={self.category} level={self.level}")
             return self.results
 
         # Collect known optima
@@ -86,15 +91,11 @@ class CategoryBenchmarkRunner:
         solvers = get_applicable_solvers(self.category)
         total_runs = len(problems) * len(solvers)
         print(f"\n{'=' * 70}")
-        print(
-            f"Category Benchmark: {self.category.upper()} "
-            f"({self.level})"
-        )
-        print(
-            f"Problems: {len(problems)} | Solvers: {len(solvers)} "
-            f"| Total runs: {total_runs}"
-        )
+        print(f"Category Benchmark: {self.category.upper()} ({self.level})")
+        print(f"Problems: {len(problems)} | Solvers: {len(solvers)} | Total runs: {total_runs}")
         print(f"Time limit: {self.time_limit}s")
+        if self.hard_timeout_grace is not None:
+            print(f"Hard timeout grace: {self.hard_timeout_grace}s")
         print(f"{'=' * 70}\n")
 
         completed = 0
@@ -107,21 +108,9 @@ class CategoryBenchmarkRunner:
 
                 # Progress output
                 icon = self._status_icon(result)
-                t_str = (
-                    f"{result.wall_time:.3f}s"
-                    if result.wall_time < float("inf")
-                    else "TL"
-                )
-                obj_str = (
-                    f"obj={result.objective:.6g}"
-                    if result.objective is not None
-                    else ""
-                )
-                iter_str = (
-                    f"iter={result.iterations}"
-                    if result.iterations > 0
-                    else ""
-                )
+                t_str = f"{result.wall_time:.3f}s" if result.wall_time < float("inf") else "TL"
+                obj_str = f"obj={result.objective:.6g}" if result.objective is not None else ""
+                iter_str = f"iter={result.iterations}" if result.iterations > 0 else ""
                 parts = [
                     f"  {icon} {problem.name:30s}",
                     f"{solver:8s}",
@@ -138,17 +127,89 @@ class CategoryBenchmarkRunner:
         self._print_summary(problems)
         return self.results
 
-    def _run_one(
-        self, problem: TestProblem, solver: str
-    ) -> SolveResult:
+    def _run_one(self, problem: TestProblem, solver: str) -> SolveResult:
         """Run a single problem with a single solver."""
+        if self.hard_timeout_grace is not None:
+            return self._run_with_hard_timeout(problem, solver)
+        return self._run_one_direct(problem, solver)
+
+    def _run_one_direct(self, problem: TestProblem, solver: str) -> SolveResult:
+        """Run a single problem in the current process."""
         if solver == "highs":
             return self._run_highs(problem)
         return self._run_discopt(problem, solver)
 
-    def _run_discopt(
-        self, problem: TestProblem, solver: str
-    ) -> SolveResult:
+    def _run_with_hard_timeout(self, problem: TestProblem, solver: str) -> SolveResult:
+        """Run a case in a worker process and kill it at the hard timeout."""
+        solver_name = "highs" if solver == "highs" else f"discopt_{solver}"
+        timeout = max(0.0, self.time_limit) + (self.hard_timeout_grace or 0.0)
+
+        with tempfile.TemporaryDirectory(prefix="discopt_category_bench_") as tmp:
+            result_path = Path(tmp) / "result.json"
+            cmd = [
+                sys.executable,
+                str(Path(__file__).resolve()),
+                "--worker",
+                self.category,
+                self.level,
+                problem.name,
+                solver,
+                str(self.time_limit),
+                str(result_path),
+            ]
+            started = time.monotonic()
+            try:
+                proc = subprocess.run(
+                    cmd,
+                    capture_output=True,
+                    text=True,
+                    timeout=timeout,
+                )
+            except subprocess.TimeoutExpired:
+                return SolveResult(
+                    instance=problem.name,
+                    solver=solver_name,
+                    status=SolveStatus.TIME_LIMIT,
+                    wall_time=self.time_limit,
+                )
+
+            elapsed = time.monotonic() - started
+            if proc.returncode != 0 or not result_path.exists():
+                print(f"    ERROR ({solver}): {problem.name}: worker failed")
+                if "--verbose" in sys.argv:
+                    if proc.stdout:
+                        print(proc.stdout, end="")
+                    if proc.stderr:
+                        print(proc.stderr, end="", file=sys.stderr)
+                return SolveResult(
+                    instance=problem.name,
+                    solver=solver_name,
+                    status=SolveStatus.ERROR,
+                    wall_time=elapsed,
+                )
+
+            try:
+                result = SolveResult.from_dict(json.loads(result_path.read_text()))
+            except Exception as e:
+                print(f"    ERROR ({solver}): {problem.name}: invalid worker result: {e}")
+                return SolveResult(
+                    instance=problem.name,
+                    solver=solver_name,
+                    status=SolveStatus.ERROR,
+                    wall_time=elapsed,
+                )
+
+        if result.wall_time > self.time_limit:
+            result.wall_time = self.time_limit
+            if result.status == SolveStatus.OPTIMAL:
+                result.status = (
+                    SolveStatus.FEASIBLE if result.objective is not None else SolveStatus.TIME_LIMIT
+                )
+            elif result.status == SolveStatus.UNKNOWN:
+                result.status = SolveStatus.TIME_LIMIT
+        return result
+
+    def _run_discopt(self, problem: TestProblem, solver: str) -> SolveResult:
         """Run problem through discopt's model.solve()."""
         try:
             model = problem.build_fn()
@@ -170,9 +231,7 @@ class CategoryBenchmarkRunner:
                 "time_limit": SolveStatus.TIME_LIMIT,
                 "node_limit": SolveStatus.TIME_LIMIT,
             }
-            bench_status = status_map.get(
-                result.status, SolveStatus.UNKNOWN
-            )
+            bench_status = status_map.get(result.status, SolveStatus.UNKNOWN)
 
             return SolveResult(
                 instance=problem.name,
@@ -257,11 +316,7 @@ class CategoryBenchmarkRunner:
             else:
                 status = SolveStatus.ERROR
 
-            obj_val = (
-                float(lp_result.objective)
-                if lp_result.objective is not None
-                else None
-            )
+            obj_val = float(lp_result.objective) if lp_result.objective is not None else None
             if obj_val is not None:
                 obj_val += float(lp.obj_const)
 
@@ -271,9 +326,7 @@ class CategoryBenchmarkRunner:
                 status=status,
                 objective=obj_val,
                 wall_time=elapsed,
-                iterations=getattr(
-                    lp_result, "iterations", 0
-                ) or 0,
+                iterations=getattr(lp_result, "iterations", 0) or 0,
             )
         except Exception as e:
             print(f"    ERROR (highs): {problem.name}: {e}")
@@ -286,9 +339,7 @@ class CategoryBenchmarkRunner:
                 wall_time=float("inf"),
             )
 
-    def _validate(
-        self, result: SolveResult, problem: TestProblem
-    ) -> None:
+    def _validate(self, result: SolveResult, problem: TestProblem) -> None:
         """Check result against expected status and known optimum."""
         # Check expected status
         if problem.expected_status == "infeasible":
@@ -296,20 +347,14 @@ class CategoryBenchmarkRunner:
                 SolveStatus.INFEASIBLE,
                 SolveStatus.ERROR,
             ):
-                print(
-                    f"    WARN: {problem.name} expected infeasible, "
-                    f"got {result.status.value}"
-                )
+                print(f"    WARN: {problem.name} expected infeasible, got {result.status.value}")
             return
         if problem.expected_status == "unbounded":
             if result.status not in (
                 SolveStatus.UNBOUNDED,
                 SolveStatus.ERROR,
             ):
-                print(
-                    f"    WARN: {problem.name} expected unbounded, "
-                    f"got {result.status.value}"
-                )
+                print(f"    WARN: {problem.name} expected unbounded, got {result.status.value}")
             return
 
         # Check objective correctness
@@ -351,41 +396,24 @@ class CategoryBenchmarkRunner:
         n_inst = len(problems)
 
         print(f"\n{'=' * 70}")
-        print(
-            f"Summary: {self.category.upper()} ({self.level}) "
-            f"— {n_inst} problems"
-        )
+        print(f"Summary: {self.category.upper()} ({self.level}) — {n_inst} problems")
         print(f"{'=' * 70}")
         print(
-            f"{'Solver':<18s} {'Solved':>8s} "
-            f"{'Incorrect':>10s} {'SGM(s)':>10s} "
-            f"{'Med Iter':>10s}"
+            f"{'Solver':<18s} {'Solved':>8s} {'Incorrect':>10s} {'SGM(s)':>10s} {'Med Iter':>10s}"
         )
         print("-" * 60)
 
         for solver in solvers:
             solver_results = self.results.get_results(solver)
             n_solved = solved_count(solver_results)
-            n_incorrect = incorrect_count(
-                solver_results, self._known_optima
-            )
-            times = [
-                r.wall_time
-                for r in solver_results
-                if r.is_solved
-            ]
+            n_incorrect = incorrect_count(solver_results, self._known_optima)
+            times = [r.wall_time for r in solver_results if r.is_solved]
             sgm = shifted_geometric_mean(times)
             istats = iteration_stats(solver_results)
             med_iter = istats["median"]
 
-            sgm_str = (
-                f"{sgm:.3f}" if sgm < 1e6 else "inf"
-            )
-            iter_str = (
-                f"{med_iter:.0f}"
-                if med_iter == med_iter
-                else "N/A"
-            )
+            sgm_str = f"{sgm:.3f}" if sgm < 1e6 else "inf"
+            iter_str = f"{med_iter:.0f}" if med_iter == med_iter else "N/A"
 
             print(
                 f"{solver:<18s} {n_solved:>3d}/{n_inst:<4d}"
@@ -398,3 +426,37 @@ class CategoryBenchmarkRunner:
     def get_known_optima(self) -> dict[str, float]:
         """Return the known optima dict."""
         return dict(self._known_optima)
+
+
+def _run_worker(argv: list[str]) -> int:
+    """Worker entry point used by subprocess-backed hard timeouts."""
+    if len(argv) != 6:
+        print(
+            "usage: category_runner.py --worker "
+            "<category> <level> <problem> <solver> <time_limit> <result_path>",
+            file=sys.stderr,
+        )
+        return 2
+
+    category, level, problem_name, solver, time_limit_s, result_path_s = argv
+    problems = get_problems(category, level)
+    problem = next((p for p in problems if p.name == problem_name), None)
+    if problem is None:
+        print(f"unknown problem {problem_name!r} for {category}/{level}", file=sys.stderr)
+        return 2
+
+    runner = CategoryBenchmarkRunner(
+        category=category,
+        level=level,
+        time_limit=float(time_limit_s),
+        hard_timeout_grace=None,
+    )
+    result = runner._run_one_direct(problem, solver)
+    Path(result_path_s).write_text(json.dumps(result.to_dict()), encoding="utf-8")
+    return 0
+
+
+if __name__ == "__main__":
+    if len(sys.argv) > 1 and sys.argv[1] == "--worker":
+        raise SystemExit(_run_worker(sys.argv[2:]))
+    raise SystemExit("category_runner.py is an internal module; use run_category_benchmarks.py")

--- a/discopt_benchmarks/category_runner.py
+++ b/discopt_benchmarks/category_runner.py
@@ -161,6 +161,12 @@ class CategoryBenchmarkRunner:
         solver_name = "highs" if solver == "highs" else f"discopt_{solver}"
         timeout = max(0.0, self.time_limit) + (self.hard_timeout_grace or 0.0)
 
+        def print_worker_output(proc: subprocess.CompletedProcess[str]) -> None:
+            if proc.stdout:
+                print(proc.stdout, end="")
+            if proc.stderr:
+                print(proc.stderr, end="", file=sys.stderr)
+
         with tempfile.TemporaryDirectory(prefix="discopt_category_bench_") as tmp:
             result_path = Path(tmp) / "result.json"
             cmd = [
@@ -194,10 +200,7 @@ class CategoryBenchmarkRunner:
             if proc.returncode != 0 or not result_path.exists():
                 print(f"    ERROR ({solver}): {problem.name}: worker failed")
                 if "--verbose" in sys.argv:
-                    if proc.stdout:
-                        print(proc.stdout, end="")
-                    if proc.stderr:
-                        print(proc.stderr, end="", file=sys.stderr)
+                    print_worker_output(proc)
                 return SolveResult(
                     instance=problem.name,
                     solver=solver_name,
@@ -218,12 +221,17 @@ class CategoryBenchmarkRunner:
 
         if result.wall_time > self.time_limit:
             result.wall_time = self.time_limit
-            if result.status == SolveStatus.OPTIMAL:
-                result.status = (
-                    SolveStatus.FEASIBLE if result.objective is not None else SolveStatus.TIME_LIMIT
-                )
-            elif result.status == SolveStatus.UNKNOWN:
+            if result.status == SolveStatus.OPTIMAL and result.objective is not None:
+                result.status = SolveStatus.FEASIBLE
+            elif result.status in {
+                SolveStatus.OPTIMAL,
+                SolveStatus.INFEASIBLE,
+                SolveStatus.UNBOUNDED,
+                SolveStatus.UNKNOWN,
+            }:
                 result.status = SolveStatus.TIME_LIMIT
+        if result.status == SolveStatus.ERROR and "--verbose" in sys.argv:
+            print_worker_output(proc)
         return result
 
     def _run_discopt(self, problem: TestProblem, solver: str) -> SolveResult:

--- a/discopt_benchmarks/category_runner.py
+++ b/discopt_benchmarks/category_runner.py
@@ -27,7 +27,6 @@ from benchmarks.metrics import (
 )
 from benchmarks.problems.base import (
     TestProblem,
-    get_applicable_solvers,
     get_problems,
 )
 
@@ -46,6 +45,7 @@ class CategoryBenchmarkRunner:
         time_limit: float = 300.0,
         num_runs: int = 1,
         hard_timeout_grace: float | None = 2.0,
+        solver_filter: list[str] | None = None,
     ):
         self.category = category
         self.level = level
@@ -54,6 +54,7 @@ class CategoryBenchmarkRunner:
         self.hard_timeout_grace = (
             None if hard_timeout_grace is None else max(0.0, float(hard_timeout_grace))
         )
+        self.solver_filter = list(solver_filter) if solver_filter is not None else None
         self.results = BenchmarkResults(
             suite=f"{category}_{level}",
             timestamp=datetime.now().isoformat(),
@@ -88,19 +89,24 @@ class CategoryBenchmarkRunner:
             )
 
         # Header
-        solvers = get_applicable_solvers(self.category)
-        total_runs = len(problems) * len(solvers)
+        problem_solvers = {p.name: self._solvers_for_problem(p) for p in problems}
+        solvers = list(dict.fromkeys(s for slist in problem_solvers.values() for s in slist))
+        total_runs = sum(len(slist) for slist in problem_solvers.values())
         print(f"\n{'=' * 70}")
         print(f"Category Benchmark: {self.category.upper()} ({self.level})")
-        print(f"Problems: {len(problems)} | Solvers: {len(solvers)} | Total runs: {total_runs}")
+        solver_label = ", ".join(solvers) if solvers else "none"
+        print(f"Problems: {len(problems)} | Solvers: {solver_label} | Total runs: {total_runs}")
         print(f"Time limit: {self.time_limit}s")
         if self.hard_timeout_grace is not None:
             print(f"Hard timeout grace: {self.hard_timeout_grace}s")
         print(f"{'=' * 70}\n")
+        if total_runs == 0:
+            print("No applicable solvers selected for this category.")
+            return self.results
 
         completed = 0
         for problem in problems:
-            for solver in problem.applicable_solvers:
+            for solver in problem_solvers[problem.name]:
                 result = self._run_one(problem, solver)
                 self._validate(result, problem)
                 self.results.add_result(result)
@@ -126,6 +132,17 @@ class CategoryBenchmarkRunner:
         # Summary
         self._print_summary(problems)
         return self.results
+
+    def _solvers_for_problem(self, problem: TestProblem) -> list[str]:
+        """Return solvers to run for a problem, honoring explicit filters."""
+        if self.solver_filter is None:
+            return list(problem.applicable_solvers)
+
+        selected = []
+        for solver in self.solver_filter:
+            if solver == "amp" or solver in problem.applicable_solvers:
+                selected.append(solver)
+        return selected
 
     def _run_one(self, problem: TestProblem, solver: str) -> SolveResult:
         """Run a single problem with a single solver."""
@@ -214,12 +231,19 @@ class CategoryBenchmarkRunner:
         try:
             model = problem.build_fn()
             start = time.monotonic()
-            result = model.solve(
-                nlp_solver=solver,
-                time_limit=self.time_limit,
-                gap_tolerance=1e-4,
-                max_nodes=100_000,
-            )
+            if solver == "amp":
+                result = model.solve(
+                    solver="amp",
+                    time_limit=self.time_limit,
+                    gap_tolerance=1e-4,
+                )
+            else:
+                result = model.solve(
+                    nlp_solver=solver,
+                    time_limit=self.time_limit,
+                    gap_tolerance=1e-4,
+                    max_nodes=100_000,
+                )
             elapsed = time.monotonic() - start
 
             # Map status

--- a/discopt_benchmarks/run_category_benchmarks.py
+++ b/discopt_benchmarks/run_category_benchmarks.py
@@ -37,11 +37,7 @@ def main():
         "--category",
         type=str,
         default="lp",
-        help=(
-            "Category to benchmark: "
-            "lp|qp|milp|miqp|minlp|global_opt|all "
-            "(default: lp)"
-        ),
+        help=("Category to benchmark: lp|qp|milp|miqp|minlp|global_opt|all (default: lp)"),
     )
     parser.add_argument(
         "--level",
@@ -73,6 +69,20 @@ def main():
         help="Per-problem time limit in seconds (default: 300)",
     )
     parser.add_argument(
+        "--hard-timeout-grace",
+        type=float,
+        default=2.0,
+        help=(
+            "Extra seconds before forcibly killing a per-problem worker "
+            "after --time-limit (default: 2)"
+        ),
+    )
+    parser.add_argument(
+        "--no-hard-timeout",
+        action="store_true",
+        help="Run category cases in-process without subprocess hard timeouts",
+    )
+    parser.add_argument(
         "--list",
         action="store_true",
         help="List available categories",
@@ -89,20 +99,13 @@ def main():
         _list_categories()
         return
 
-    categories = (
-        get_all_categories()
-        if args.category == "all"
-        else [args.category]
-    )
+    categories = get_all_categories() if args.category == "all" else [args.category]
 
     # Validate categories
     valid = set(get_all_categories())
     for cat in categories:
         if cat not in valid:
-            print(
-                f"ERROR: Unknown category '{cat}'. "
-                f"Valid: {', '.join(sorted(valid))}"
-            )
+            print(f"ERROR: Unknown category '{cat}'. Valid: {', '.join(sorted(valid))}")
             sys.exit(1)
 
     # Run each category
@@ -115,6 +118,7 @@ def main():
             args.output,
             args.report,
             args.html,
+            None if args.no_hard_timeout else args.hard_timeout_grace,
         )
         all_results.append((cat, results))
 
@@ -147,6 +151,7 @@ def _run_category(
     output_dir: str | None,
     generate_report: bool,
     generate_html: bool,
+    hard_timeout_grace: float | None,
 ):
     """Run benchmarks for a single category."""
     from category_runner import CategoryBenchmarkRunner
@@ -155,6 +160,7 @@ def _run_category(
         category=category,
         level=level,
         time_limit=time_limit,
+        hard_timeout_grace=hard_timeout_grace,
     )
     results = runner.run()
 
@@ -220,20 +226,14 @@ def _print_combined_summary(
     print(f"Combined Summary — All Categories ({level})")
     print(f"{'=' * 70}")
 
-    print(
-        f"{'Category':<12s} {'Solver':<18s} "
-        f"{'Solved':>8s} {'Incorrect':>10s} "
-        f"{'SGM(s)':>10s}"
-    )
+    print(f"{'Category':<12s} {'Solver':<18s} {'Solved':>8s} {'Incorrect':>10s} {'SGM(s)':>10s}")
     print("-" * 62)
 
     total_incorrect = 0
     for cat, results in all_results:
         for solver in sorted(results.get_solvers()):
             solver_results = results.get_results(solver)
-            n_inst = len(
-                {r.instance for r in solver_results}
-            )
+            n_inst = len({r.instance for r in solver_results})
             n_solved = solved_count(solver_results)
 
             # Build known optima from instance_info
@@ -245,29 +245,19 @@ def _print_combined_summary(
             n_inc = incorrect_count(solver_results, known)
             total_incorrect += n_inc
 
-            times = [
-                r.wall_time
-                for r in solver_results
-                if r.is_solved
-            ]
+            times = [r.wall_time for r in solver_results if r.is_solved]
             sgm = shifted_geometric_mean(times)
-            sgm_str = (
-                f"{sgm:.3f}" if sgm < 1e6 else "inf"
-            )
+            sgm_str = f"{sgm:.3f}" if sgm < 1e6 else "inf"
 
             print(
-                f"{cat:<12s} {solver:<18s} "
-                f"{n_solved:>3d}/{n_inst:<4d}"
-                f" {n_inc:>10d} {sgm_str:>10s}"
+                f"{cat:<12s} {solver:<18s} {n_solved:>3d}/{n_inst:<4d} {n_inc:>10d} {sgm_str:>10s}"
             )
 
     print("-" * 62)
     if total_incorrect == 0:
         print("All results correct (0 incorrect total)")
     else:
-        print(
-            f"WARNING: {total_incorrect} incorrect result(s)!"
-        )
+        print(f"WARNING: {total_incorrect} incorrect result(s)!")
 
 
 if __name__ == "__main__":

--- a/discopt_benchmarks/run_category_benchmarks.py
+++ b/discopt_benchmarks/run_category_benchmarks.py
@@ -69,6 +69,15 @@ def main():
         help="Per-problem time limit in seconds (default: 300)",
     )
     parser.add_argument(
+        "--solvers",
+        type=str,
+        default=None,
+        help=(
+            "Comma-separated solver filter. Supports ipm,ripopt,ipopt,highs,amp. "
+            "Use --solvers amp for AMP-specific category benchmarks."
+        ),
+    )
+    parser.add_argument(
         "--hard-timeout-grace",
         type=float,
         default=2.0,
@@ -99,6 +108,7 @@ def main():
         _list_categories()
         return
 
+    solver_filter = _parse_solver_filter(args.solvers)
     categories = get_all_categories() if args.category == "all" else [args.category]
 
     # Validate categories
@@ -119,6 +129,7 @@ def main():
             args.report,
             args.html,
             None if args.no_hard_timeout else args.hard_timeout_grace,
+            solver_filter,
         )
         all_results.append((cat, results))
 
@@ -134,14 +145,30 @@ def _list_categories():
         "qp": "Quadratic programming (QP) — ipm, ripopt, ipopt",
         "milp": "Mixed-integer LP (MILP) — ipm, ripopt, ipopt",
         "miqp": "Mixed-integer QP (MIQP) — ipm, ripopt, ipopt",
-        "minlp": "Mixed-integer NLP (MINLP) — ipm, ripopt, ipopt",
-        "global_opt": "Global optimization — ipm, ripopt, ipopt",
+        "minlp": "Mixed-integer NLP (MINLP) — ipm, ripopt, ipopt; use --solvers amp for AMP",
+        "global_opt": "Global optimization — ipm, ripopt, ipopt; use --solvers amp for AMP",
     }
     print("\nAvailable benchmark categories:\n")
     for name, desc in categories.items():
         print(f"  {name:12s}  {desc}")
     print("\n  all          Run all categories sequentially")
     print()
+
+
+def _parse_solver_filter(raw: str | None) -> list[str] | None:
+    """Parse and validate a comma-separated solver filter."""
+    if raw is None:
+        return None
+    solvers = [part.strip() for part in raw.split(",") if part.strip()]
+    if not solvers:
+        return None
+
+    valid = {"ipm", "ripopt", "ipopt", "highs", "amp"}
+    invalid = [solver for solver in solvers if solver not in valid]
+    if invalid:
+        print(f"ERROR: Unknown solver(s): {', '.join(invalid)}. Valid: {', '.join(sorted(valid))}")
+        sys.exit(1)
+    return list(dict.fromkeys(solvers))
 
 
 def _run_category(
@@ -152,6 +179,7 @@ def _run_category(
     generate_report: bool,
     generate_html: bool,
     hard_timeout_grace: float | None,
+    solver_filter: list[str] | None,
 ):
     """Run benchmarks for a single category."""
     from category_runner import CategoryBenchmarkRunner
@@ -161,6 +189,7 @@ def _run_category(
         level=level,
         time_limit=time_limit,
         hard_timeout_grace=hard_timeout_grace,
+        solver_filter=solver_filter,
     )
     results = runner.run()
 

--- a/discopt_benchmarks/tests/test_category_runner.py
+++ b/discopt_benchmarks/tests/test_category_runner.py
@@ -6,20 +6,21 @@ import json
 import subprocess
 import sys
 from pathlib import Path
+from types import SimpleNamespace
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 from benchmarks.metrics import SolveResult, SolveStatus
 from benchmarks.problems.base import TestProblem as BenchmarkProblem
-from category_runner import CategoryBenchmarkRunner
+from category_runner import CategoryBenchmarkRunner, _run_worker
 
 
-def _problem() -> BenchmarkProblem:
+def _problem(build_fn=None) -> BenchmarkProblem:
     return BenchmarkProblem(
         name="dummy",
         category="lp",
         level="smoke",
-        build_fn=lambda: None,
+        build_fn=build_fn or (lambda: None),
         known_optimum=0.0,
         applicable_solvers=["ipm"],
     )
@@ -74,3 +75,93 @@ def test_category_runner_caps_over_limit_worker_results(monkeypatch):
     assert result.status == SolveStatus.FEASIBLE
     assert result.objective == 1.0
     assert result.wall_time == 3.0
+
+
+def test_category_runner_explicit_amp_filter_runs_amp(monkeypatch):
+    """An explicit AMP filter should run AMP even when default solvers omit it."""
+    calls = []
+
+    def fake_run_discopt(self, problem, solver):
+        del self, problem
+        calls.append(solver)
+        return SolveResult(
+            instance="dummy",
+            solver=f"discopt_{solver}",
+            status=SolveStatus.TIME_LIMIT,
+            wall_time=0.1,
+        )
+
+    monkeypatch.setattr("category_runner.get_problems", lambda category, level: [_problem()])
+    monkeypatch.setattr(CategoryBenchmarkRunner, "_run_discopt", fake_run_discopt)
+
+    runner = CategoryBenchmarkRunner(
+        category="lp",
+        level="smoke",
+        time_limit=3.0,
+        hard_timeout_grace=None,
+        solver_filter=["amp"],
+    )
+    results = runner.run()
+
+    assert calls == ["amp"]
+    assert results.get_solvers() == ["discopt_amp"]
+
+
+def test_category_runner_amp_solver_calls_model_solve_with_solver_amp():
+    """The AMP benchmark backend should call Model.solve(solver='amp')."""
+    captured = {}
+
+    class FakeModel:
+        def solve(self, **kwargs):
+            captured.update(kwargs)
+            return SimpleNamespace(
+                status="optimal",
+                objective=1.0,
+                bound=1.0,
+                node_count=0,
+                iterations=0,
+            )
+
+    runner = CategoryBenchmarkRunner(
+        category="lp",
+        level="smoke",
+        time_limit=3.0,
+        hard_timeout_grace=None,
+    )
+    result = runner._run_discopt(_problem(build_fn=FakeModel), "amp")
+
+    assert captured["solver"] == "amp"
+    assert captured["time_limit"] == 3.0
+    assert captured["gap_tolerance"] == 1e-4
+    assert "nlp_solver" not in captured
+    assert "max_nodes" not in captured
+    assert result.solver == "discopt_amp"
+    assert result.status == SolveStatus.OPTIMAL
+
+
+def test_category_worker_writes_amp_result(tmp_path, monkeypatch):
+    """The hard-timeout worker entrypoint should run and serialize AMP results."""
+
+    class FakeModel:
+        def solve(self, **kwargs):
+            assert kwargs["solver"] == "amp"
+            return SimpleNamespace(
+                status="optimal",
+                objective=1.0,
+                bound=1.0,
+                node_count=0,
+                iterations=0,
+            )
+
+    monkeypatch.setattr(
+        "category_runner.get_problems",
+        lambda category, level: [_problem(build_fn=FakeModel)],
+    )
+
+    result_path = tmp_path / "result.json"
+    rc = _run_worker(["lp", "smoke", "dummy", "amp", "3.0", str(result_path)])
+
+    assert rc == 0
+    data = json.loads(result_path.read_text(encoding="utf-8"))
+    assert data["solver"] == "discopt_amp"
+    assert data["status"] == "optimal"

--- a/discopt_benchmarks/tests/test_category_runner.py
+++ b/discopt_benchmarks/tests/test_category_runner.py
@@ -1,0 +1,76 @@
+"""Tests for category benchmark runner process isolation."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from benchmarks.metrics import SolveResult, SolveStatus
+from benchmarks.problems.base import TestProblem as BenchmarkProblem
+from category_runner import CategoryBenchmarkRunner
+
+
+def _problem() -> BenchmarkProblem:
+    return BenchmarkProblem(
+        name="dummy",
+        category="lp",
+        level="smoke",
+        build_fn=lambda: None,
+        known_optimum=0.0,
+        applicable_solvers=["ipm"],
+    )
+
+
+def test_category_runner_hard_timeout_returns_time_limit(monkeypatch):
+    """The parent runner should kill over-budget workers and record TL."""
+
+    def fake_run(*args, **kwargs):
+        raise subprocess.TimeoutExpired(cmd=args[0], timeout=kwargs["timeout"])
+
+    monkeypatch.setattr("category_runner.subprocess.run", fake_run)
+
+    runner = CategoryBenchmarkRunner(
+        category="lp",
+        level="smoke",
+        time_limit=3.0,
+        hard_timeout_grace=0.5,
+    )
+    result = runner._run_with_hard_timeout(_problem(), "ipm")
+
+    assert result.status == SolveStatus.TIME_LIMIT
+    assert result.wall_time == 3.0
+    assert result.solver == "discopt_ipm"
+
+
+def test_category_runner_caps_over_limit_worker_results(monkeypatch):
+    """A worker that returns during grace should not report over-limit time."""
+
+    def fake_run(cmd, **kwargs):
+        del kwargs
+        worker_result = SolveResult(
+            instance="dummy",
+            solver="discopt_ipm",
+            status=SolveStatus.OPTIMAL,
+            objective=1.0,
+            wall_time=4.0,
+        )
+        Path(cmd[-1]).write_text(json.dumps(worker_result.to_dict()), encoding="utf-8")
+        return subprocess.CompletedProcess(cmd, 0, "", "")
+
+    monkeypatch.setattr("category_runner.subprocess.run", fake_run)
+
+    runner = CategoryBenchmarkRunner(
+        category="lp",
+        level="smoke",
+        time_limit=3.0,
+        hard_timeout_grace=1.0,
+    )
+    result = runner._run_with_hard_timeout(_problem(), "ipm")
+
+    assert result.status == SolveStatus.FEASIBLE
+    assert result.objective == 1.0
+    assert result.wall_time == 3.0

--- a/discopt_benchmarks/tests/test_category_runner.py
+++ b/discopt_benchmarks/tests/test_category_runner.py
@@ -77,6 +77,70 @@ def test_category_runner_caps_over_limit_worker_results(monkeypatch):
     assert result.wall_time == 3.0
 
 
+def test_category_runner_converts_late_certificates_to_time_limit(monkeypatch):
+    """Late proof certificates should not be counted as in-budget results."""
+    statuses = [SolveStatus.INFEASIBLE, SolveStatus.UNBOUNDED]
+
+    def fake_run(cmd, **kwargs):
+        del kwargs
+        worker_result = SolveResult(
+            instance="dummy",
+            solver="discopt_ipm",
+            status=statuses.pop(0),
+            wall_time=4.0,
+        )
+        Path(cmd[-1]).write_text(json.dumps(worker_result.to_dict()), encoding="utf-8")
+        return subprocess.CompletedProcess(cmd, 0, "", "")
+
+    monkeypatch.setattr("category_runner.subprocess.run", fake_run)
+
+    runner = CategoryBenchmarkRunner(
+        category="lp",
+        level="smoke",
+        time_limit=3.0,
+        hard_timeout_grace=1.0,
+    )
+
+    for _ in range(2):
+        result = runner._run_with_hard_timeout(_problem(), "ipm")
+        assert result.status == SolveStatus.TIME_LIMIT
+        assert result.wall_time == 3.0
+
+
+def test_category_runner_prints_error_worker_output_when_verbose(
+    monkeypatch,
+    capsys,
+):
+    """Verbose hard-timeout runs should surface worker diagnostics on ERROR."""
+
+    def fake_run(cmd, **kwargs):
+        del kwargs
+        worker_result = SolveResult(
+            instance="dummy",
+            solver="discopt_ipm",
+            status=SolveStatus.ERROR,
+            wall_time=0.2,
+        )
+        Path(cmd[-1]).write_text(json.dumps(worker_result.to_dict()), encoding="utf-8")
+        return subprocess.CompletedProcess(cmd, 0, "worker stdout\n", "worker stderr\n")
+
+    monkeypatch.setattr("category_runner.subprocess.run", fake_run)
+    monkeypatch.setattr("category_runner.sys.argv", ["run_category_benchmarks.py", "--verbose"])
+
+    runner = CategoryBenchmarkRunner(
+        category="lp",
+        level="smoke",
+        time_limit=3.0,
+        hard_timeout_grace=1.0,
+    )
+    result = runner._run_with_hard_timeout(_problem(), "ipm")
+    captured = capsys.readouterr()
+
+    assert result.status == SolveStatus.ERROR
+    assert "worker stdout" in captured.out
+    assert "worker stderr" in captured.err
+
+
 def test_category_runner_explicit_amp_filter_runs_amp(monkeypatch):
     """An explicit AMP filter should run AMP even when default solvers omit it."""
     calls = []

--- a/python/discopt/_jax/mccormick_nlp.py
+++ b/python/discopt/_jax/mccormick_nlp.py
@@ -14,10 +14,15 @@ Two modes:
 
 from __future__ import annotations
 
+import time
 from typing import Callable, Optional
 
 import jax.numpy as jnp
 import numpy as np
+
+
+def _deadline_expired(deadline: float | None) -> bool:
+    return deadline is not None and time.perf_counter() >= deadline
 
 
 def evaluate_midpoint_bound(
@@ -126,6 +131,7 @@ def solve_mccormick_relaxation_nlp(
     node_ub: jnp.ndarray,
     negate: bool = False,
     max_iter: int = 50,
+    deadline: float | None = None,
 ) -> float:
     """Solve a convex NLP over McCormick relaxations for a tight lower bound.
 
@@ -140,11 +146,16 @@ def solve_mccormick_relaxation_nlp(
         node_ub: Variable upper bounds, shape (n,).
         negate: True if the original problem is maximization.
         max_iter: Maximum IPM iterations.
+        deadline: Absolute ``time.perf_counter()`` deadline. If expired before
+            a new relaxation solve starts, return ``-inf`` without solving.
 
     Returns:
         Valid lower bound (float), or -inf on failure.
     """
     from discopt._jax.ipm import IPMOptions, ipm_solve
+
+    if _deadline_expired(deadline):
+        return -np.inf
 
     lb = jnp.asarray(node_lb, dtype=jnp.float64)
     ub = jnp.asarray(node_ub, dtype=jnp.float64)
@@ -171,6 +182,9 @@ def solve_mccormick_relaxation_nlp(
     con_fn = None
 
     if con_relax_fns and con_senses:
+        if _deadline_expired(deadline):
+            return -np.inf
+
         # Filter out constraints that produce inf/NaN at wide bounds
         good_fns, good_senses = _filter_well_behaved_constraints(con_relax_fns, con_senses, lb, ub)
 
@@ -207,6 +221,9 @@ def solve_mccormick_relaxation_nlp(
     opts = IPMOptions(max_iter=max_iter)
     x0 = jnp.clip(0.5 * (lb + ub), lb, ub)
 
+    if _deadline_expired(deadline):
+        return -np.inf
+
     try:
         state = ipm_solve(obj_fn, con_fn, x0, lb, ub, g_l, g_u, opts)
         conv = int(state.converged)
@@ -228,6 +245,7 @@ def solve_mccormick_batch(
     ub_batch: jnp.ndarray,
     negate: bool = False,
     max_iter: int = 50,
+    deadline: float | None = None,
 ) -> jnp.ndarray:
     """Solve McCormick relaxation NLPs for a batch of nodes via vmap.
 
@@ -239,6 +257,9 @@ def solve_mccormick_batch(
         ub_batch: Upper bounds, shape (N, n_vars).
         negate: True for maximization.
         max_iter: Max IPM iterations per node.
+        deadline: Absolute ``time.perf_counter()`` deadline. If it expires,
+            remaining nodes receive ``-inf`` bounds without starting more
+            relaxation solves.
 
     Returns:
         Array of lower bounds, shape (N,).
@@ -260,6 +281,10 @@ def solve_mccormick_batch(
     result_list = []
 
     for i in range(n_batch):
+        if _deadline_expired(deadline):
+            result_list.extend([-np.inf] * (n_batch - i))
+            break
+
         lb_i = lb_batch[i]
         ub_i = ub_batch[i]
         val = solve_mccormick_relaxation_nlp(
@@ -270,6 +295,7 @@ def solve_mccormick_batch(
             ub_i,
             negate=negate,
             max_iter=max_iter,
+            deadline=deadline,
         )
         result_list.append(val)
 

--- a/python/discopt/_jax/milp_relaxation.py
+++ b/python/discopt/_jax/milp_relaxation.py
@@ -55,6 +55,7 @@ logger = logging.getLogger(__name__)
 
 # Dedupe identical warnings emitted across repeated relaxation builds (AMP iterates).
 _warned_messages: set[str] = set()
+_MAX_FINITE_EXP_ARG = float(np.log(np.finfo(np.float64).max))
 
 
 def _warn_once(msg: str, *args) -> None:
@@ -537,7 +538,7 @@ def _univariate_domain_ok(func_name: str, arg_lb: float, arg_ub: float) -> bool:
     if func_name in {"sqrt", "log", "log2", "log10"}:
         return True
     if func_name == "exp":
-        return bool(np.isfinite(np.exp(arg_lb)) and np.isfinite(np.exp(arg_ub)))
+        return bool(arg_ub <= _MAX_FINITE_EXP_ARG)
     if func_name == "abs":
         return True
     return False

--- a/python/discopt/_jax/nonlinear_bound_tightening.py
+++ b/python/discopt/_jax/nonlinear_bound_tightening.py
@@ -1499,11 +1499,15 @@ def tighten_nonlinear_bounds(
         if rule_name not in applied_rules:
             applied_rules.append(rule_name)
 
+    def _count_changed(new: np.ndarray, old: np.ndarray) -> int:
+        finite = np.isfinite(new) & np.isfinite(old)
+        changed = np.zeros(new.shape, dtype=bool)
+        changed[finite] = np.abs(new[finite] - old[finite]) > 1e-12
+        changed[~finite] = new[~finite] != old[~finite]
+        return int(np.count_nonzero(changed))
+
     def _count_tightened(lb: np.ndarray, ub: np.ndarray) -> int:
-        return int(
-            np.count_nonzero(np.abs(lb - initial_lb) > 1e-12)
-            + np.count_nonzero(np.abs(ub - initial_ub) > 1e-12)
-        )
+        return int(_count_changed(lb, initial_lb) + _count_changed(ub, initial_ub))
 
     empty_initial = np.flatnonzero(tightened_lb > tightened_ub + 1e-12)
     if empty_initial.size > 0:
@@ -1560,9 +1564,8 @@ def tighten_nonlinear_bounds(
             tightened_lb = np.maximum(prev_lb, cand_lb_arr)
             tightened_ub = np.minimum(prev_ub, cand_ub_arr)
 
-            n_changed = int(
-                np.count_nonzero(np.abs(tightened_lb - prev_lb) > 1e-12)
-                + np.count_nonzero(np.abs(tightened_ub - prev_ub) > 1e-12)
+            n_changed = _count_changed(tightened_lb, prev_lb) + _count_changed(
+                tightened_ub, prev_ub
             )
             if n_changed > 0:
                 _mark_rule(rule.name)

--- a/python/discopt/solver.py
+++ b/python/discopt/solver.py
@@ -2294,6 +2294,7 @@ def solve_model(
                                 lb_jax,
                                 ub_jax,
                                 negate=_mc_negate,
+                                deadline=t_start + time_limit,
                             )
                         )
                     elif _mc_mode != "nlp":
@@ -2428,6 +2429,7 @@ def solve_model(
                                     lb_j,
                                     ub_j,
                                     negate=_mc_negate,
+                                    deadline=t_start + time_limit,
                                 )
                             elif _mc_mode != "nlp":
                                 from discopt._jax.mccormick_nlp import (

--- a/python/discopt/solvers/amp.py
+++ b/python/discopt/solvers/amp.py
@@ -2034,7 +2034,7 @@ def solve_amp(
                 n_orig=n_orig,
                 candidate_idxs=_candidates,
                 time_limit_per_lp=_per_lp,
-                deadline=t_start + obbt_time_limit,
+                deadline=min(deadline, t_start + obbt_time_limit),
             )
             if _obbt.n_tightened > 0:
                 # Apply tightened bounds to the model and to flat_lb / flat_ub.

--- a/python/tests/test_amp.py
+++ b/python/tests/test_amp.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import os
 import subprocess
+import warnings
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -139,6 +140,16 @@ def test_amp_helper_defaults_cover_semifinite_domains():
     np.testing.assert_allclose(recovery_starts[0], np.array([0.5, 10.0]))
     np.testing.assert_allclose(recovery_starts[1], np.array([0.0, 2.0]))
     np.testing.assert_allclose(recovery_starts[2], np.array([1.0, 2.0]))
+
+
+def test_exp_univariate_domain_rejects_overflowing_bounds_without_warning():
+    """Wide finite exp domains should be rejected without probing exp(ub)."""
+    from discopt._jax.milp_relaxation import _univariate_domain_ok
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", RuntimeWarning)
+        assert _univariate_domain_ok("exp", 0.0, 1000.0) is False
+        assert _univariate_domain_ok("exp", -1000.0, 10.0) is True
 
 
 def test_amp_normalizes_initial_point_length_and_bounds():

--- a/python/tests/test_amp.py
+++ b/python/tests/test_amp.py
@@ -1522,6 +1522,30 @@ def test_nonlinear_tightening_reports_issue_28_contradictions(
     np.testing.assert_allclose(tightened_ub, flat_ub)
 
 
+def test_nonlinear_tightening_counts_infinite_bounds_without_warning():
+    """Unchanged infinite bounds should not warn while counting tightened entries."""
+    import warnings
+
+    from discopt._jax.nonlinear_bound_tightening import tighten_nonlinear_bounds
+
+    m = Model("infinite_bound_counting")
+    x = m.continuous("x", lb=0.0, ub=np.inf)
+    y = m.continuous("y", lb=0.0, ub=np.inf)
+    m.subject_to(x**2 + y**2 <= 4.0)
+    m.minimize(x + y)
+
+    flat_lb = np.array([0.0, 0.0], dtype=np.float64)
+    flat_ub = np.array([np.inf, np.inf], dtype=np.float64)
+    with warnings.catch_warnings(record=True) as captured:
+        warnings.simplefilter("always")
+        tightened_lb, tightened_ub, stats = tighten_nonlinear_bounds(m, flat_lb, flat_ub)
+
+    assert not captured
+    assert stats.n_tightened == 2
+    np.testing.assert_allclose(tightened_lb, flat_lb)
+    np.testing.assert_allclose(tightened_ub, np.array([2.0, 2.0]))
+
+
 def test_oa_cut_recovery_drops_oldest_half(monkeypatch):
     """OA recovery should retry with the oldest half of cuts removed."""
     from discopt._jax.milp_relaxation import MilpRelaxationResult

--- a/python/tests/test_mccormick_bounds.py
+++ b/python/tests/test_mccormick_bounds.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import time
+
 import jax.numpy as jnp
 import numpy as np
 from discopt.modeling.core import Model
@@ -278,6 +280,35 @@ class TestNLPBounds:
         # McCormick cv should reach near-zero minimum
         assert nlp_lb <= 0.0 + 1e-2
         assert np.isfinite(nlp_lb)
+
+    def test_expired_deadline_skips_relaxation_solves(self):
+        """Expired B&B deadlines should not start more McCormick NLP solves."""
+        from discopt._jax.mccormick_nlp import (
+            solve_mccormick_batch,
+            solve_mccormick_relaxation_nlp,
+        )
+
+        calls = 0
+
+        def relax_fn(x_cv, x_cc, lb, ub):
+            nonlocal calls
+            calls += 1
+            return x_cv[0], x_cc[0]
+
+        lb = jnp.array([0.0])
+        ub = jnp.array([1.0])
+        expired = time.perf_counter() - 1.0
+
+        nlp_lb = solve_mccormick_relaxation_nlp(relax_fn, None, None, lb, ub, deadline=expired)
+        assert nlp_lb == -np.inf
+
+        lb_batch = jnp.array([[0.0], [0.0], [0.0]])
+        ub_batch = jnp.array([[1.0], [1.0], [1.0]])
+        batch_lbs = solve_mccormick_batch(
+            relax_fn, None, None, lb_batch, ub_batch, deadline=expired
+        )
+        np.testing.assert_allclose(np.asarray(batch_lbs), np.full(3, -np.inf))
+        assert calls == 0
 
     def test_end_to_end_minlp_nlp(self):
         """Full solve with mccormick_bounds='nlp'."""

--- a/python/tests/test_minlptests.py
+++ b/python/tests/test_minlptests.py
@@ -26,7 +26,7 @@ from typing import Callable
 
 import discopt.modeling as dm
 import pytest
-from discopt.modeling.core import Model
+from discopt.modeling.core import FunctionCall, Model, ObjectiveSense
 from discopt.validation.examiner import assert_examined
 
 # ── Failure tracking ─────────────────────────────────────────────────────────
@@ -1244,10 +1244,10 @@ def _build_nlp_008_011() -> Model:
 
 
 def _build_nlp_009_010() -> Model:
-    """Min min(0.75+(x-0.5)^3, 0.75-(x-0.5)^2). Opt: 0.75 at x=0.5."""
+    """Max min(0.75+(x-0.5)^3, 0.75-(x-0.5)^2). Opt: 0.75 at x=0.5."""
     m = dm.Model("nlp_009_010")
     x = m.continuous("x")
-    m.minimize(dm.minimum(0.75 + (x - 0.5) ** 3, 0.75 - (x - 0.5) ** 2))
+    m.maximize(dm.minimum(0.75 + (x - 0.5) ** 3, 0.75 - (x - 0.5) ** 2))
     return m
 
 
@@ -1632,6 +1632,18 @@ INFEASIBLE_INSTANCES = [
 # ═════════════════════════════════════════════════════════════════════════════
 # Test classes
 # ═════════════════════════════════════════════════════════════════════════════
+
+
+class TestMINLPTestsTranslations:
+    """Checks for source-level MINLPTests.jl translation details."""
+
+    def test_nlp_009_010_maximizes_min_objective(self) -> None:
+        model = _build_nlp_009_010()
+
+        assert model._objective is not None
+        assert model._objective.sense is ObjectiveSense.MAXIMIZE
+        assert isinstance(model._objective.expression, FunctionCall)
+        assert model._objective.expression.func_name == "min"
 
 
 @pytest.mark.minlptests


### PR DESCRIPTION
## Summary
- run category benchmark cases in subprocess workers with a parent-enforced hard timeout and a configurable grace window
- cap worker results that return after the requested time limit, and add regression tests for hard-timeout handling
- add an explicit category benchmark solver filter, including `--solvers amp`, so AMP benchmarks call `Model.solve(solver="amp")` instead of the NLP-BB `ipm`/`ripopt`/`ipopt` path
- document AMP-specific category benchmark commands for `minlp` and `global_opt`
- pass branch-and-bound deadlines into McCormick NLP relaxation bounds and avoid inf-inf warning noise while counting tightened nonlinear bounds
- keep AMP root OBBT within the global AMP deadline

## Validation
- commit hooks: ruff, ruff format, mypy
- pixi/uv local .venv: ruff check and ruff format --check on touched files
- pytest `discopt_benchmarks/tests/test_category_runner.py`
- focused McCormick deadline and infinite-bound warning regressions
- fast AMP battery: `python/tests/test_amp.py`, 56 passed
- cyipopt 1.7.0 smoke reruns with hard timeout:
  - `global_opt` smoke max `wall_time` 60.0
  - `minlp` smoke max `wall_time` 60.0
- short AMP-specific CLI check:
  - `run_category_benchmarks.py --category minlp --level smoke --solvers amp --time-limit 5 --hard-timeout-grace 1`
  - ran 4 `discopt_amp` cases; max recorded `wall_time` 5.0

## Notes
Generated benchmark result artifacts were used for verification only and are not included in this PR. Hard-killed workers cannot return incumbents, so strict benchmark timing records those cases as `time_limit` rather than `feasible`.
