### PR TITLE
Fix AMP shifted quadratic infeasibility

### DIFF
--- a/python/discopt/_jax/term_classifier.py
+++ b/python/discopt/_jax/term_classifier.py
@@ -125,6 +125,38 @@ def _get_flat_index(expr: Expression, model: Model) -> int | None:
     return None
 
 
+def _contains_expandable_square(model: Model) -> bool:
+    """Return True if Python classification should expand a non-leaf square."""
+
+    def visit(expr: Expression) -> bool:
+        if isinstance(expr, BinaryOp):
+            if (
+                expr.op == "**"
+                and isinstance(expr.right, Constant)
+                and float(expr.right.value) == 2.0
+                and _get_flat_index(expr.left, model) is None
+            ):
+                return True
+            return visit(expr.left) or visit(expr.right)
+        if isinstance(expr, UnaryOp):
+            return visit(expr.operand)
+        if isinstance(expr, FunctionCall):
+            return any(visit(arg) for arg in expr.args)
+        if isinstance(expr, IndexExpression):
+            return not isinstance(expr.base, Variable) and visit(expr.base)
+        if isinstance(expr, SumExpression):
+            return visit(expr.operand)
+        if isinstance(expr, SumOverExpression):
+            return any(visit(term) for term in expr.terms)
+        if isinstance(expr, MatMulExpression):
+            return visit(expr.left) or visit(expr.right)
+        return False
+
+    if model._objective is not None and visit(model._objective.expression):
+        return True
+    return any(visit(constraint.body) for constraint in model._constraints)
+
+
 # ---------------------------------------------------------------------------
 # Helpers: product-tree decomposition
 # ---------------------------------------------------------------------------
@@ -164,12 +196,15 @@ def distribute_products(expr: Expression) -> Expression:
     """Recursively distribute multiplication over addition/subtraction.
 
     ``(a + b) * c`` → ``a*c + b*c``;  ``c * (a - b)`` → ``c*a - c*b``.
+    ``(a + b)^2`` → ``(a + b) * (a + b)`` before distribution.
     Applied bottom-up so nested distributions resolve.  Other expression
     types are returned with operator-tree shape preserved structurally.
     """
     if isinstance(expr, BinaryOp):
         left = distribute_products(expr.left)
         right = distribute_products(expr.right)
+        if expr.op == "**" and isinstance(right, Constant) and float(right.value) == 2.0:
+            return distribute_products(BinaryOp("*", left, left))
         if expr.op == "*":
             if isinstance(right, BinaryOp) and right.op in ("+", "-"):
                 return BinaryOp(
@@ -249,9 +284,10 @@ def classify_nonlinear_terms(model: Model) -> NonlinearTerms:
     available, falling back to the Python implementation for unsupported models
     and for cases that need concrete ``general_nl`` expression objects.
     """
-    rust_terms = _classify_nonlinear_terms_rust(model)
-    if rust_terms is not None:
-        return rust_terms
+    if not _contains_expandable_square(model):
+        rust_terms = _classify_nonlinear_terms_rust(model)
+        if rust_terms is not None:
+            return rust_terms
     return _classify_nonlinear_terms_python(model)
 
 

--- a/python/tests/test_amp.py
+++ b/python/tests/test_amp.py
@@ -44,6 +44,15 @@ def _make_obbt_demo() -> Model:
     return m
 
 
+def _make_shifted_square_infeasible() -> Model:
+    m = dm.Model("nlp_mi_007_020")
+    x = m.integer("x", lb=-2, ub=3)
+    y = m.binary("y")
+    m.minimize(x * 0.0)
+    m.subject_to((x - 0.5) ** 2 + (4 * y - 2) ** 2 <= 3)
+    return m
+
+
 def _build_relaxation_for_test(
     model: Model,
     part_vars: list[int] | None = None,
@@ -211,6 +220,41 @@ def test_partitioned_square_secants_tighten_circle_superlevel_bound():
     assert fine.objective is not None
     assert fine.objective >= coarse.objective + 0.05
     assert fine.objective == pytest.approx(np.sqrt(2.0), abs=1e-4)
+
+
+def test_shifted_square_constraint_linearizes_and_proves_infeasible(caplog):
+    """Affine-square constraints should stay in the AMP MILP relaxation."""
+    from discopt._jax.term_classifier import classify_nonlinear_terms
+
+    m = _make_shifted_square_infeasible()
+    terms = classify_nonlinear_terms(m)
+
+    assert set(terms.monomial) == {(0, 2), (1, 2)}
+
+    with caplog.at_level("WARNING"):
+        milp_model, varmap = _build_relaxation_for_test(m)
+        result = milp_model.solve()
+
+    assert set(varmap["monomial"]) == {(0, 2), (1, 2)}
+    assert result.status == "infeasible"
+    assert "omitting constraint" not in caplog.text
+
+
+def test_amp_reports_shifted_square_minlptests_case_infeasible():
+    """Regression for MINLPTests nlp_mi_007_020."""
+    m = _make_shifted_square_infeasible()
+
+    result = m.solve(
+        solver="amp",
+        nlp_solver="ipm",
+        max_iter=1,
+        time_limit=10.0,
+        presolve_bt=False,
+        apply_partitioning=False,
+    )
+
+    assert result.status == "infeasible"
+    assert result.x is None
 
 
 def test_solve_nlp_subproblem_retries_ipopt_and_restores_bounds(monkeypatch):


### PR DESCRIPTION
Summary
- Expand exact squared non-leaf expressions before AMP term classification and MILP linearization, so shifted affine squares reuse the existing monomial/bilinear relaxation path.
- Add fast regressions proving the `nlp_mi_007_020` shifted-square constraint is retained and AMP reports `infeasible`.

Tests run
- `.venv/bin/pytest python/tests/test_amp.py::test_shifted_square_constraint_linearizes_and_proves_infeasible python/tests/test_amp.py::test_amp_reports_shifted_square_minlptests_case_infeasible -q -v --tb=short` -> 2 passed in 11.27s.
- `make test-amp-fast PYTHON=.venv/bin/python PYTEST=.venv/bin/pytest` -> 59 passed in 17.83s.
- `make lint RUFF=.venv/bin/ruff` -> ruff check and ruff format check passed.
- `.venv/bin/mypy python/discopt/` -> Success: no issues found in 170 source files.
- `make test PYTHON=.venv/bin/python PYTEST=.venv/bin/pytest` -> 2477 passed, 59 skipped, 707 deselected, 2 xfailed, 11 warnings in 516.70s.
- `.venv/bin/pytest python/tests/test_amp_integration.py::TestTermClassifier::test_detect_monomial_squared python/tests/test_amp_integration.py::TestTermClassifier::test_term_incidence_correct -q -v --tb=short` -> 2 passed in 0.66s.

Notes
- Test environment was created with `pixi exec ... -- uv venv --allow-existing .venv` and dependencies were installed into `.venv`; no ambient local Python environment was used.
- Full `make test-amp-integration` was not run locally because it is the long opt-in Alpine/MINLPTests/incidence suite; the focused incidence checks above were run from the same pixi-backed `.venv`.

Closes #65
