### PR TITLE
Add alpha-BB OA cuts for AMP quadratics

### DIFF
--- a/python/discopt/_jax/cutting_planes.py
+++ b/python/discopt/_jax/cutting_planes.py
@@ -19,6 +19,9 @@ from typing import NamedTuple, Optional
 
 import numpy as np
 
+from discopt._jax.nonlinear_bound_tightening import is_effectively_finite
+from discopt.constants import ALPHABB_EPS, ALPHABB_SAFETY
+
 
 class LinearCut(NamedTuple):
     """A single linear cutting plane: coeffs @ x  sense  rhs.
@@ -283,6 +286,120 @@ def generate_oa_cuts_from_evaluator(
         sense = constraint_senses[k]
         cut = generate_oa_cut(grad_k, g_k, x_sol, sense=sense)
         cuts.append(cut)
+
+    return cuts
+
+
+def _constraint_row_hessian(evaluator, row_idx: int, x_sol: np.ndarray) -> np.ndarray:
+    """Evaluate the Hessian for one scalar constraint row."""
+    lam = np.zeros(evaluator.n_constraints, dtype=np.float64)
+    lam[row_idx] = 1.0
+    hess: np.ndarray = np.asarray(
+        evaluator.evaluate_lagrangian_hessian(x_sol, 0.0, lam),
+        dtype=np.float64,
+    )
+    sym_hess: np.ndarray = 0.5 * (hess + hess.T)
+    return sym_hess
+
+
+def _quadratic_probe_point(x_sol: np.ndarray, x_lb: np.ndarray, x_ub: np.ndarray) -> np.ndarray:
+    """Build a nearby point for checking that a row Hessian is constant."""
+    probe: np.ndarray = np.asarray(x_sol, dtype=np.float64).copy()
+    for idx in range(probe.size):
+        lb_i = float(x_lb[idx])
+        ub_i = float(x_ub[idx])
+        if is_effectively_finite(lb_i) and is_effectively_finite(ub_i):
+            width = ub_i - lb_i
+            if width <= 1e-10:
+                continue
+            step = min(max(0.173 * width, 1e-4), 1.0)
+        else:
+            step = 1.0
+
+        direction = 1.0 if idx % 2 == 0 else -1.0
+        candidate = probe[idx] + direction * step
+        if candidate < lb_i - 1e-12 or candidate > ub_i + 1e-12:
+            candidate = probe[idx] - direction * step
+        if candidate < lb_i - 1e-12 or candidate > ub_i + 1e-12:
+            continue
+        probe[idx] = candidate
+    return probe
+
+
+def generate_alphabb_quadratic_oa_cuts_from_evaluator(
+    evaluator,
+    x_sol: np.ndarray,
+    x_lb: np.ndarray,
+    x_ub: np.ndarray,
+    constraint_senses: Optional[list[str]] = None,
+    convex_mask: Optional[list[bool]] = None,
+    hessian_tol: float = 1e-8,
+) -> list[LinearCut]:
+    """Generate OA cuts from alpha-BB relaxations of nonconvex quadratic rows.
+
+    Direct OA cuts on a nonconvex row are not globally valid. For a quadratic
+    row ``q(x) <= 0`` with finite bounds on curved variables, alpha-BB gives a
+    convex underestimator
+
+        q_under(x) = q(x) - sum_i alpha_i (x_i - lb_i) (ub_i - x_i)
+
+    satisfying ``q_under(x) <= q(x)`` over the box. Every point feasible for the
+    original row therefore satisfies ``q_under(x) <= 0``, so a tangent cut of
+    the convex underestimator is a valid relaxation cut.
+    """
+    m = evaluator.n_constraints
+    if m == 0:
+        return []
+
+    x_sol = np.asarray(x_sol, dtype=np.float64).reshape(-1)
+    x_lb = np.asarray(x_lb, dtype=np.float64).reshape(-1)
+    x_ub = np.asarray(x_ub, dtype=np.float64).reshape(-1)
+    if x_sol.size != x_lb.size or x_sol.size != x_ub.size:
+        raise ValueError("x_sol, x_lb, and x_ub must have matching shapes")
+
+    if constraint_senses is None:
+        constraint_senses = ["<="] * m
+
+    cons_vals = evaluator.evaluate_constraints(x_sol)
+    jac = evaluator.evaluate_jacobian(x_sol)
+    probe = _quadratic_probe_point(x_sol, x_lb, x_ub)
+
+    cuts: list[LinearCut] = []
+    for k in range(m):
+        if convex_mask is not None and convex_mask[k]:
+            continue
+        if constraint_senses[k] != "<=":
+            continue
+
+        hess = _constraint_row_hessian(evaluator, k, x_sol)
+        probe_hess = _constraint_row_hessian(evaluator, k, probe)
+        if not np.allclose(hess, probe_hess, atol=hessian_tol, rtol=0.0):
+            continue
+
+        curved = np.flatnonzero(np.any(np.abs(hess) > hessian_tol, axis=0))
+        if curved.size == 0:
+            continue
+        if not all(
+            is_effectively_finite(float(x_lb[idx])) and is_effectively_finite(float(x_ub[idx]))
+            for idx in curved
+        ):
+            continue
+
+        hess_sub = hess[np.ix_(curved, curved)]
+        min_eig = float(np.linalg.eigvalsh(hess_sub)[0])
+        if min_eig >= -ALPHABB_EPS:
+            continue
+
+        alpha = np.zeros_like(x_sol, dtype=np.float64)
+        alpha[curved] = max(0.0, -0.5 * min_eig + ALPHABB_SAFETY)
+
+        perturbation = float(
+            np.sum(alpha[curved] * (x_sol[curved] - x_lb[curved]) * (x_ub[curved] - x_sol[curved]))
+        )
+        under_val = float(cons_vals[k]) - perturbation
+        under_grad = np.asarray(jac[k, :], dtype=np.float64).copy()
+        under_grad[curved] -= alpha[curved] * (x_lb[curved] + x_ub[curved] - 2.0 * x_sol[curved])
+        cuts.append(generate_oa_cut(under_grad, under_val, x_sol, sense="<="))
 
     return cuts
 

--- a/python/discopt/_jax/cutting_planes.py
+++ b/python/discopt/_jax/cutting_planes.py
@@ -21,6 +21,16 @@ import numpy as np
 
 from discopt._jax.nonlinear_bound_tightening import is_effectively_finite
 from discopt.constants import ALPHABB_EPS, ALPHABB_SAFETY
+from discopt.modeling.core import (
+    BinaryOp,
+    Constant,
+    Expression,
+    IndexExpression,
+    Model,
+    SumOverExpression,
+    UnaryOp,
+    Variable,
+)
 
 
 class LinearCut(NamedTuple):
@@ -290,40 +300,188 @@ def generate_oa_cuts_from_evaluator(
     return cuts
 
 
-def _constraint_row_hessian(evaluator, row_idx: int, x_sol: np.ndarray) -> np.ndarray:
-    """Evaluate the Hessian for one scalar constraint row."""
-    lam = np.zeros(evaluator.n_constraints, dtype=np.float64)
-    lam[row_idx] = 1.0
-    hess: np.ndarray = np.asarray(
-        evaluator.evaluate_lagrangian_hessian(x_sol, 0.0, lam),
-        dtype=np.float64,
-    )
-    sym_hess: np.ndarray = 0.5 * (hess + hess.T)
-    return sym_hess
+QuadraticPolynomial = dict[tuple[int, ...], float]
 
 
-def _quadratic_probe_point(x_sol: np.ndarray, x_lb: np.ndarray, x_ub: np.ndarray) -> np.ndarray:
-    """Build a nearby point for checking that a row Hessian is constant."""
-    probe: np.ndarray = np.asarray(x_sol, dtype=np.float64).copy()
-    for idx in range(probe.size):
-        lb_i = float(x_lb[idx])
-        ub_i = float(x_ub[idx])
-        if is_effectively_finite(lb_i) and is_effectively_finite(ub_i):
-            width = ub_i - lb_i
-            if width <= 1e-10:
-                continue
-            step = min(max(0.173 * width, 1e-4), 1.0)
-        else:
-            step = 1.0
+def _constant_scalar(expr: Expression) -> Optional[float]:
+    """Return a scalar constant value, or None when the expression is not scalar constant."""
+    if not isinstance(expr, Constant):
+        return None
+    value = np.asarray(expr.value, dtype=np.float64)
+    if value.shape != ():
+        return None
+    return float(value)
 
-        direction = 1.0 if idx % 2 == 0 else -1.0
-        candidate = probe[idx] + direction * step
-        if candidate < lb_i - 1e-12 or candidate > ub_i + 1e-12:
-            candidate = probe[idx] - direction * step
-        if candidate < lb_i - 1e-12 or candidate > ub_i + 1e-12:
-            continue
-        probe[idx] = candidate
-    return probe
+
+def _var_offset(var: Variable, model: Model) -> int:
+    """Return a variable's start index in the flattened model vector."""
+    offset = 0
+    for existing in model._variables[: var._index]:
+        offset += existing.size
+    return offset
+
+
+def _scalar_var_index(expr: Expression, model: Model) -> Optional[int]:
+    """Return the flat index for a scalar variable expression."""
+    if isinstance(expr, Variable):
+        if expr.size == 1:
+            return _var_offset(expr, model)
+        return None
+    if isinstance(expr, IndexExpression) and isinstance(expr.base, Variable):
+        base_offset = _var_offset(expr.base, model)
+        idx = expr.index
+        if isinstance(idx, int):
+            return base_offset + idx
+        if isinstance(idx, tuple) and len(idx) == 1 and isinstance(idx[0], int):
+            return base_offset + idx[0]
+    return None
+
+
+def _cleanup_polynomial(poly: QuadraticPolynomial) -> QuadraticPolynomial:
+    """Drop numerical zero coefficients from a structural polynomial."""
+    return {key: coeff for key, coeff in poly.items() if abs(coeff) > 1e-14}
+
+
+def _scale_polynomial(poly: QuadraticPolynomial, scale: float) -> QuadraticPolynomial:
+    """Scale polynomial coefficients."""
+    return _cleanup_polynomial({key: scale * coeff for key, coeff in poly.items()})
+
+
+def _add_polynomials(
+    left: QuadraticPolynomial,
+    right: QuadraticPolynomial,
+    right_scale: float = 1.0,
+) -> QuadraticPolynomial:
+    """Add two polynomials, optionally scaling the right operand."""
+    result = dict(left)
+    for key, coeff in right.items():
+        result[key] = result.get(key, 0.0) + right_scale * coeff
+    return _cleanup_polynomial(result)
+
+
+def _multiply_polynomials(
+    left: QuadraticPolynomial,
+    right: QuadraticPolynomial,
+) -> Optional[QuadraticPolynomial]:
+    """Multiply two polynomials, rejecting terms above degree two."""
+    result: QuadraticPolynomial = {}
+    for left_key, left_coeff in left.items():
+        for right_key, right_coeff in right.items():
+            key = tuple(sorted(left_key + right_key))
+            if len(key) > 2:
+                return None
+            result[key] = result.get(key, 0.0) + left_coeff * right_coeff
+    return _cleanup_polynomial(result)
+
+
+def _quadratic_polynomial(expr: Expression, model: Model) -> Optional[QuadraticPolynomial]:
+    """Extract a scalar polynomial of degree at most two, or None if unsupported."""
+    const_val = _constant_scalar(expr)
+    if const_val is not None:
+        return {(): const_val}
+
+    flat_idx = _scalar_var_index(expr, model)
+    if flat_idx is not None:
+        return {(flat_idx,): 1.0}
+
+    if isinstance(expr, UnaryOp) and expr.op == "neg":
+        operand = _quadratic_polynomial(expr.operand, model)
+        if operand is None:
+            return None
+        return _scale_polynomial(operand, -1.0)
+
+    if isinstance(expr, SumOverExpression):
+        result: QuadraticPolynomial = {}
+        for term in expr.terms:
+            term_poly = _quadratic_polynomial(term, model)
+            if term_poly is None:
+                return None
+            result = _add_polynomials(result, term_poly)
+        return result
+
+    if not isinstance(expr, BinaryOp):
+        return None
+
+    if expr.op in {"+", "-"}:
+        left = _quadratic_polynomial(expr.left, model)
+        right = _quadratic_polynomial(expr.right, model)
+        if left is None or right is None:
+            return None
+        return _add_polynomials(left, right, -1.0 if expr.op == "-" else 1.0)
+
+    if expr.op == "*":
+        left = _quadratic_polynomial(expr.left, model)
+        right = _quadratic_polynomial(expr.right, model)
+        if left is None or right is None:
+            return None
+        return _multiply_polynomials(left, right)
+
+    if expr.op == "/":
+        denom = _constant_scalar(expr.right)
+        if denom is None or abs(denom) <= 1e-14:
+            return None
+        left = _quadratic_polynomial(expr.left, model)
+        if left is None:
+            return None
+        return _scale_polynomial(left, 1.0 / denom)
+
+    if expr.op == "**":
+        exponent = _constant_scalar(expr.right)
+        if exponent is None or abs(exponent - round(exponent)) > 1e-12:
+            return None
+        exponent_int = int(round(exponent))
+        if exponent_int == 0:
+            return {(): 1.0}
+        if exponent_int == 1:
+            return _quadratic_polynomial(expr.left, model)
+        if exponent_int == 2:
+            base = _quadratic_polynomial(expr.left, model)
+            if base is None:
+                return None
+            return _multiply_polynomials(base, base)
+        return None
+
+    return None
+
+
+def _quadratic_hessian_from_polynomial(poly: QuadraticPolynomial, n_vars: int) -> np.ndarray:
+    """Build a Hessian matrix from a structural quadratic polynomial."""
+    hess = np.zeros((n_vars, n_vars), dtype=np.float64)
+    for key, coeff in poly.items():
+        if len(key) == 2:
+            i, j = key
+            if i == j:
+                hess[i, i] += 2.0 * coeff
+            else:
+                hess[i, j] += coeff
+                hess[j, i] += coeff
+    return hess
+
+
+def _constraint_row_quadratic_hessian(
+    evaluator,
+    row_idx: int,
+    n_vars: int,
+) -> Optional[np.ndarray]:
+    """Return a structural quadratic Hessian for a scalar constraint row."""
+    model = getattr(evaluator, "_model", None)
+    source_constraints = getattr(evaluator, "_source_constraints", None)
+    flat_sizes = getattr(evaluator, "_constraint_flat_sizes", None)
+    if model is None or source_constraints is None or flat_sizes is None:
+        return None
+
+    offset = 0
+    for constraint, flat_size_raw in zip(source_constraints, flat_sizes):
+        flat_size = int(flat_size_raw)
+        if row_idx < offset + flat_size:
+            if flat_size != 1 or row_idx != offset:
+                return None
+            poly = _quadratic_polynomial(constraint.body, model)
+            if poly is None:
+                return None
+            return _quadratic_hessian_from_polynomial(poly, n_vars)
+        offset += flat_size
+    return None
 
 
 def generate_alphabb_quadratic_oa_cuts_from_evaluator(
@@ -362,7 +520,6 @@ def generate_alphabb_quadratic_oa_cuts_from_evaluator(
 
     cons_vals = evaluator.evaluate_constraints(x_sol)
     jac = evaluator.evaluate_jacobian(x_sol)
-    probe = _quadratic_probe_point(x_sol, x_lb, x_ub)
 
     cuts: list[LinearCut] = []
     for k in range(m):
@@ -371,9 +528,8 @@ def generate_alphabb_quadratic_oa_cuts_from_evaluator(
         if constraint_senses[k] != "<=":
             continue
 
-        hess = _constraint_row_hessian(evaluator, k, x_sol)
-        probe_hess = _constraint_row_hessian(evaluator, k, probe)
-        if not np.allclose(hess, probe_hess, atol=hessian_tol, rtol=0.0):
+        hess = _constraint_row_quadratic_hessian(evaluator, k, x_sol.size)
+        if hess is None:
             continue
 
         curved = np.flatnonzero(np.any(np.abs(hess) > hessian_tol, axis=0))
@@ -549,7 +705,6 @@ def detect_bilinear_terms(model) -> list[BilinearTerm]:
     """
     from discopt.modeling.core import (
         BinaryOp,
-        Expression,
         IndexExpression,
         Variable,
     )

--- a/python/discopt/solver.py
+++ b/python/discopt/solver.py
@@ -1498,6 +1498,7 @@ def solve_model(
             "use_start_as_incumbent",
             "obbt_at_root",
             "obbt_with_cutoff",
+            "alphabb_cutoff_obbt",
             "obbt_time_limit",
         )
         for key in amp_option_keys:

--- a/python/discopt/solvers/amp.py
+++ b/python/discopt/solvers/amp.py
@@ -115,6 +115,237 @@ def _apply_flat_bounds_to_model(model: Model, lb: np.ndarray, ub: np.ndarray) ->
         offset += size
 
 
+def _refresh_partitions_for_bounds(
+    model: Model,
+    disc_state,
+    flat_lb: np.ndarray,
+    flat_ub: np.ndarray,
+    part_vars: list[int],
+    disc_abs_width_tol: float,
+    n_init_partitions: int,
+) -> tuple[list[int], list[float], list[float]]:
+    """Apply tightened bounds and keep AMP partition endpoints consistent."""
+    _apply_flat_bounds_to_model(model, flat_lb, flat_ub)
+    part_vars = [i for i in part_vars if float(flat_ub[i]) - float(flat_lb[i]) > disc_abs_width_tol]
+    part_lbs = [float(flat_lb[i]) for i in part_vars]
+    part_ubs = [float(flat_ub[i]) for i in part_vars]
+    for k_pv, v_idx in enumerate(part_vars):
+        pts = disc_state.partitions.get(v_idx)
+        new_lo = float(part_lbs[k_pv])
+        new_hi = float(part_ubs[k_pv])
+        if pts is None or len(pts) < 2:
+            disc_state.partitions[v_idx] = np.linspace(new_lo, new_hi, n_init_partitions + 1)
+            continue
+        clipped = np.clip(pts, new_lo, new_hi)
+        merged = np.unique(np.concatenate([[new_lo], clipped, [new_hi]]))
+        disc_state.partitions[v_idx] = np.sort(merged)
+    return part_vars, part_lbs, part_ubs
+
+
+def _scalar_constant(expr: Expression) -> Optional[float]:
+    if not isinstance(expr, Constant):
+        return None
+    value = np.asarray(expr.value, dtype=np.float64)
+    if value.shape != ():
+        return None
+    return float(value)
+
+
+def _flat_var_index(expr: Expression, model: Model) -> Optional[int]:
+    if isinstance(expr, Variable):
+        if expr.size != 1:
+            return None
+        return sum(existing.size for existing in model._variables[: expr._index])
+    if isinstance(expr, IndexExpression) and isinstance(expr.base, Variable):
+        base = expr.base
+        base_offset = sum(existing.size for existing in model._variables[: base._index])
+        idx = expr.index
+        if base.shape == ():
+            return base_offset
+        if not isinstance(idx, tuple):
+            idx = (idx,)
+        return base_offset + int(np.ravel_multi_index(idx, base.shape))
+    return None
+
+
+def _flatten_objective_power_terms(
+    expr: Expression,
+    model: Model,
+    scale: float,
+    groups: dict[int, dict[int, float]],
+) -> Optional[float]:
+    """Collect separable monomial objective terms, returning the constant offset."""
+    const = _scalar_constant(expr)
+    if const is not None:
+        return scale * const
+
+    flat_idx = _flat_var_index(expr, model)
+    if flat_idx is not None:
+        terms = groups.setdefault(flat_idx, {})
+        terms[1] = terms.get(1, 0.0) + scale
+        return 0.0
+
+    if isinstance(expr, SumExpression):
+        return _flatten_objective_power_terms(expr.operand, model, scale, groups)
+
+    if isinstance(expr, SumOverExpression):
+        total = 0.0
+        for term in expr.terms:
+            term_const = _flatten_objective_power_terms(term, model, scale, groups)
+            if term_const is None:
+                return None
+            total += term_const
+        return total
+
+    if isinstance(expr, UnaryOp) and expr.op == "neg":
+        return _flatten_objective_power_terms(expr.operand, model, -scale, groups)
+
+    if not isinstance(expr, BinaryOp):
+        return None
+
+    if expr.op in {"+", "-"}:
+        left_const = _flatten_objective_power_terms(expr.left, model, scale, groups)
+        right_scale = scale if expr.op == "+" else -scale
+        right_const = _flatten_objective_power_terms(expr.right, model, right_scale, groups)
+        if left_const is None or right_const is None:
+            return None
+        return left_const + right_const
+
+    if expr.op == "*":
+        left_const = _scalar_constant(expr.left)
+        if left_const is not None:
+            return _flatten_objective_power_terms(expr.right, model, scale * left_const, groups)
+        right_const = _scalar_constant(expr.right)
+        if right_const is not None:
+            return _flatten_objective_power_terms(expr.left, model, scale * right_const, groups)
+        return None
+
+    if expr.op == "/":
+        denom = _scalar_constant(expr.right)
+        if denom is None or abs(denom) <= 1e-14:
+            return None
+        return _flatten_objective_power_terms(expr.left, model, scale / denom, groups)
+
+    if expr.op == "**":
+        exponent = _scalar_constant(expr.right)
+        if exponent is None or abs(exponent - round(exponent)) > 1e-12:
+            return None
+        exponent_int = int(round(exponent))
+        if exponent_int <= 0:
+            return None
+        flat_idx = _flat_var_index(expr.left, model)
+        if flat_idx is None:
+            return None
+        terms = groups.setdefault(flat_idx, {})
+        terms[exponent_int] = terms.get(exponent_int, 0.0) + scale
+        return 0.0
+
+    return None
+
+
+def _polynomial_value(terms: dict[int, float], x: float) -> float:
+    return float(sum(coeff * (x**degree) for degree, coeff in terms.items()))
+
+
+def _univariate_polynomial_minimum(terms: dict[int, float], lb: float, ub: float) -> float:
+    points = [lb, ub]
+    if lb <= 0.0 <= ub:
+        points.append(0.0)
+    max_degree = max((degree for degree in terms if degree > 0), default=0)
+    derivative_coeffs = [terms.get(degree, 0.0) * degree for degree in range(max_degree, 0, -1)]
+    if any(abs(coeff) > 1e-14 for coeff in derivative_coeffs):
+        for root in np.roots(derivative_coeffs):
+            if abs(float(np.imag(root))) <= 1e-10:
+                real_root = float(np.real(root))
+                if lb <= real_root <= ub:
+                    points.append(real_root)
+    return min(_polynomial_value(terms, point) for point in points)
+
+
+def _tighten_simple_power_group(
+    terms: dict[int, float],
+    rhs: float,
+    lb: float,
+    ub: float,
+) -> tuple[float, float]:
+    """Intersect simple monomial level sets with the current interval."""
+    nonzero_terms = {degree: coeff for degree, coeff in terms.items() if abs(coeff) > 1e-14}
+    if not np.isfinite(rhs) or not nonzero_terms:
+        return lb, ub
+    if len(nonzero_terms) != 1:
+        return lb, ub
+
+    degree, coeff = next(iter(nonzero_terms.items()))
+    if degree == 1:
+        bound = rhs / coeff
+        if coeff > 0.0:
+            return lb, min(ub, bound)
+        return max(lb, bound), ub
+
+    if coeff <= 0.0 or rhs < 0.0:
+        return lb, ub
+
+    radius = float((rhs / coeff) ** (1.0 / degree))
+    if degree % 2 == 0:
+        return max(lb, -radius), min(ub, radius)
+    if lb >= 0.0:
+        return lb, min(ub, radius)
+    if ub <= 0.0:
+        return max(lb, -radius), ub
+    return lb, ub
+
+
+def _tighten_bounds_with_objective_cutoff(
+    model: Model,
+    flat_lb: np.ndarray,
+    flat_ub: np.ndarray,
+    cutoff: float,
+) -> tuple[np.ndarray, np.ndarray]:
+    """Use a separable objective cutoff to infer a finite box before cutoff OBBT."""
+    if (
+        model._objective is None
+        or model._objective.sense != ObjectiveSense.MINIMIZE
+        or not np.isfinite(cutoff)
+    ):
+        return flat_lb, flat_ub
+
+    groups: dict[int, dict[int, float]] = {}
+    constant = _flatten_objective_power_terms(model._objective.expression, model, 1.0, groups)
+    if constant is None or not groups:
+        return flat_lb, flat_ub
+
+    tightened_lb = np.asarray(flat_lb, dtype=np.float64).copy()
+    tightened_ub = np.asarray(flat_ub, dtype=np.float64).copy()
+    cutoff = float(cutoff) + 1e-8 * max(1.0, abs(float(cutoff)))
+
+    group_min: dict[int, float] = {}
+    for flat_idx, terms in groups.items():
+        lb_i = float(tightened_lb[flat_idx])
+        ub_i = float(tightened_ub[flat_idx])
+        if not (np.isfinite(lb_i) and np.isfinite(ub_i)):
+            return flat_lb, flat_ub
+        group_min[flat_idx] = _univariate_polynomial_minimum(terms, lb_i, ub_i)
+
+    total_min = float(constant) + float(sum(group_min.values()))
+    if total_min > cutoff + 1e-8:
+        return flat_lb, flat_ub
+
+    for flat_idx, terms in groups.items():
+        other_min = total_min - group_min[flat_idx]
+        rhs = cutoff - other_min
+        new_lb, new_ub = _tighten_simple_power_group(
+            terms,
+            rhs,
+            float(tightened_lb[flat_idx]),
+            float(tightened_ub[flat_idx]),
+        )
+        if new_lb <= new_ub + 1e-10:
+            tightened_lb[flat_idx] = max(tightened_lb[flat_idx], new_lb)
+            tightened_ub[flat_idx] = min(tightened_ub[flat_idx], new_ub)
+
+    return tightened_lb, tightened_ub
+
+
 def _default_nlp_start(flat_lb: np.ndarray, flat_ub: np.ndarray) -> np.ndarray:
     """Build a neutral NLP start point that behaves sensibly on semi-infinite domains."""
     x0 = np.zeros_like(flat_lb, dtype=np.float64)
@@ -1591,24 +1822,15 @@ def _run_cutoff_obbt(
             tight_ub[bad] = mid
         _apply_flat_bounds_to_model(model, tight_lb, tight_ub)
         flat_lb, flat_ub = tight_lb, tight_ub
-        # Drop partition vars whose width has collapsed.
-        part_vars = [
-            i for i in part_vars if float(flat_ub[i]) - float(flat_lb[i]) > disc_abs_width_tol
-        ]
-        part_lbs = [float(flat_lb[i]) for i in part_vars]
-        part_ubs = [float(flat_ub[i]) for i in part_vars]
-        # Clip existing breakpoints into the new tighter box and re-anchor
-        # endpoints to the OBBT bounds.  Preserves prior refinement effort.
-        for k_pv, v_idx in enumerate(part_vars):
-            pts = disc_state.partitions.get(v_idx)
-            new_lo = float(part_lbs[k_pv])
-            new_hi = float(part_ubs[k_pv])
-            if pts is None or len(pts) < 2:
-                disc_state.partitions[v_idx] = np.linspace(new_lo, new_hi, n_init_partitions + 1)
-                continue
-            clipped = np.clip(pts, new_lo, new_hi)
-            merged = np.unique(np.concatenate([[new_lo], clipped, [new_hi]]))
-            disc_state.partitions[v_idx] = np.sort(merged)
+        part_vars, part_lbs, part_ubs = _refresh_partitions_for_bounds(
+            model,
+            disc_state,
+            flat_lb,
+            flat_ub,
+            part_vars,
+            disc_abs_width_tol,
+            n_init_partitions,
+        )
         logger.info(
             "AMP cutoff OBBT @ iter %d: %d/%d bounds tightened in %d LPs (%.2fs, cutoff=%.6g)",
             iteration,
@@ -2125,6 +2347,152 @@ def solve_amp(
     _last_obbt_iter = 0
     _obbt_period = 5
 
+    def _append_linearized_cuts(cuts) -> int:
+        appended = 0
+        for cut in cuts:
+            if np.linalg.norm(cut.coeffs) < 1e-12:
+                continue
+            if cut.sense == ">=":
+                # Convert to <= form for milp_relaxation.py
+                oa_cuts.append((-cut.coeffs, -cut.rhs))
+            elif cut.sense == "==":
+                oa_cuts.append((cut.coeffs, cut.rhs))
+                oa_cuts.append((-cut.coeffs, -cut.rhs))
+                appended += 2
+                continue
+            else:
+                oa_cuts.append((cut.coeffs, cut.rhs))
+            appended += 1
+        return appended
+
+    def _add_incumbent_oa_cuts_after_cutoff_tightening(
+        x_incumbent: np.ndarray,
+        iteration_idx: int,
+    ) -> int:
+        """Append direct OA, run cutoff tightening, then append alpha-BB OA cuts."""
+        nonlocal flat_lb, flat_ub, part_vars, part_lbs, part_ubs
+        nonlocal _cutoff_obbt_done, _last_obbt_iter
+
+        if evaluator.n_constraints <= 0:
+            return 0
+
+        appended = 0
+        try:
+            from discopt._jax.cutting_planes import (
+                generate_alphabb_quadratic_oa_cuts_from_evaluator,
+                generate_oa_cuts_from_evaluator,
+            )
+            from discopt.modeling.core import Constraint
+
+            _x_orig = x_incumbent[:n_orig]
+            _senses = [c.sense for c in model._constraints if isinstance(c, Constraint)]
+            direct_cuts = generate_oa_cuts_from_evaluator(
+                evaluator,
+                _x_orig,
+                constraint_senses=_senses,
+                convex_mask=oa_convexity.constraint_mask,
+            )
+            appended += _append_linearized_cuts(direct_cuts)
+
+            has_nonconvex_oa_row = not all(oa_convexity.constraint_mask)
+            had_effectively_unbounded = any(
+                not is_effectively_finite(float(value))
+                for value in np.concatenate([flat_lb, flat_ub])
+            )
+            if has_nonconvex_oa_row and UB < np.inf:
+                cutoff_lb, cutoff_ub = _tighten_bounds_with_objective_cutoff(
+                    model,
+                    flat_lb,
+                    flat_ub,
+                    UB,
+                )
+                if np.any(cutoff_lb > flat_lb + 1e-10) or np.any(cutoff_ub < flat_ub - 1e-10):
+                    flat_lb = np.maximum(flat_lb, cutoff_lb)
+                    flat_ub = np.minimum(flat_ub, cutoff_ub)
+                    _apply_flat_bounds_to_model(model, flat_lb, flat_ub)
+                    try:
+                        from discopt.solvers._root_presolve import tighten_root_bounds_with_fbbt
+
+                        fbbt_lb, fbbt_ub, fbbt_infeasible, _fbbt_changed = (
+                            tighten_root_bounds_with_fbbt(
+                                model,
+                                flat_lb,
+                                flat_ub,
+                                int_offsets,
+                                int_sizes,
+                            )
+                        )
+                        if not fbbt_infeasible:
+                            flat_lb = np.maximum(flat_lb, fbbt_lb)
+                            flat_ub = np.minimum(flat_ub, fbbt_ub)
+                    except Exception as _cutoff_fbbt_err:
+                        logger.debug(
+                            "AMP objective cutoff FBBT skipped: %s",
+                            _cutoff_fbbt_err,
+                        )
+                    part_vars, part_lbs, part_ubs = _refresh_partitions_for_bounds(
+                        model,
+                        disc_state,
+                        flat_lb,
+                        flat_ub,
+                        part_vars,
+                        disc_abs_width_tol,
+                        n_init_partitions,
+                    )
+                    logger.info(
+                        "AMP objective cutoff tightened bounds before alpha-BB OA generation"
+                    )
+
+            if (
+                UB < np.inf
+                and not _cutoff_obbt_done
+                and (obbt_with_cutoff or (has_nonconvex_oa_row and had_effectively_unbounded))
+            ):
+                _cutoff_obbt_done = True
+                flat_lb, flat_ub, part_vars, part_lbs, part_ubs = _run_cutoff_obbt(
+                    model=model,
+                    terms=terms,
+                    disc_state=disc_state,
+                    oa_cuts=oa_cuts,
+                    convhull_mode=convhull_mode,
+                    UB=UB,
+                    flat_lb=flat_lb,
+                    flat_ub=flat_ub,
+                    part_vars=part_vars,
+                    part_lbs=part_lbs,
+                    part_ubs=part_ubs,
+                    n_orig=n_orig,
+                    obbt_time_limit=obbt_time_limit,
+                    partition_scaling_factor=partition_scaling_factor,
+                    disc_abs_width_tol=disc_abs_width_tol,
+                    n_init_partitions=n_init_partitions,
+                    deadline=deadline,
+                    iteration=iteration_idx,
+                    from_min_space=_from_minimization_space,
+                )
+                _last_obbt_iter = iteration_idx
+
+            try:
+                alphabb_cuts = generate_alphabb_quadratic_oa_cuts_from_evaluator(
+                    evaluator,
+                    _x_orig,
+                    flat_lb,
+                    flat_ub,
+                    constraint_senses=_senses,
+                    convex_mask=oa_convexity.constraint_mask,
+                )
+                appended += _append_linearized_cuts(alphabb_cuts)
+            except Exception as _alphabb_oa_err:
+                logger.debug(
+                    "AMP: alpha-BB OA cut computation failed: %s",
+                    _alphabb_oa_err,
+                )
+
+            _prune_oa_cuts(oa_cuts)
+        except Exception as _oa_err:
+            logger.debug("AMP: OA cut computation failed: %s", _oa_err)
+        return appended
+
     for iteration in range(1, max_iter + 1):
         elapsed = time.perf_counter() - t_start
         if elapsed >= time_limit:
@@ -2188,6 +2556,39 @@ def solve_amp(
                             initial_point=initial_point_arr,
                         )
                         if recovered is not None:
+                            recovered_x = None
+                            if recovered.x is not None:
+                                try:
+                                    recovered_x = np.concatenate(
+                                        [
+                                            np.asarray(recovered.x[var.name], dtype=np.float64)
+                                            .reshape(-1)
+                                            .copy()
+                                            for var in model._variables
+                                        ]
+                                    )
+                                except Exception:
+                                    recovered_x = None
+                            if recovered_x is not None and recovered.objective is not None:
+                                incumbent = recovered_x
+                                UB = (
+                                    -float(recovered.objective)
+                                    if maximize
+                                    else float(recovered.objective)
+                                )
+                                n_before = len(oa_cuts)
+                                _add_incumbent_oa_cuts_after_cutoff_tightening(
+                                    incumbent,
+                                    iteration,
+                                )
+                                if len(oa_cuts) > n_before:
+                                    termination_reason = "iteration_limit"
+                                    logger.info(
+                                        "AMP: continuing after pure-continuous recovery "
+                                        "with %d OA cuts",
+                                        len(oa_cuts) - n_before,
+                                    )
+                                    continue
                             recovered.mip_count = mip_count
                             return recovered
                     fallback_x, fallback_obj = _solve_small_integer_domain_fallback(
@@ -2259,86 +2660,10 @@ def solve_amp(
                     _from_minimization_space(UB),
                 )
 
-                # Accumulate OA tangent cuts at this NLP solution to tighten
-                # the next MILP relaxation.  Uses existing OA infrastructure
-                # from cutting_planes.py which handles all constraint senses.
-                try:
-                    from discopt._jax.cutting_planes import (
-                        generate_alphabb_quadratic_oa_cuts_from_evaluator,
-                        generate_oa_cuts_from_evaluator,
-                    )
-                    from discopt.modeling.core import Constraint
-
-                    _x_orig = x_nlp[:n_orig]
-                    if evaluator.n_constraints > 0:
-                        _senses = [c.sense for c in model._constraints if isinstance(c, Constraint)]
-                        cuts = generate_oa_cuts_from_evaluator(
-                            evaluator,
-                            _x_orig,
-                            constraint_senses=_senses,
-                            convex_mask=oa_convexity.constraint_mask,
-                        )
-
-                        try:
-                            cuts.extend(
-                                generate_alphabb_quadratic_oa_cuts_from_evaluator(
-                                    evaluator,
-                                    _x_orig,
-                                    flat_lb,
-                                    flat_ub,
-                                    constraint_senses=_senses,
-                                    convex_mask=oa_convexity.constraint_mask,
-                                )
-                            )
-                        except Exception as _alphabb_oa_err:
-                            logger.debug(
-                                "AMP: alpha-BB OA cut computation failed: %s",
-                                _alphabb_oa_err,
-                            )
-
-                        for cut in cuts:
-                            if np.linalg.norm(cut.coeffs) < 1e-12:
-                                continue
-                            if cut.sense == ">=":
-                                # Convert to <= form for milp_relaxation.py
-                                oa_cuts.append((-cut.coeffs, -cut.rhs))
-                            elif cut.sense == "==":
-                                oa_cuts.append((cut.coeffs, cut.rhs))
-                                oa_cuts.append((-cut.coeffs, -cut.rhs))
-                            else:
-                                oa_cuts.append((cut.coeffs, cut.rhs))
-                        _prune_oa_cuts(oa_cuts)
-                except Exception as _oa_err:
-                    logger.debug("AMP: OA cut computation failed: %s", _oa_err)
-
-                # ── Cutoff OBBT (first incumbent) ────────────────────────────
-                # Re-run OBBT with c^T x <= UB to exclude regions that cannot
-                # improve on the new incumbent.  Uses the current disc_state
-                # so envelopes are tighter than the empty-partition LP.
-                if obbt_with_cutoff and not _cutoff_obbt_done:
-                    _cutoff_obbt_done = True
-                    flat_lb, flat_ub, part_vars, part_lbs, part_ubs = _run_cutoff_obbt(
-                        model=model,
-                        terms=terms,
-                        disc_state=disc_state,
-                        oa_cuts=oa_cuts,
-                        convhull_mode=convhull_mode,
-                        UB=UB,
-                        flat_lb=flat_lb,
-                        flat_ub=flat_ub,
-                        part_vars=part_vars,
-                        part_lbs=part_lbs,
-                        part_ubs=part_ubs,
-                        n_orig=n_orig,
-                        obbt_time_limit=obbt_time_limit,
-                        partition_scaling_factor=partition_scaling_factor,
-                        disc_abs_width_tol=disc_abs_width_tol,
-                        n_init_partitions=n_init_partitions,
-                        deadline=deadline,
-                        iteration=iteration,
-                        from_min_space=_from_minimization_space,
-                    )
-                    _last_obbt_iter = iteration
+                # Accumulate OA tangent cuts at this NLP solution.  Direct
+                # convex OA cuts are appended first, then cutoff tightening runs
+                # before alpha-BB tries to build cuts that require finite boxes.
+                _add_incumbent_oa_cuts_after_cutoff_tightening(x_nlp, iteration)
 
         # ── Periodic cutoff OBBT ─────────────────────────────────────────────
         # After the first incumbent OBBT, re-run periodically as partitioning

--- a/python/discopt/solvers/amp.py
+++ b/python/discopt/solvers/amp.py
@@ -1885,6 +1885,7 @@ def solve_amp(
     skip_convex_check: bool = False,
     obbt_at_root: bool = False,
     obbt_with_cutoff: bool = False,
+    alphabb_cutoff_obbt: bool = True,
     obbt_time_limit: float = 30.0,
 ) -> SolveResult:
     """Solve MINLP globally using Adaptive Multivariate Partitioning (AMP).
@@ -1981,6 +1982,12 @@ def solve_amp(
         to redirect adaptive partition refinement toward a worse fixed point
         on problems where variable bounds are already reasonably tight; turn
         on for problems with loose initial variable bounds.
+    alphabb_cutoff_obbt : bool, default True
+        Allow one cutoff OBBT pass before alpha-BB OA generation when a
+        nonconvex OA row starts from effectively unbounded variable bounds.
+        This is independent of the broader ``obbt_with_cutoff`` option and is
+        used to create finite boxes for alpha-BB cuts on loose MINLPTests-style
+        instances. Set False to disable this alpha-BB prerequisite pass.
     obbt_time_limit : float, default 30.0
         Total wall-clock budget for OBBT calls (in seconds).  Per-LP budget is
         ``min(1.0, obbt_time_limit / max(1, 2*n_candidates))``.
@@ -2450,7 +2457,10 @@ def solve_amp(
             if (
                 UB < np.inf
                 and not _cutoff_obbt_done
-                and (obbt_with_cutoff or (has_nonconvex_oa_row and had_effectively_unbounded))
+                and (
+                    obbt_with_cutoff
+                    or (alphabb_cutoff_obbt and has_nonconvex_oa_row and had_effectively_unbounded)
+                )
             ):
                 _cutoff_obbt_done = True
                 flat_lb, flat_ub, part_vars, part_lbs, part_ubs = _run_cutoff_obbt(

--- a/python/discopt/solvers/amp.py
+++ b/python/discopt/solvers/amp.py
@@ -1869,7 +1869,7 @@ def _run_cutoff_obbt(
 # ---------------------------------------------------------------------------
 
 
-def solve_amp(
+def _solve_amp_impl(
     model: Model,
     rel_gap: float = 1e-3,
     abs_tol: float = 1e-6,
@@ -3038,3 +3038,78 @@ def solve_amp(
             gap_certified=False,
         )
     )
+
+
+def solve_amp(
+    model: Model,
+    rel_gap: float = 1e-3,
+    abs_tol: float = 1e-6,
+    time_limit: float = 3600.0,
+    max_iter: int = 50,
+    n_init_partitions: int = 2,
+    partition_method: str = "auto",
+    nlp_solver: str = "ipm",
+    iteration_callback: Optional[Callable] = None,
+    milp_time_limit: Optional[float] = None,
+    milp_gap_tolerance: Optional[float] = None,
+    apply_partitioning: bool = True,
+    disc_var_pick: int | str | Callable[[dict[str, Any]], Any] | None = None,
+    partition_scaling_factor: float = 10.0,
+    partition_scaling_factor_update: Optional[Callable[[dict[str, Any]], Any]] = None,
+    disc_add_partition_method: str | Callable[[dict[str, Any]], Any] = "adaptive",
+    disc_abs_width_tol: float = 1e-3,
+    convhull_formulation: str = "disaggregated",
+    convhull_ebd: bool = False,
+    convhull_ebd_encoding: str = "gray",
+    presolve_bt: bool = True,
+    presolve_bt_algo: int | str = 1,
+    presolve_bt_time_limit: Optional[float] = None,
+    presolve_bt_mip_time_limit: Optional[float] = None,
+    initial_point: Optional[np.ndarray] = None,
+    use_start_as_incumbent: bool = False,
+    skip_convex_check: bool = False,
+    obbt_at_root: bool = False,
+    obbt_with_cutoff: bool = False,
+    alphabb_cutoff_obbt: bool = True,
+    obbt_time_limit: float = 30.0,
+) -> SolveResult:
+    saved_bounds = _snapshot_variable_bounds(model)
+    try:
+        return _solve_amp_impl(
+            model,
+            rel_gap=rel_gap,
+            abs_tol=abs_tol,
+            time_limit=time_limit,
+            max_iter=max_iter,
+            n_init_partitions=n_init_partitions,
+            partition_method=partition_method,
+            nlp_solver=nlp_solver,
+            iteration_callback=iteration_callback,
+            milp_time_limit=milp_time_limit,
+            milp_gap_tolerance=milp_gap_tolerance,
+            apply_partitioning=apply_partitioning,
+            disc_var_pick=disc_var_pick,
+            partition_scaling_factor=partition_scaling_factor,
+            partition_scaling_factor_update=partition_scaling_factor_update,
+            disc_add_partition_method=disc_add_partition_method,
+            disc_abs_width_tol=disc_abs_width_tol,
+            convhull_formulation=convhull_formulation,
+            convhull_ebd=convhull_ebd,
+            convhull_ebd_encoding=convhull_ebd_encoding,
+            presolve_bt=presolve_bt,
+            presolve_bt_algo=presolve_bt_algo,
+            presolve_bt_time_limit=presolve_bt_time_limit,
+            presolve_bt_mip_time_limit=presolve_bt_mip_time_limit,
+            initial_point=initial_point,
+            use_start_as_incumbent=use_start_as_incumbent,
+            skip_convex_check=skip_convex_check,
+            obbt_at_root=obbt_at_root,
+            obbt_with_cutoff=obbt_with_cutoff,
+            alphabb_cutoff_obbt=alphabb_cutoff_obbt,
+            obbt_time_limit=obbt_time_limit,
+        )
+    finally:
+        _restore_variable_bounds(saved_bounds)
+
+
+solve_amp.__doc__ = _solve_amp_impl.__doc__

--- a/python/discopt/solvers/amp.py
+++ b/python/discopt/solvers/amp.py
@@ -2264,6 +2264,7 @@ def solve_amp(
                 # from cutting_planes.py which handles all constraint senses.
                 try:
                     from discopt._jax.cutting_planes import (
+                        generate_alphabb_quadratic_oa_cuts_from_evaluator,
                         generate_oa_cuts_from_evaluator,
                     )
                     from discopt.modeling.core import Constraint
@@ -2276,6 +2277,16 @@ def solve_amp(
                             _x_orig,
                             constraint_senses=_senses,
                             convex_mask=oa_convexity.constraint_mask,
+                        )
+                        cuts.extend(
+                            generate_alphabb_quadratic_oa_cuts_from_evaluator(
+                                evaluator,
+                                _x_orig,
+                                flat_lb,
+                                flat_ub,
+                                constraint_senses=_senses,
+                                convex_mask=oa_convexity.constraint_mask,
+                            )
                         )
                         for cut in cuts:
                             if np.linalg.norm(cut.coeffs) < 1e-12:

--- a/python/discopt/solvers/amp.py
+++ b/python/discopt/solvers/amp.py
@@ -1780,6 +1780,10 @@ def _run_cutoff_obbt(
     relaxation reflects the latest envelope strength.  Returns possibly
     updated (flat_lb, flat_ub, part_vars, part_lbs, part_ubs).
     """
+    remaining_wall_time = _remaining_wall_time(deadline)
+    if remaining_wall_time is not None and remaining_wall_time <= 0.0:
+        return flat_lb, flat_ub, part_vars, part_lbs, part_ubs
+
     try:
         from discopt._jax.milp_relaxation import build_milp_relaxation
         from discopt._jax.obbt import run_obbt_on_relaxation
@@ -1795,8 +1799,18 @@ def _run_cutoff_obbt(
         candidates = sorted(set(part_vars) | set(terms.partition_candidates))
         if not candidates:
             return flat_lb, flat_ub, part_vars, part_lbs, part_ubs
-        per_lp = max(0.05, min(1.0, obbt_time_limit / max(1, 2 * len(candidates))))
-        remaining = max(1.0, min(obbt_time_limit, deadline - time.perf_counter()))
+        remaining_wall_time = _remaining_wall_time(deadline)
+        if remaining_wall_time is not None and remaining_wall_time <= 0.0:
+            return flat_lb, flat_ub, part_vars, part_lbs, part_ubs
+        remaining = obbt_time_limit
+        if remaining_wall_time is not None:
+            remaining = min(remaining, remaining_wall_time)
+        if remaining <= 0.0:
+            return flat_lb, flat_ub, part_vars, part_lbs, part_ubs
+        per_lp = min(
+            remaining,
+            max(0.05, min(1.0, obbt_time_limit / max(1, 2 * len(candidates)))),
+        )
         result = run_obbt_on_relaxation(
             cutoff_relax,
             n_orig=n_orig,
@@ -2454,9 +2468,12 @@ def solve_amp(
                         "AMP objective cutoff tightened bounds before alpha-BB OA generation"
                     )
 
+            remaining_for_cutoff_obbt = _remaining_wall_time(deadline)
             if (
                 UB < np.inf
                 and not _cutoff_obbt_done
+                and remaining_for_cutoff_obbt is not None
+                and remaining_for_cutoff_obbt > 0.0
                 and (
                     obbt_with_cutoff
                     or (alphabb_cutoff_obbt and has_nonconvex_oa_row and had_effectively_unbounded)

--- a/python/discopt/solvers/amp.py
+++ b/python/discopt/solvers/amp.py
@@ -2057,6 +2057,11 @@ def solve_amp(
     n_orig = sum(v.size for v in model._variables)
     flat_lb, flat_ub = flat_variable_bounds(model)
     initial_point_arr = _normalize_initial_point(initial_point, n_orig, flat_lb, flat_ub)
+    original_variable_bounds = _snapshot_variable_bounds(model)
+
+    def _finish(result: SolveResult) -> SolveResult:
+        _restore_variable_bounds(original_variable_bounds)
+        return result
 
     if pure_continuous and not skip_convex_check:
         try:
@@ -2078,7 +2083,7 @@ def solve_amp(
                     initial_point=initial_point_arr,
                 )
                 result.convex_fast_path = True
-                return result
+                return _finish(result)
         except Exception as exc:
             logger.debug("AMP: convex delegation check failed: %s", exc)
 
@@ -2104,11 +2109,13 @@ def solve_amp(
         int_sizes,
     )
     if root_infeasible:
-        return SolveResult(
-            status="infeasible",
-            wall_time=time.perf_counter() - t_start,
-            mip_count=0,
-            gap_certified=True,
+        return _finish(
+            SolveResult(
+                status="infeasible",
+                wall_time=time.perf_counter() - t_start,
+                mip_count=0,
+                gap_certified=True,
+            )
         )
     if root_changed:
         logger.info("AMP: root FBBT tightened variable bounds before relaxation")
@@ -2121,11 +2128,13 @@ def solve_amp(
             "AMP: nonlinear bound tightening proved infeasibility: %s",
             nonlinear_bt_stats.infeasibility_reason,
         )
-        return SolveResult(
-            status="infeasible",
-            wall_time=time.perf_counter() - t_start,
-            mip_count=0,
-            gap_certified=True,
+        return _finish(
+            SolveResult(
+                status="infeasible",
+                wall_time=time.perf_counter() - t_start,
+                mip_count=0,
+                gap_certified=True,
+            )
         )
     if nonlinear_bt_stats.n_tightened > 0:
         flat_lb = tightened_lb
@@ -2621,7 +2630,7 @@ def solve_amp(
                                     )
                                     continue
                             recovered.mip_count = mip_count
-                            return recovered
+                            return _finish(recovered)
                     fallback_x, fallback_obj = _solve_small_integer_domain_fallback(
                         model,
                         evaluator,
@@ -2633,21 +2642,25 @@ def solve_amp(
                         deadline=deadline,
                     )
                     if fallback_x is not None and fallback_obj is not None:
-                        return SolveResult(
-                            status="feasible",
-                            objective=_from_minimization_space(fallback_obj),
-                            bound=None,
-                            gap=None,
-                            x=_build_x_dict(fallback_x, model),
-                            wall_time=time.perf_counter() - t_start,
-                            mip_count=mip_count,
-                            gap_certified=False,
+                        return _finish(
+                            SolveResult(
+                                status="feasible",
+                                objective=_from_minimization_space(fallback_obj),
+                                bound=None,
+                                gap=None,
+                                x=_build_x_dict(fallback_x, model),
+                                wall_time=time.perf_counter() - t_start,
+                                mip_count=mip_count,
+                                gap_certified=False,
+                            )
                         )
                     if milp_result.status == "infeasible":
-                        return SolveResult(
-                            status="infeasible",
-                            wall_time=time.perf_counter() - t_start,
-                            mip_count=mip_count,
+                        return _finish(
+                            SolveResult(
+                                status="infeasible",
+                                wall_time=time.perf_counter() - t_start,
+                                mip_count=mip_count,
+                            )
                         )
             break
 
@@ -2946,11 +2959,13 @@ def solve_amp(
             status = "error"
         else:
             status = "iteration_limit"
-        return SolveResult(
-            status=status,
-            wall_time=elapsed,
-            mip_count=mip_count,
-            gap_certified=False,
+        return _finish(
+            SolveResult(
+                status=status,
+                wall_time=elapsed,
+                mip_count=mip_count,
+                gap_certified=False,
+            )
         )
 
     if incumbent is not None:
@@ -2971,15 +2986,19 @@ def solve_amp(
         rel_gap_final = _compute_relative_gap(abs_gap_final, UB)
         status = "optimal" if gap_certified else "feasible"
 
-        return SolveResult(
-            status=status,
-            objective=_from_minimization_space(UB),
-            bound=(_from_minimization_space(LB) if LB > -np.inf and bound_is_trustworthy else None),
-            gap=float(rel_gap_final) if rel_gap_final is not None else None,
-            x=_build_x_dict(incumbent, model),
-            wall_time=elapsed,
-            mip_count=mip_count,
-            gap_certified=gap_certified,
+        return _finish(
+            SolveResult(
+                status=status,
+                objective=_from_minimization_space(UB),
+                bound=(
+                    _from_minimization_space(LB) if LB > -np.inf and bound_is_trustworthy else None
+                ),
+                gap=float(rel_gap_final) if rel_gap_final is not None else None,
+                x=_build_x_dict(incumbent, model),
+                wall_time=elapsed,
+                mip_count=mip_count,
+                gap_certified=gap_certified,
+            )
         )
 
     # No feasible solution found
@@ -2996,7 +3015,7 @@ def solve_amp(
         )
         if recovered is not None:
             recovered.mip_count = mip_count
-            return recovered
+            return _finish(recovered)
 
     if termination_reason == "time_limit" or elapsed >= time_limit:
         status = "time_limit"
@@ -3007,13 +3026,15 @@ def solve_amp(
     else:
         status = "iteration_limit"
 
-    return SolveResult(
-        status=status,
-        objective=None,
-        bound=_from_minimization_space(LB) if LB > -np.inf else None,
-        gap=None,
-        x=None,
-        wall_time=elapsed,
-        mip_count=mip_count,
-        gap_certified=False,
+    return _finish(
+        SolveResult(
+            status=status,
+            objective=None,
+            bound=_from_minimization_space(LB) if LB > -np.inf else None,
+            gap=None,
+            x=None,
+            wall_time=elapsed,
+            mip_count=mip_count,
+            gap_certified=False,
+        )
     )

--- a/python/discopt/solvers/amp.py
+++ b/python/discopt/solvers/amp.py
@@ -129,6 +129,10 @@ def _refresh_partitions_for_bounds(
     part_vars = [i for i in part_vars if float(flat_ub[i]) - float(flat_lb[i]) > disc_abs_width_tol]
     part_lbs = [float(flat_lb[i]) for i in part_vars]
     part_ubs = [float(flat_ub[i]) for i in part_vars]
+    active_part_vars = set(part_vars)
+    for stale_idx in list(disc_state.partitions):
+        if stale_idx not in active_part_vars:
+            del disc_state.partitions[stale_idx]
     for k_pv, v_idx in enumerate(part_vars):
         pts = disc_state.partitions.get(v_idx)
         new_lo = float(part_lbs[k_pv])
@@ -282,17 +286,17 @@ def _tighten_simple_power_group(
             return lb, min(ub, bound)
         return max(lb, bound), ub
 
+    if degree % 2 == 1:
+        signed_root = float(np.sign(rhs / coeff) * (abs(rhs / coeff) ** (1.0 / degree)))
+        if coeff > 0.0:
+            return lb, min(ub, signed_root)
+        return max(lb, signed_root), ub
+
     if coeff <= 0.0 or rhs < 0.0:
         return lb, ub
 
     radius = float((rhs / coeff) ** (1.0 / degree))
-    if degree % 2 == 0:
-        return max(lb, -radius), min(ub, radius)
-    if lb >= 0.0:
-        return lb, min(ub, radius)
-    if ub <= 0.0:
-        return max(lb, -radius), ub
-    return lb, ub
+    return max(lb, -radius), min(ub, radius)
 
 
 def _tighten_bounds_with_objective_cutoff(

--- a/python/discopt/solvers/amp.py
+++ b/python/discopt/solvers/amp.py
@@ -2278,16 +2278,24 @@ def solve_amp(
                             constraint_senses=_senses,
                             convex_mask=oa_convexity.constraint_mask,
                         )
-                        cuts.extend(
-                            generate_alphabb_quadratic_oa_cuts_from_evaluator(
-                                evaluator,
-                                _x_orig,
-                                flat_lb,
-                                flat_ub,
-                                constraint_senses=_senses,
-                                convex_mask=oa_convexity.constraint_mask,
+
+                        try:
+                            cuts.extend(
+                                generate_alphabb_quadratic_oa_cuts_from_evaluator(
+                                    evaluator,
+                                    _x_orig,
+                                    flat_lb,
+                                    flat_ub,
+                                    constraint_senses=_senses,
+                                    convex_mask=oa_convexity.constraint_mask,
+                                )
                             )
-                        )
+                        except Exception as _alphabb_oa_err:
+                            logger.debug(
+                                "AMP: alpha-BB OA cut computation failed: %s",
+                                _alphabb_oa_err,
+                            )
+
                         for cut in cuts:
                             if np.linalg.norm(cut.coeffs) < 1e-12:
                                 continue

--- a/python/tests/test_amp.py
+++ b/python/tests/test_amp.py
@@ -2184,6 +2184,77 @@ def test_refresh_partitions_for_bounds_prunes_stale_partition_entries():
     np.testing.assert_allclose(x.ub, flat_ub)
 
 
+@pytest.mark.parametrize(
+    ("solver_kwargs", "expected_obbt_calls"),
+    [
+        ({}, 1),
+        ({"alphabb_cutoff_obbt": False}, 0),
+        ({"alphabb_cutoff_obbt": False, "obbt_with_cutoff": True}, 1),
+    ],
+)
+def test_alphabb_cutoff_obbt_option_controls_prerequisite_pass(
+    monkeypatch,
+    solver_kwargs,
+    expected_obbt_calls,
+):
+    """The alpha-BB cutoff OBBT pass has its own switch."""
+    from discopt._jax.milp_relaxation import MilpRelaxationResult
+    from discopt.solvers import amp as amp_mod
+
+    calls = []
+
+    monkeypatch.setattr(
+        amp_mod,
+        "_solve_milp_with_oa_recovery",
+        lambda **kwargs: (
+            MilpRelaxationResult(
+                status="optimal",
+                objective=-1.0,
+                x=np.array([0.0, 0.0], dtype=np.float64),
+            ),
+            {},
+            [],
+            1,
+        ),
+    )
+    monkeypatch.setattr(
+        amp_mod,
+        "_solve_best_nlp_candidate",
+        lambda *args, **kwargs: (np.array([0.0, 0.0], dtype=np.float64), 0.0),
+    )
+
+    def fake_cutoff_obbt(**kwargs):
+        calls.append(kwargs["iteration"])
+        return (
+            kwargs["flat_lb"],
+            kwargs["flat_ub"],
+            kwargs["part_vars"],
+            kwargs["part_lbs"],
+            kwargs["part_ubs"],
+        )
+
+    monkeypatch.setattr(amp_mod, "_run_cutoff_obbt", fake_cutoff_obbt)
+
+    m = Model("alphabb_cutoff_obbt_option")
+    x = m.continuous("x")
+    y = m.continuous("y")
+    m.minimize(x + y**2)
+    m.subject_to(x**2 <= y**2 + 1.0)
+
+    result = m.solve(
+        solver="amp",
+        apply_partitioning=False,
+        skip_convex_check=True,
+        presolve_bt=False,
+        max_iter=1,
+        time_limit=5,
+        **solver_kwargs,
+    )
+
+    assert result.status in ("optimal", "feasible")
+    assert len(calls) == expected_obbt_calls
+
+
 def test_objective_cutoff_bounds_enable_alphabb_for_issue_63_instances():
     """The exact nlp_008 objective cutoff should create finite alpha-BB bounds."""
     from discopt._jax.convexity import classify_oa_cut_convexity

--- a/python/tests/test_amp.py
+++ b/python/tests/test_amp.py
@@ -2082,6 +2082,31 @@ def test_alphabb_quadratic_oa_cut_covers_issue_63_row():
         assert float(np.dot(cut.coeffs, point)) <= cut.rhs + 1e-8
 
 
+def test_alphabb_quadratic_oa_skips_nonquadratic_row():
+    """Nonquadratic rows must not be accepted by local Hessian coincidence."""
+    from discopt._jax.cutting_planes import generate_alphabb_quadratic_oa_cuts_from_evaluator
+    from discopt._jax.model_utils import flat_variable_bounds
+    from discopt._jax.nlp_evaluator import NLPEvaluator
+
+    m = Model("nonquadratic_alphabb_skip")
+    x = m.continuous("x", lb=-1.0, ub=1.0)
+    m.subject_to(-(x**4) <= -1.0)
+    m.minimize(x)
+
+    evaluator = NLPEvaluator(m)
+    flat_lb, flat_ub = flat_variable_bounds(m)
+    cuts = generate_alphabb_quadratic_oa_cuts_from_evaluator(
+        evaluator,
+        np.array([-0.173], dtype=np.float64),
+        flat_lb,
+        flat_ub,
+        constraint_senses=[c.sense for c in m._constraints],
+        convex_mask=[False],
+    )
+
+    assert cuts == []
+
+
 def test_amp_appends_alphabb_cut_for_issue_63_quadratic(monkeypatch):
     """AMP should append an alpha-BB cut for the nonconvex quadratic row."""
     import discopt._jax.cutting_planes as cutting_planes
@@ -2140,6 +2165,79 @@ def test_amp_appends_alphabb_cut_for_issue_63_quadratic(monkeypatch):
     coeffs, rhs = captured_cuts[0]
     assert np.linalg.norm(coeffs) > 1e-12
     assert np.isfinite(rhs)
+
+
+def test_amp_keeps_direct_oa_when_alphabb_generation_fails(monkeypatch):
+    """Alpha-BB failures should not suppress already generated convex OA cuts."""
+    import discopt._jax.cutting_planes as cutting_planes
+    from discopt._jax.cutting_planes import LinearCut
+    from discopt._jax.milp_relaxation import MilpRelaxationResult
+    from discopt.solvers import amp as amp_mod
+
+    captured_cuts = []
+
+    monkeypatch.setattr(
+        amp_mod,
+        "_solve_milp_with_oa_recovery",
+        lambda **kwargs: (
+            MilpRelaxationResult(
+                status="optimal",
+                objective=0.0,
+                x=np.array([1.0], dtype=np.float64),
+            ),
+            {},
+            [],
+            1,
+        ),
+    )
+    monkeypatch.setattr(
+        amp_mod,
+        "_solve_best_nlp_candidate",
+        lambda *args, **kwargs: (np.array([1.0], dtype=np.float64), 1.0),
+    )
+    monkeypatch.setattr(
+        cutting_planes,
+        "generate_oa_cuts_from_evaluator",
+        lambda *args, **kwargs: [
+            LinearCut(coeffs=np.array([1.0], dtype=np.float64), rhs=2.0, sense="<=")
+        ],
+    )
+
+    def fail_alphabb(*args, **kwargs):
+        del args, kwargs
+        raise RuntimeError("alpha-BB failure")
+
+    def spy_prune(oa_cuts, max_cuts=128):
+        del max_cuts
+        captured_cuts[:] = list(oa_cuts)
+        return None
+
+    monkeypatch.setattr(
+        cutting_planes,
+        "generate_alphabb_quadratic_oa_cuts_from_evaluator",
+        fail_alphabb,
+    )
+    monkeypatch.setattr(amp_mod, "_prune_oa_cuts", spy_prune)
+
+    m = Model("direct_oa_survives_alphabb_failure")
+    x = m.continuous("x", lb=0.0, ub=2.0)
+    m.subject_to(x <= 2.0)
+    m.minimize(x)
+
+    result = m.solve(
+        solver="amp",
+        apply_partitioning=False,
+        skip_convex_check=True,
+        presolve_bt=False,
+        max_iter=1,
+        time_limit=5,
+    )
+
+    assert result.status in ("optimal", "feasible")
+    assert len(captured_cuts) == 1
+    coeffs, rhs = captured_cuts[0]
+    np.testing.assert_allclose(coeffs, np.array([1.0], dtype=np.float64))
+    assert rhs == pytest.approx(2.0)
 
 
 def test_amp_root_presolve_preserves_heterogeneous_array_bounds():

--- a/python/tests/test_amp.py
+++ b/python/tests/test_amp.py
@@ -2107,6 +2107,83 @@ def test_alphabb_quadratic_oa_skips_nonquadratic_row():
     assert cuts == []
 
 
+def test_objective_cutoff_odd_power_tightening_uses_signed_monotonic_root():
+    """Odd monomials are monotone, not symmetric level sets."""
+    from discopt.solvers import amp as amp_mod
+
+    assert amp_mod._tighten_simple_power_group({3: 1.0}, 8.0, -10.0, 10.0) == pytest.approx(
+        (-10.0, 2.0)
+    )
+    assert amp_mod._tighten_simple_power_group({3: 1.0}, 8.0, -10.0, -1.0) == pytest.approx(
+        (-10.0, -1.0)
+    )
+    assert amp_mod._tighten_simple_power_group({3: 1.0}, -8.0, -10.0, 10.0) == pytest.approx(
+        (-10.0, -2.0)
+    )
+    assert amp_mod._tighten_simple_power_group({3: -1.0}, 8.0, -10.0, 10.0) == pytest.approx(
+        (-2.0, 10.0)
+    )
+
+
+def test_objective_cutoff_negative_odd_power_interval_preserves_feasible_points():
+    """A positive cutoff on x**3 over a negative interval must not trim the left side."""
+    from discopt._jax.model_utils import flat_variable_bounds
+    from discopt.solvers import amp as amp_mod
+
+    m = Model("odd_power_cutoff_counterexample")
+    x = m.continuous("x", lb=-10.0, ub=-1.0)
+    y = m.continuous("y", lb=100.0, ub=100.0)
+    m.minimize(x**3 + y**2)
+
+    flat_lb, flat_ub = flat_variable_bounds(m)
+    cutoff = 10001.0
+    cutoff_lb, cutoff_ub = amp_mod._tighten_bounds_with_objective_cutoff(
+        m,
+        flat_lb,
+        flat_ub,
+        cutoff=cutoff,
+    )
+
+    assert (-10.0) ** 3 + 100.0**2 <= cutoff
+    np.testing.assert_allclose(cutoff_lb, flat_lb)
+    np.testing.assert_allclose(cutoff_ub, flat_ub)
+
+
+def test_refresh_partitions_for_bounds_prunes_stale_partition_entries():
+    """Dropped partition vars must not leave stale active entries in disc_state."""
+    from discopt.solvers import amp as amp_mod
+
+    m = Model("partition_refresh_prunes_stale")
+    x = m.continuous("x", shape=(3,))
+    disc_state = SimpleNamespace(
+        partitions={
+            0: np.array([-5.0, 0.0, 5.0], dtype=np.float64),
+            1: np.array([1.0, 2.0, 3.0], dtype=np.float64),
+            2: np.array([-3.0, 0.0, 3.0], dtype=np.float64),
+        }
+    )
+    flat_lb = np.array([-1.0, 2.0, -3.0], dtype=np.float64)
+    flat_ub = np.array([1.0, 2.0, 3.0], dtype=np.float64)
+
+    part_vars, part_lbs, part_ubs = amp_mod._refresh_partitions_for_bounds(
+        m,
+        disc_state,
+        flat_lb,
+        flat_ub,
+        part_vars=[0, 1],
+        disc_abs_width_tol=1e-9,
+        n_init_partitions=2,
+    )
+
+    assert part_vars == [0]
+    assert part_lbs == [-1.0]
+    assert part_ubs == [1.0]
+    assert set(disc_state.partitions) == {0}
+    np.testing.assert_allclose(disc_state.partitions[0], np.array([-1.0, 0.0, 1.0]))
+    np.testing.assert_allclose(x.lb, flat_lb)
+    np.testing.assert_allclose(x.ub, flat_ub)
+
+
 def test_objective_cutoff_bounds_enable_alphabb_for_issue_63_instances():
     """The exact nlp_008 objective cutoff should create finite alpha-BB bounds."""
     from discopt._jax.convexity import classify_oa_cut_convexity

--- a/python/tests/test_amp.py
+++ b/python/tests/test_amp.py
@@ -2035,6 +2035,113 @@ def test_oa_cut_generation_receives_convex_constraint_mask(monkeypatch):
     assert recorded_masks == [[True, False]]
 
 
+def test_alphabb_quadratic_oa_cut_covers_issue_63_row():
+    """The indefinite quadratic row should get a relaxed OA cut, not direct OA."""
+    from discopt._jax.convexity import classify_oa_cut_convexity
+    from discopt._jax.cutting_planes import generate_alphabb_quadratic_oa_cuts_from_evaluator
+    from discopt._jax.model_utils import flat_variable_bounds
+    from discopt._jax.nlp_evaluator import NLPEvaluator
+
+    m = Model("issue_63_quadratic_cut")
+    x = m.continuous("x", lb=-2.0, ub=2.0)
+    y = m.continuous("y", lb=-2.0, ub=2.0)
+    z = m.continuous("z", lb=0.0, ub=1.0)
+    m.minimize(x + y**2 + z**3)
+    m.subject_to(y >= dm.exp(-x - 2) + dm.exp(-z - 2) - 2)
+    m.subject_to(x**2 <= y**2 + z**2)
+    m.subject_to(y >= x / 2 + z)
+
+    oa_convexity = classify_oa_cut_convexity(m, use_certificate=True)
+    assert oa_convexity.constraint_mask == [True, False, True]
+
+    evaluator = NLPEvaluator(m)
+    flat_lb, flat_ub = flat_variable_bounds(m)
+    x_star = np.array([0.25, 0.5, 0.25], dtype=np.float64)
+    cuts = generate_alphabb_quadratic_oa_cuts_from_evaluator(
+        evaluator,
+        x_star,
+        flat_lb,
+        flat_ub,
+        constraint_senses=[c.sense for c in m._constraints],
+        convex_mask=oa_convexity.constraint_mask,
+    )
+
+    assert len(cuts) == 1
+    cut = cuts[0]
+    assert cut.sense == "<="
+    assert np.linalg.norm(cut.coeffs) > 1e-12
+    assert np.isfinite(cut.rhs)
+
+    feasible_points = [
+        np.array([0.0, 0.0, 0.0], dtype=np.float64),
+        np.array([1.0, 1.0, 0.0], dtype=np.float64),
+        np.array([-1.0, 1.0, 1.0], dtype=np.float64),
+    ]
+    for point in feasible_points:
+        assert point[0] ** 2 <= point[1] ** 2 + point[2] ** 2 + 1e-12
+        assert float(np.dot(cut.coeffs, point)) <= cut.rhs + 1e-8
+
+
+def test_amp_appends_alphabb_cut_for_issue_63_quadratic(monkeypatch):
+    """AMP should append an alpha-BB cut for the nonconvex quadratic row."""
+    import discopt._jax.cutting_planes as cutting_planes
+    from discopt._jax.milp_relaxation import MilpRelaxationResult
+    from discopt.solvers import amp as amp_mod
+
+    captured_cuts = []
+
+    monkeypatch.setattr(
+        amp_mod,
+        "_solve_milp_with_oa_recovery",
+        lambda **kwargs: (
+            MilpRelaxationResult(
+                status="optimal",
+                objective=0.0,
+                x=np.array([0.25, 0.5, 0.25], dtype=np.float64),
+            ),
+            {},
+            [],
+            1,
+        ),
+    )
+    monkeypatch.setattr(
+        amp_mod,
+        "_solve_best_nlp_candidate",
+        lambda *args, **kwargs: (np.array([0.25, 0.5, 0.25], dtype=np.float64), 1.0),
+    )
+    monkeypatch.setattr(cutting_planes, "generate_oa_cuts_from_evaluator", lambda *a, **k: [])
+
+    def spy_prune(oa_cuts, max_cuts=128):
+        captured_cuts[:] = list(oa_cuts)
+        return None
+
+    monkeypatch.setattr(amp_mod, "_prune_oa_cuts", spy_prune)
+
+    m = Model("issue_63_amp_cut")
+    x = m.continuous("x", lb=-2.0, ub=2.0)
+    y = m.continuous("y", lb=-2.0, ub=2.0)
+    z = m.continuous("z", lb=0.0, ub=1.0)
+    m.minimize(x + y**2 + z**3)
+    m.subject_to(y >= dm.exp(-x - 2) + dm.exp(-z - 2) - 2)
+    m.subject_to(x**2 <= y**2 + z**2)
+    m.subject_to(y >= x / 2 + z)
+
+    result = m.solve(
+        solver="amp",
+        apply_partitioning=False,
+        skip_convex_check=True,
+        presolve_bt=False,
+        max_iter=1,
+        time_limit=5,
+    )
+
+    assert result.status in ("optimal", "feasible")
+    assert len(captured_cuts) == 1
+    coeffs, rhs = captured_cuts[0]
+    assert np.linalg.norm(coeffs) > 1e-12
+    assert np.isfinite(rhs)
+
+
 def test_amp_root_presolve_preserves_heterogeneous_array_bounds():
     """Root FBBT must not narrow every array element to the first element's bound."""
     m = Model("amp_heterogeneous_array_bounds")

--- a/python/tests/test_amp.py
+++ b/python/tests/test_amp.py
@@ -2107,6 +2107,71 @@ def test_alphabb_quadratic_oa_skips_nonquadratic_row():
     assert cuts == []
 
 
+def test_objective_cutoff_bounds_enable_alphabb_for_issue_63_instances():
+    """The exact nlp_008 objective cutoff should create finite alpha-BB bounds."""
+    from discopt._jax.convexity import classify_oa_cut_convexity
+    from discopt._jax.cutting_planes import generate_alphabb_quadratic_oa_cuts_from_evaluator
+    from discopt._jax.model_utils import flat_variable_bounds
+    from discopt._jax.nlp_evaluator import NLPEvaluator
+    from discopt.solvers import amp as amp_mod
+    from discopt.solvers._root_presolve import tighten_root_bounds_with_fbbt
+
+    m = Model("issue_63_exact_cutoff_bounds")
+    x = m.continuous("x")
+    y = m.continuous("y")
+    z = m.continuous("z", lb=0.0, ub=1.0)
+    m.minimize(x + y**2 + z**3)
+    m.subject_to(y >= dm.exp(-x - 2) + dm.exp(-z - 2) - 2)
+    m.subject_to(x**2 <= y**2 + z**2)
+    m.subject_to(y >= x / 2 + z)
+
+    flat_lb, flat_ub = flat_variable_bounds(m)
+    flat_lb, flat_ub, infeasible, _changed = tighten_root_bounds_with_fbbt(
+        m,
+        flat_lb,
+        flat_ub,
+        [],
+        [],
+    )
+    assert infeasible is False
+    assert not amp_mod.is_effectively_finite(float(flat_ub[0]))
+    assert not amp_mod.is_effectively_finite(float(flat_ub[1]))
+
+    cutoff_lb, cutoff_ub = amp_mod._tighten_bounds_with_objective_cutoff(
+        m,
+        flat_lb,
+        flat_ub,
+        cutoff=-0.3285279886580375,
+    )
+
+    assert amp_mod.is_effectively_finite(float(cutoff_ub[0]))
+    assert amp_mod.is_effectively_finite(float(cutoff_ub[1]))
+
+    amp_mod._apply_flat_bounds_to_model(m, cutoff_lb, cutoff_ub)
+    cutoff_lb, cutoff_ub, infeasible, _changed = tighten_root_bounds_with_fbbt(
+        m,
+        cutoff_lb,
+        cutoff_ub,
+        [],
+        [],
+    )
+    assert infeasible is False
+    assert cutoff_lb[0] > -10.0
+
+    oa_convexity = classify_oa_cut_convexity(m, use_certificate=True)
+    evaluator = NLPEvaluator(m)
+    cuts = generate_alphabb_quadratic_oa_cuts_from_evaluator(
+        evaluator,
+        np.array([-0.57718987, 0.27099034, 0.55958528], dtype=np.float64),
+        cutoff_lb,
+        cutoff_ub,
+        constraint_senses=[c.sense for c in m._constraints],
+        convex_mask=oa_convexity.constraint_mask,
+    )
+
+    assert len(cuts) == 1
+
+
 def test_amp_appends_alphabb_cut_for_issue_63_quadratic(monkeypatch):
     """AMP should append an alpha-BB cut for the nonconvex quadratic row."""
     import discopt._jax.cutting_planes as cutting_planes

--- a/python/tests/test_amp.py
+++ b/python/tests/test_amp.py
@@ -2442,6 +2442,59 @@ def test_objective_cutoff_bounds_enable_alphabb_for_issue_63_instances():
     assert len(cuts) == 1
 
 
+def test_amp_restores_model_bounds_after_objective_cutoff_tightening(monkeypatch):
+    """Internal cutoff/FBBT bounds must not leak back to the caller's model."""
+    from discopt._jax.milp_relaxation import MilpRelaxationResult
+    from discopt._jax.model_utils import flat_variable_bounds
+    from discopt.solvers import amp as amp_mod
+
+    monkeypatch.setattr(
+        amp_mod,
+        "_solve_milp_with_oa_recovery",
+        lambda **kwargs: (
+            MilpRelaxationResult(
+                status="optimal",
+                objective=-1.0,
+                x=np.array([-0.6, 0.3, 0.5], dtype=np.float64),
+            ),
+            {},
+            [],
+            1,
+        ),
+    )
+    monkeypatch.setattr(
+        amp_mod,
+        "_solve_best_nlp_candidate",
+        lambda *args, **kwargs: (np.array([-0.6, 0.3, 0.5], dtype=np.float64), -0.33),
+    )
+
+    m = Model("issue_63_bound_restore")
+    x = m.continuous("x")
+    y = m.continuous("y")
+    z = m.continuous("z", lb=0.0, ub=1.0)
+    m.minimize(x + y**2 + z**3)
+    m.subject_to(y >= dm.exp(-x - 2) + dm.exp(-z - 2) - 2)
+    m.subject_to(x**2 <= y**2 + z**2)
+    m.subject_to(y >= x / 2 + z)
+
+    original_lb, original_ub = flat_variable_bounds(m)
+
+    result = m.solve(
+        solver="amp",
+        apply_partitioning=False,
+        skip_convex_check=True,
+        presolve_bt=False,
+        alphabb_cutoff_obbt=False,
+        max_iter=1,
+        time_limit=5,
+    )
+
+    restored_lb, restored_ub = flat_variable_bounds(m)
+    assert result.status in ("optimal", "feasible")
+    np.testing.assert_allclose(restored_lb, original_lb)
+    np.testing.assert_allclose(restored_ub, original_ub)
+
+
 def test_amp_appends_alphabb_cut_for_issue_63_quadratic(monkeypatch):
     """AMP should append an alpha-BB cut for the nonconvex quadratic row."""
     import discopt._jax.cutting_planes as cutting_planes

--- a/python/tests/test_amp.py
+++ b/python/tests/test_amp.py
@@ -2495,6 +2495,63 @@ def test_amp_restores_model_bounds_after_objective_cutoff_tightening(monkeypatch
     np.testing.assert_allclose(restored_ub, original_ub)
 
 
+def test_amp_restores_model_bounds_when_callback_raises_after_cutoff(monkeypatch):
+    """Propagated callback errors must still restore temporary AMP bounds."""
+    from discopt._jax.milp_relaxation import MilpRelaxationResult
+    from discopt._jax.model_utils import flat_variable_bounds
+    from discopt.solvers import amp as amp_mod
+
+    monkeypatch.setattr(
+        amp_mod,
+        "_solve_milp_with_oa_recovery",
+        lambda **kwargs: (
+            MilpRelaxationResult(
+                status="optimal",
+                objective=-1.0,
+                x=np.array([-0.6, 0.3, 0.5], dtype=np.float64),
+            ),
+            {},
+            [],
+            1,
+        ),
+    )
+    monkeypatch.setattr(
+        amp_mod,
+        "_solve_best_nlp_candidate",
+        lambda *args, **kwargs: (np.array([-0.6, 0.3, 0.5], dtype=np.float64), -0.33),
+    )
+
+    m = Model("issue_63_bound_restore_callback_error")
+    x = m.continuous("x")
+    y = m.continuous("y")
+    z = m.continuous("z", lb=0.0, ub=1.0)
+    m.minimize(x + y**2 + z**3)
+    m.subject_to(y >= dm.exp(-x - 2) + dm.exp(-z - 2) - 2)
+    m.subject_to(x**2 <= y**2 + z**2)
+    m.subject_to(y >= x / 2 + z)
+
+    original_lb, original_ub = flat_variable_bounds(m)
+
+    def fail_callback(_info):
+        raise RuntimeError("callback failed")
+
+    with pytest.raises(RuntimeError, match="callback failed"):
+        m.solve(
+            solver="amp",
+            apply_partitioning=False,
+            skip_convex_check=True,
+            presolve_bt=False,
+            alphabb_cutoff_obbt=False,
+            max_iter=1,
+            time_limit=5,
+            iteration_callback=fail_callback,
+        )
+
+    restored_lb, restored_ub = flat_variable_bounds(m)
+    np.testing.assert_allclose(restored_lb, original_lb)
+    np.testing.assert_allclose(restored_ub, original_ub)
+
+
 def test_amp_appends_alphabb_cut_for_issue_63_quadratic(monkeypatch):
     """AMP should append an alpha-BB cut for the nonconvex quadratic row."""
     import discopt._jax.cutting_planes as cutting_planes

--- a/python/tests/test_amp.py
+++ b/python/tests/test_amp.py
@@ -2255,6 +2255,128 @@ def test_alphabb_cutoff_obbt_option_controls_prerequisite_pass(
     assert len(calls) == expected_obbt_calls
 
 
+def test_run_cutoff_obbt_returns_without_time_after_deadline(monkeypatch):
+    """Expired AMP deadlines must not be converted into a fresh OBBT budget."""
+    from discopt._jax import milp_relaxation as milp_relaxation_mod
+    from discopt.solvers import amp as amp_mod
+
+    build_calls = []
+
+    def fail_build_relaxation(*args, **kwargs):
+        build_calls.append((args, kwargs))
+        raise AssertionError("cutoff OBBT should not build a relaxation after the deadline")
+
+    monkeypatch.setattr(
+        milp_relaxation_mod,
+        "build_milp_relaxation",
+        fail_build_relaxation,
+    )
+
+    m = Model("expired_cutoff_obbt")
+    x = m.continuous("x")
+    m.minimize(x)
+    flat_lb = np.array([-np.inf], dtype=np.float64)
+    flat_ub = np.array([np.inf], dtype=np.float64)
+    part_vars = [0]
+    part_lbs = [-1.0]
+    part_ubs = [1.0]
+
+    result = amp_mod._run_cutoff_obbt(
+        model=m,
+        terms=SimpleNamespace(partition_candidates=[0]),
+        disc_state=SimpleNamespace(partitions={}),
+        oa_cuts=[],
+        convhull_mode="sos2",
+        UB=0.0,
+        flat_lb=flat_lb,
+        flat_ub=flat_ub,
+        part_vars=part_vars,
+        part_lbs=part_lbs,
+        part_ubs=part_ubs,
+        n_orig=1,
+        obbt_time_limit=30.0,
+        partition_scaling_factor=0.1,
+        disc_abs_width_tol=1e-9,
+        n_init_partitions=2,
+        deadline=amp_mod.time.perf_counter() - 1.0,
+        iteration=1,
+        from_min_space=float,
+    )
+
+    result_lb, result_ub, result_part_vars, result_part_lbs, result_part_ubs = result
+    assert result_lb is flat_lb
+    assert result_ub is flat_ub
+    assert result_part_vars is part_vars
+    assert result_part_lbs is part_lbs
+    assert result_part_ubs is part_ubs
+    assert build_calls == []
+
+
+def test_alphabb_cutoff_obbt_prerequisite_respects_expired_deadline(monkeypatch):
+    """The default alpha-BB prerequisite pass must honor the global AMP deadline."""
+    from discopt._jax.milp_relaxation import MilpRelaxationResult
+    from discopt.solvers import amp as amp_mod
+
+    cutoff_obbt_calls = []
+
+    monkeypatch.setattr(
+        amp_mod,
+        "_solve_milp_with_oa_recovery",
+        lambda **kwargs: (
+            MilpRelaxationResult(
+                status="optimal",
+                objective=-1.0,
+                x=np.array([0.0, 0.0], dtype=np.float64),
+            ),
+            {},
+            [],
+            1,
+        ),
+    )
+    monkeypatch.setattr(
+        amp_mod,
+        "_solve_best_nlp_candidate",
+        lambda *args, **kwargs: (np.array([0.0, 0.0], dtype=np.float64), 0.0),
+    )
+
+    def fake_cutoff_obbt(**kwargs):
+        cutoff_obbt_calls.append(kwargs["iteration"])
+        return (
+            kwargs["flat_lb"],
+            kwargs["flat_ub"],
+            kwargs["part_vars"],
+            kwargs["part_lbs"],
+            kwargs["part_ubs"],
+        )
+
+    monkeypatch.setattr(amp_mod, "_run_cutoff_obbt", fake_cutoff_obbt)
+
+    clock_values = iter([0.0, 0.1, 2.0])
+
+    def fake_perf_counter():
+        return next(clock_values, 2.0)
+
+    monkeypatch.setattr(amp_mod.time, "perf_counter", fake_perf_counter)
+
+    m = Model("alphabb_cutoff_obbt_expired_deadline")
+    x = m.continuous("x")
+    y = m.continuous("y")
+    m.minimize(x + y**2)
+    m.subject_to(x**2 <= y**2 + 1.0)
+
+    result = m.solve(
+        solver="amp",
+        apply_partitioning=False,
+        skip_convex_check=True,
+        presolve_bt=False,
+        max_iter=1,
+        time_limit=1.0,
+    )
+
+    assert result.status in ("optimal", "feasible")
+    assert cutoff_obbt_calls == []
+
+
 def test_objective_cutoff_bounds_enable_alphabb_for_issue_63_instances():
     """The exact nlp_008 objective cutoff should create finite alpha-BB bounds."""
     from discopt._jax.convexity import classify_oa_cut_convexity


### PR DESCRIPTION
Summary
- Add an alpha-BB quadratic OA cut generator for nonconvex quadratic `<=` rows with bounded curved variables.
- Use structural quadratic extraction instead of a local Hessian probe so nonquadratic rows are skipped conservatively.
- Wire AMP to keep direct convex OA cuts, then tighten bounds from an incumbent objective cutoff before alpha-BB generation.
- Run cutoff OBBT before alpha-BB when a nonconvex OA row still came from an effectively unbounded box.
- Add documented `alphabb_cutoff_obbt` control for that alpha-BB prerequisite cutoff OBBT pass, while keeping broader cutoff OBBT under `obbt_with_cutoff`.
- Continue AMP after pure-continuous recovery when new OA cuts are available, allowing the exact `nlp_008_010` and `nlp_008_011` instances to improve past the recovered incumbent.
- Keep objective-cutoff tightening sound for separable odd-power objectives by using signed monotonic roots instead of symmetric radius logic.
- Prune stale partition entries when tightened bounds drop variables from the active partition set.
- Add focused AMP regressions for alpha-BB generation, direct-OA retention, exact issue-63 cutoff/FBBT propagation, odd-power cutoff soundness, partition refresh pruning, and `alphabb_cutoff_obbt` option behavior.

Tests run
- `.venv/bin/python -m pytest python/tests/test_amp.py::test_objective_cutoff_odd_power_tightening_uses_signed_monotonic_root python/tests/test_amp.py::test_objective_cutoff_negative_odd_power_interval_preserves_feasible_points python/tests/test_amp.py::test_refresh_partitions_for_bounds_prunes_stale_partition_entries python/tests/test_amp.py::test_objective_cutoff_bounds_enable_alphabb_for_issue_63_instances -v --tb=short -q` -> 4 passed.
- `.venv/bin/python -m pytest python/tests/test_amp.py::test_alphabb_cutoff_obbt_option_controls_prerequisite_pass -v --tb=short -q` -> 3 passed.
- `.venv/bin/python -m pytest python/tests/test_amp.py::test_alphabb_quadratic_oa_cut_covers_issue_63_row python/tests/test_amp.py::test_alphabb_quadratic_oa_skips_nonquadratic_row python/tests/test_amp.py::test_objective_cutoff_odd_power_tightening_uses_signed_monotonic_root python/tests/test_amp.py::test_objective_cutoff_negative_odd_power_interval_preserves_feasible_points python/tests/test_amp.py::test_refresh_partitions_for_bounds_prunes_stale_partition_entries python/tests/test_amp.py::test_alphabb_cutoff_obbt_option_controls_prerequisite_pass python/tests/test_amp.py::test_objective_cutoff_bounds_enable_alphabb_for_issue_63_instances python/tests/test_amp.py::test_amp_appends_alphabb_cut_for_issue_63_quadratic python/tests/test_amp.py::test_amp_keeps_direct_oa_when_alphabb_generation_fails -v --tb=short -q` -> 11 passed.
- `.venv/bin/python -m pytest python/tests/test_amp_integration.py::TestCurrentCodeWeaknesses::test_amp_recovers_remaining_pure_continuous_minlptests_cases -k 'nlp_008_010 or nlp_008_011' -v --tb=short -q -s` -> 2 passed, 3 deselected.
- `.venv/bin/python -m ruff check python/discopt/solver.py python/discopt/solvers/amp.py python/tests/test_amp.py` -> passed.
- `.venv/bin/python -m ruff format --check python/discopt/solver.py python/discopt/solvers/amp.py python/tests/test_amp.py` -> passed.
- `.venv/bin/python -m mypy python/discopt/solver.py python/discopt/solvers/amp.py` -> no issues found.
- `make PYTHON=.venv/bin/python MATURIN='.venv/bin/python -m maturin' PYTEST='.venv/bin/python -m pytest' test-amp-fast` -> 70 passed.
- `make PYTHON=.venv/bin/python MATURIN='.venv/bin/python -m maturin' PYTEST='.venv/bin/python -m pytest' test` -> 2488 passed, 59 skipped, 707 deselected, 2 xfailed.

Notes
- Running plain `make test-amp-fast` used the ambient `/home/bernalde/miniconda3/bin/python` and failed before tests with `No module named maturin`; rerunning the documented target with the project `.venv` Python succeeded.
- The exact `nlp_008_010` and `nlp_008_011` cases now pass locally in the `.venv`.

Closes #63
