### PR TITLE
Fix AMP reciprocal relaxations

### DIFF
--- a/python/discopt/_jax/milp_relaxation.py
+++ b/python/discopt/_jax/milp_relaxation.py
@@ -195,6 +195,15 @@ def _linear_expr_bounds(
     return lower, upper
 
 
+def _constant_value(expr: Expression) -> Optional[float]:
+    if not isinstance(expr, Constant):
+        return None
+    values = np.asarray(expr.value, dtype=np.float64).ravel()
+    if values.size != 1:
+        return None
+    return float(values[0])
+
+
 def _normalize_convhull_formulation(formulation: str) -> str:
     """Normalize accepted bilinear convex-hull mode names."""
     aliases = {
@@ -492,6 +501,8 @@ def _univariate_arg(expr: Expression) -> tuple[str, Expression] | None:
             return name, expr.args[0]
     if isinstance(expr, UnaryOp) and expr.op == "abs":
         return "abs", expr.operand
+    if isinstance(expr, BinaryOp) and expr.op == "/" and _constant_value(expr.left) is not None:
+        return "reciprocal", expr.right
     return None
 
 
@@ -509,6 +520,8 @@ def _univariate_value(func_name: str, x: float) -> float:
         return float(np.exp(x))
     if func_name == "abs":
         return float(abs(x))
+    if func_name == "reciprocal":
+        return float(1.0 / x)
     raise ValueError(f"Unsupported univariate function: {func_name}")
 
 
@@ -524,6 +537,8 @@ def _univariate_grad(func_name: str, x: float) -> float:
         return float(1.0 / (x * np.log(10.0)))
     if func_name == "exp":
         return float(np.exp(x))
+    if func_name == "reciprocal":
+        return float(-1.0 / (x * x))
     raise ValueError(f"No smooth derivative for univariate function: {func_name}")
 
 
@@ -541,6 +556,8 @@ def _univariate_domain_ok(func_name: str, arg_lb: float, arg_ub: float) -> bool:
         return bool(arg_ub <= _MAX_FINITE_EXP_ARG)
     if func_name == "abs":
         return True
+    if func_name == "reciprocal":
+        return bool(arg_lb > 0.0)
     return False
 
 
@@ -562,7 +579,7 @@ def _tangent_points(func_name: str, lb: float, ub: float) -> list[float]:
     for pt in raw_points:
         if func_name == "sqrt" and pt <= 0.0:
             continue
-        if func_name in {"log", "log2", "log10"} and pt <= 0.0:
+        if func_name in {"log", "log2", "log10", "reciprocal"} and pt <= 0.0:
             continue
         if not np.isfinite(pt):
             continue
@@ -571,16 +588,112 @@ def _tangent_points(func_name: str, lb: float, ub: float) -> list[float]:
     return points
 
 
+def _univariate_signature(
+    func_name: str,
+    arg_coeff: np.ndarray,
+    arg_const: float,
+) -> tuple[str, tuple[float, ...], float]:
+    return func_name, tuple(float(c) for c in arg_coeff.tolist()), float(arg_const)
+
+
+def _flatten_additive_terms(
+    expr: Expression, scale: float, out: list[tuple[float, Expression]]
+) -> None:
+    if isinstance(expr, BinaryOp) and expr.op == "+":
+        _flatten_additive_terms(expr.left, scale, out)
+        _flatten_additive_terms(expr.right, scale, out)
+        return
+    if isinstance(expr, BinaryOp) and expr.op == "-":
+        _flatten_additive_terms(expr.left, scale, out)
+        _flatten_additive_terms(expr.right, -scale, out)
+        return
+    if isinstance(expr, SumOverExpression):
+        for term in expr.terms:
+            _flatten_additive_terms(term, scale, out)
+        return
+    out.append((scale, expr))
+
+
+def _match_scaled_constant_division(
+    expr: Expression,
+    scale: float,
+) -> Optional[tuple[float, Expression]]:
+    """Return (scaled numerator, denominator) for scale * (c / denominator)."""
+    if isinstance(expr, UnaryOp) and expr.op == "neg":
+        return _match_scaled_constant_division(expr.operand, -scale)
+
+    if isinstance(expr, BinaryOp) and expr.op == "*":
+        left_const = _constant_value(expr.left)
+        if left_const is not None:
+            return _match_scaled_constant_division(expr.right, scale * left_const)
+        right_const = _constant_value(expr.right)
+        if right_const is not None:
+            return _match_scaled_constant_division(expr.left, scale * right_const)
+        return None
+
+    if not isinstance(expr, BinaryOp) or expr.op != "/":
+        return None
+    numerator = _constant_value(expr.left)
+    if numerator is None or abs(numerator) <= 1e-12:
+        return None
+    return scale * numerator, expr.right
+
+
+def _exact_positive_reciprocal_row(
+    expr: Expression,
+    model: Model,
+    flat_lb: np.ndarray,
+    flat_ub: np.ndarray,
+) -> Optional[tuple[np.ndarray, float]]:
+    """Match ``constant - numerator / positive_affine <= 0`` as an exact affine row."""
+    terms: list[tuple[float, Expression]] = []
+    _flatten_additive_terms(expr, 1.0, terms)
+
+    constant_term = 0.0
+    reciprocal_match: Optional[tuple[float, Expression]] = None
+
+    for scale, term in terms:
+        const_val = _constant_value(term)
+        if const_val is not None:
+            constant_term += scale * const_val
+            continue
+
+        match = _match_scaled_constant_division(term, scale)
+        if match is None or reciprocal_match is not None:
+            return None
+        reciprocal_match = match
+
+    if reciprocal_match is None or constant_term <= 0.0:
+        return None
+
+    scaled_numerator, denominator = reciprocal_match
+    if scaled_numerator >= 0.0:
+        return None
+
+    try:
+        denom_coeff, denom_const = _linearize_affine_expr(denominator, model, len(flat_lb))
+        denom_lb, _denom_ub = _linear_expr_bounds(denom_coeff, denom_const, flat_lb, flat_ub)
+    except ValueError:
+        return None
+
+    if denom_lb <= 0.0:
+        return None
+    rhs = -scaled_numerator / constant_term
+    if not np.isfinite(rhs):
+        return None
+    return denom_coeff, float(rhs - denom_const)
+
+
 def _collect_univariate_relaxations(
     model: Model,
     n_orig: int,
     flat_lb: np.ndarray,
     flat_ub: np.ndarray,
     start_col: int,
-) -> tuple[list[UnivariateRelaxation], dict[int, int], list[tuple[float, float]]]:
+) -> tuple[list[UnivariateRelaxation], dict[object, int], list[tuple[float, float]]]:
     """Collect supported univariate operator nodes and assign auxiliary columns."""
     relaxations: list[UnivariateRelaxation] = []
-    var_map: dict[int, int] = {}
+    var_map: dict[object, int] = {}
     bounds: list[tuple[float, float]] = []
     seen: set[int] = set()
     col_idx = start_col
@@ -604,8 +717,14 @@ def _collect_univariate_relaxations(
         val_lb, val_ub = _univariate_value_bounds(func_name, arg_lb, arg_ub)
         if not np.isfinite(val_lb) or not np.isfinite(val_ub):
             return
+        signature = _univariate_signature(func_name, arg_coeff, arg_const)
+        if signature in var_map:
+            seen.add(expr_id)
+            var_map[expr_id] = var_map[signature]
+            return
         seen.add(expr_id)
         var_map[expr_id] = col_idx
+        var_map[signature] = col_idx
         relaxations.append(
             UnivariateRelaxation(
                 expr_id=expr_id,
@@ -659,7 +778,7 @@ def _linearize_expr(
     trilinear_var_map: dict[tuple[int, int, int], int],
     multilinear_var_map: dict[tuple[int, ...], int],
     monomial_var_map: dict[tuple[int, int], int],
-    univariate_var_map: dict[int, int],
+    univariate_var_map: dict[object, int],
     n_total_vars: int,
     fractional_power_var_map: Optional[dict[tuple[int, float], int]] = None,
 ) -> tuple[np.ndarray, float]:
@@ -673,6 +792,7 @@ def _linearize_expr(
     """
     coeff = np.zeros(n_total_vars, dtype=np.float64)
     const_acc: list[float] = [0.0]
+    n_orig = sum(var.size for var in model._variables)
 
     def visit(e: Expression, scale: float) -> None:  # noqa: C901
         if isinstance(e, Constant):
@@ -713,6 +833,21 @@ def _linearize_expr(
             elif e.op == "/":
                 if isinstance(e.right, Constant):
                     visit(e.left, scale / float(e.right.value))
+                elif isinstance(e.left, Constant):
+                    aux_col = univariate_var_map.get(id(e))
+                    if aux_col is None:
+                        try:
+                            arg_coeff, arg_const = _linearize_affine_expr(e.right, model, n_orig)
+                        except ValueError:
+                            aux_col = None
+                        else:
+                            aux_col = univariate_var_map.get(
+                                _univariate_signature("reciprocal", arg_coeff, arg_const)
+                            )
+                    if aux_col is not None:
+                        coeff[aux_col] += scale * float(e.left.value)
+                    else:
+                        raise ValueError(f"Cannot linearize non-constant division: {e}")
                 else:
                     raise ValueError(f"Cannot linearize non-constant division: {e}")
 
@@ -728,11 +863,12 @@ def _linearize_expr(
                         if n_int == 0:
                             const_acc[0] += scale
                             return
-                        key = (flat, n_int)
-                        if key in monomial_var_map:
-                            coeff[monomial_var_map[key]] += scale
-                            return
-                        raise ValueError(f"Monomial {key} not in monomial_var_map")
+                        if n_int >= 2:
+                            key = (flat, n_int)
+                            if key in monomial_var_map:
+                                coeff[monomial_var_map[key]] += scale
+                                return
+                            raise ValueError(f"Monomial {key} not in monomial_var_map")
                     fp_key = (flat, exp_val)
                     if fractional_power_var_map and fp_key in fractional_power_var_map:
                         coeff[fractional_power_var_map[fp_key]] += scale
@@ -908,7 +1044,7 @@ def build_milp_relaxation(
     multilinear_var_map: dict[tuple[int, ...], int] = {}
     multilinear_stage_map: dict[tuple[int, ...], list[dict[str, int]]] = {}
     monomial_var_map: dict[tuple[int, int], int] = {}
-    univariate_var_map: dict[int, int] = {}
+    univariate_var_map: dict[object, int] = {}
     fractional_power_var_map: dict[tuple[int, float], int] = {}
 
     col_idx = n_orig
@@ -1779,7 +1915,7 @@ def build_milp_relaxation(
         secant_slope = (f_ub - f_lb) / (ub_u - lb_u)
         secant_intercept = f_lb - secant_slope * lb_u
 
-        if relax.func_name == "exp":
+        if relax.func_name in {"exp", "reciprocal"}:
             # Convex: tangents are lower bounds; secant is an upper bound.
             for pt in _tangent_points(relax.func_name, lb_u, ub_u):
                 slope = _univariate_grad(relax.func_name, pt)
@@ -1889,6 +2025,13 @@ def build_milp_relaxation(
     for constraint in model._constraints:
         body = distribute_products(constraint.body)
         sense = constraint.sense
+        if sense == "<=":
+            exact_row = _exact_positive_reciprocal_row(body, model, flat_lb, flat_ub)
+            if exact_row is not None:
+                c_exact, rhs_exact = exact_row
+                row_exact = np.zeros(n_total)
+                row_exact[:n_orig] = c_exact
+                _add_row(row_exact, rhs_exact)
         try:
             c, const = _linearize_expr(
                 body,
@@ -2000,8 +2143,12 @@ def build_milp_relaxation(
         "multilinear_stages": multilinear_stage_map,
         "monomial": monomial_var_map,
         "monomial_pw": monomial_pw_map,
-        "univariate": univariate_var_map,
+        "univariate": {k: v for k, v in univariate_var_map.items() if isinstance(k, int)},
+        "univariate_signatures": {
+            k: v for k, v in univariate_var_map.items() if not isinstance(k, int)
+        },
         "univariate_relaxations": univariate_relaxations,
+        "fractional_power": fractional_power_var_map,
         "bilinear_pw": bilinear_pw_map,
         "bilinear_lambda": bilinear_lambda_map,
         "convhull_formulation": convhull_mode,

--- a/python/discopt/_jax/nonlinear_bound_tightening.py
+++ b/python/discopt/_jax/nonlinear_bound_tightening.py
@@ -290,6 +290,135 @@ def _tighten_affine_argument_interval(
     )
 
 
+def _linearize_affine_expr(
+    expr,
+    scale: float,
+    metadata: FlatVariableMetadata,
+    n_vars: int,
+) -> Optional[tuple[np.ndarray, float]]:
+    const_val = _constant_value(expr)
+    if const_val is not None:
+        return np.zeros(n_vars, dtype=np.float64), scale * const_val
+
+    flat_idx = metadata.scalar_flat_index(expr)
+    if flat_idx is not None:
+        coeff = np.zeros(n_vars, dtype=np.float64)
+        coeff[flat_idx] = scale
+        return coeff, 0.0
+
+    if isinstance(expr, UnaryOp) and expr.op == "neg":
+        return _linearize_affine_expr(expr.operand, -scale, metadata, n_vars)
+
+    if isinstance(expr, BinaryOp):
+        if expr.op == "+":
+            left = _linearize_affine_expr(expr.left, scale, metadata, n_vars)
+            right = _linearize_affine_expr(expr.right, scale, metadata, n_vars)
+            if left is None or right is None:
+                return None
+            return left[0] + right[0], left[1] + right[1]
+        if expr.op == "-":
+            left = _linearize_affine_expr(expr.left, scale, metadata, n_vars)
+            right = _linearize_affine_expr(expr.right, -scale, metadata, n_vars)
+            if left is None or right is None:
+                return None
+            return left[0] + right[0], left[1] + right[1]
+        if expr.op == "*":
+            left_const = _constant_value(expr.left)
+            if left_const is not None:
+                return _linearize_affine_expr(expr.right, scale * left_const, metadata, n_vars)
+            right_const = _constant_value(expr.right)
+            if right_const is not None:
+                return _linearize_affine_expr(expr.left, scale * right_const, metadata, n_vars)
+            return None
+        if expr.op == "/":
+            right_const = _constant_value(expr.right)
+            if right_const is not None and abs(right_const) > 1e-12:
+                return _linearize_affine_expr(expr.left, scale / right_const, metadata, n_vars)
+            return None
+        if expr.op == "**":
+            exponent = _constant_value(expr.right)
+            if exponent == 1.0:
+                return _linearize_affine_expr(expr.left, scale, metadata, n_vars)
+            if exponent == 0.0:
+                return np.zeros(n_vars, dtype=np.float64), scale
+            return None
+
+    if isinstance(expr, SumOverExpression):
+        coeff = np.zeros(n_vars, dtype=np.float64)
+        const = 0.0
+        for term in expr.terms:
+            piece = _linearize_affine_expr(term, scale, metadata, n_vars)
+            if piece is None:
+                return None
+            coeff += piece[0]
+            const += piece[1]
+        return coeff, const
+
+    return None
+
+
+def _affine_bounds(
+    coeff: np.ndarray,
+    const: float,
+    lb: np.ndarray,
+    ub: np.ndarray,
+) -> tuple[float, float]:
+    lower = float(const)
+    upper = float(const)
+    for c_i, lb_i, ub_i in zip(coeff, lb, ub):
+        c = float(c_i)
+        if c >= 0.0:
+            lower += c * float(lb_i)
+            upper += c * float(ub_i)
+        else:
+            lower += c * float(ub_i)
+            upper += c * float(lb_i)
+    return lower, upper
+
+
+def _tighten_affine_upper_bound(
+    tightened_lb: np.ndarray,
+    tightened_ub: np.ndarray,
+    metadata: FlatVariableMetadata,
+    coeff: np.ndarray,
+    const: float,
+    rhs: float,
+) -> None:
+    """Intersect a box with ``coeff @ x + const <= rhs`` using interval FBBT."""
+    for idx, c_i in enumerate(coeff):
+        c = float(c_i)
+        if abs(c) <= 1e-12:
+            continue
+
+        other_min = float(const)
+        for j, c_j in enumerate(coeff):
+            if j == idx:
+                continue
+            cj = float(c_j)
+            if cj >= 0.0:
+                other_min += cj * float(tightened_lb[j])
+            else:
+                other_min += cj * float(tightened_ub[j])
+
+        bound = (float(rhs) - other_min) / c
+        new_lb = float(tightened_lb[idx])
+        new_ub = float(tightened_ub[idx])
+        if c > 0.0:
+            new_ub = min(new_ub, bound)
+        else:
+            new_lb = max(new_lb, bound)
+
+        new_lb, new_ub = _apply_integrality(new_lb, new_ub, metadata.flat_var_types[idx])
+        if new_lb <= new_ub:
+            tightened_lb[idx] = new_lb
+            tightened_ub[idx] = new_ub
+            continue
+
+        raise NonlinearBoundTighteningInfeasible(
+            f"tightened interval is empty for flat variable {idx}: [{new_lb}, {new_ub}]"
+        )
+
+
 def _flatten_sum(expr, scale: float, out: list[tuple[float, object]]) -> None:
     if isinstance(expr, SumOverExpression):
         for term in expr.terms:
@@ -1336,6 +1465,219 @@ class QuadraticEqualityBoundsRule(NonlinearBoundTighteningRule):
         return tightened_lb, tightened_ub
 
 
+def _match_scaled_constant_division(expr, scale: float) -> Optional[tuple[float, object]]:
+    if isinstance(expr, UnaryOp) and expr.op == "neg":
+        return _match_scaled_constant_division(expr.operand, -scale)
+
+    if isinstance(expr, BinaryOp) and expr.op == "*":
+        left_const = _constant_value(expr.left)
+        if left_const is not None:
+            return _match_scaled_constant_division(expr.right, scale * left_const)
+        right_const = _constant_value(expr.right)
+        if right_const is not None:
+            return _match_scaled_constant_division(expr.left, scale * right_const)
+        return None
+
+    if not isinstance(expr, BinaryOp) or expr.op != "/":
+        return None
+    numerator = _constant_value(expr.left)
+    if numerator is None or abs(numerator) <= 1e-12:
+        return None
+    return scale * numerator, expr.right
+
+
+def _match_scaled_negative_power(
+    expr,
+    scale: float,
+    metadata: FlatVariableMetadata,
+) -> Optional[tuple[int, float, float]]:
+    if isinstance(expr, UnaryOp) and expr.op == "neg":
+        return _match_scaled_negative_power(expr.operand, -scale, metadata)
+
+    if isinstance(expr, BinaryOp) and expr.op == "*":
+        left_const = _constant_value(expr.left)
+        if left_const is not None:
+            return _match_scaled_negative_power(expr.right, scale * left_const, metadata)
+        right_const = _constant_value(expr.right)
+        if right_const is not None:
+            return _match_scaled_negative_power(expr.left, scale * right_const, metadata)
+        return None
+
+    if not isinstance(expr, BinaryOp) or expr.op != "**":
+        return None
+    exponent = _constant_value(expr.right)
+    if exponent is None or exponent >= 0.0:
+        return None
+    flat_idx = metadata.scalar_flat_index(expr.left)
+    if flat_idx is None:
+        return None
+    return flat_idx, float(exponent), scale
+
+
+class PositiveAffineReciprocalBoundsRule(NonlinearBoundTighteningRule):
+    """Propagate ``c / positive_affine >= rhs`` into affine upper bounds."""
+
+    name = "positive_affine_reciprocal_bounds"
+
+    def tighten(
+        self,
+        model: Model,
+        flat_lb: np.ndarray,
+        flat_ub: np.ndarray,
+        metadata: FlatVariableMetadata,
+    ) -> tuple[np.ndarray, np.ndarray]:
+        tightened_lb = flat_lb.copy()
+        tightened_ub = flat_ub.copy()
+        n_vars = len(flat_lb)
+
+        for constraint in model._constraints:
+            if getattr(constraint, "sense", None) not in ("<=", "=="):
+                continue
+
+            terms: list[tuple[float, object]] = []
+            _flatten_sum(constraint.body, 1.0, terms)
+
+            constant_term = 0.0
+            reciprocal_match: Optional[tuple[float, object]] = None
+            matches_pattern = True
+
+            for scale, term in terms:
+                const_val = _constant_value(term)
+                if const_val is not None:
+                    constant_term += scale * const_val
+                    continue
+
+                match = _match_scaled_constant_division(term, scale)
+                if match is None or reciprocal_match is not None:
+                    matches_pattern = False
+                    break
+                reciprocal_match = match
+
+            if not matches_pattern or reciprocal_match is None or constant_term <= 0.0:
+                continue
+
+            scaled_numerator, denominator = reciprocal_match
+            if scaled_numerator >= 0.0:
+                continue
+
+            affine = _linearize_affine_expr(denominator, 1.0, metadata, n_vars)
+            if affine is None:
+                continue
+            coeff, const = affine
+            arg_lb, arg_ub = _affine_bounds(coeff, const, tightened_lb, tightened_ub)
+            if arg_lb <= 0.0:
+                continue
+
+            rhs = -scaled_numerator / constant_term
+            if not np.isfinite(rhs):
+                continue
+            if arg_lb > rhs + 1e-12:
+                _prove_infeasible(
+                    self.name,
+                    constraint,
+                    "positive affine denominator exceeds reciprocal upper bound",
+                )
+            if arg_ub <= rhs + 1e-12:
+                continue
+            _tighten_affine_upper_bound(tightened_lb, tightened_ub, metadata, coeff, const, rhs)
+
+        return tightened_lb, tightened_ub
+
+
+class NegativePowerBoundsRule(NonlinearBoundTighteningRule):
+    """Infer strict positive lower bounds from ``x**p <= affine`` for ``p < 0``."""
+
+    name = "negative_power_bounds"
+
+    def tighten(
+        self,
+        model: Model,
+        flat_lb: np.ndarray,
+        flat_ub: np.ndarray,
+        metadata: FlatVariableMetadata,
+    ) -> tuple[np.ndarray, np.ndarray]:
+        tightened_lb = flat_lb.copy()
+        tightened_ub = flat_ub.copy()
+        n_vars = len(flat_lb)
+
+        for constraint in model._constraints:
+            if getattr(constraint, "sense", None) not in ("<=", "=="):
+                continue
+
+            terms: list[tuple[float, object]] = []
+            _flatten_sum(constraint.body, 1.0, terms)
+
+            power_match: Optional[tuple[int, float, float]] = None
+            affine_coeff = np.zeros(n_vars, dtype=np.float64)
+            affine_const = 0.0
+            matches_pattern = True
+
+            for scale, term in terms:
+                match = _match_scaled_negative_power(term, scale, metadata)
+                if match is not None:
+                    if power_match is not None:
+                        matches_pattern = False
+                        break
+                    power_match = match
+                    continue
+
+                affine = _linearize_affine_expr(term, scale, metadata, n_vars)
+                if affine is None:
+                    matches_pattern = False
+                    break
+                affine_coeff += affine[0]
+                affine_const += affine[1]
+
+            if not matches_pattern or power_match is None:
+                continue
+
+            base_idx, exponent, power_scale = power_match
+            if power_scale <= 0.0:
+                continue
+            if abs(float(affine_coeff[base_idx])) > 1e-12:
+                continue
+            if tightened_lb[base_idx] < -1e-12 or tightened_ub[base_idx] <= 0.0:
+                continue
+
+            affine_min, _affine_max = _affine_bounds(
+                affine_coeff,
+                affine_const,
+                tightened_lb,
+                tightened_ub,
+            )
+            rhs_ub = -affine_min / power_scale
+            if rhs_ub <= 0.0:
+                _prove_infeasible(
+                    self.name,
+                    constraint,
+                    "negative power has no positive upper allowance",
+                )
+            if not np.isfinite(rhs_ub):
+                continue
+
+            lower = float(rhs_ub ** (1.0 / exponent))
+            if not np.isfinite(lower):
+                continue
+            new_lb = max(float(tightened_lb[base_idx]), lower)
+            new_ub = float(tightened_ub[base_idx])
+            new_lb, new_ub = _apply_integrality(
+                new_lb,
+                new_ub,
+                metadata.flat_var_types[base_idx],
+            )
+            if new_lb <= new_ub:
+                tightened_lb[base_idx] = new_lb
+                tightened_ub[base_idx] = new_ub
+                continue
+            _prove_infeasible(
+                self.name,
+                constraint,
+                f"required positive lower bound {new_lb} exceeds upper bound {new_ub}",
+            )
+
+        return tightened_lb, tightened_ub
+
+
 class ReciprocalBoundsRule(NonlinearBoundTighteningRule):
     """Tighten sign-stable affine denominators in simple reciprocal constraints."""
 
@@ -1472,6 +1814,8 @@ DEFAULT_NONLINEAR_BOUND_RULES: tuple[NonlinearBoundTighteningRule, ...] = (
     MonotoneFunctionEqualityRule(),
     QuadraticEqualityBoundsRule(),
     MonotoneFunctionBoundsRule(),
+    PositiveAffineReciprocalBoundsRule(),
+    NegativePowerBoundsRule(),
     ReciprocalBoundsRule(),
     SqrtSumOfSquaresUpperBoundRule(),
     SumOfSquaresUpperBoundRule(),

--- a/python/tests/test_amp_integration.py
+++ b/python/tests/test_amp_integration.py
@@ -1548,6 +1548,51 @@ class TestAmpPhase4Coverage:
         assert lbs[0] < 0.2
         assert lbs[-1] >= 0.999
 
+    def test_nlp_005_010_relaxation_keeps_reciprocal_and_negative_power(self, caplog):
+        """Issue #62: the root MILP should retain reciprocal and y**(-2) structure."""
+        from discopt._jax.nonlinear_bound_tightening import tighten_nonlinear_bounds
+
+        instance = MINLPTESTS_NLP_BY_ID["nlp_005_010"]
+        m = instance.build_fn()
+        flat_lb, flat_ub = flat_variable_bounds(m)
+        tightened_lb, tightened_ub, _stats = tighten_nonlinear_bounds(m, flat_lb, flat_ub)
+
+        terms = self.classify(m)
+        state = self.init_partitions(
+            terms.partition_candidates,
+            lb=[float(tightened_lb[i]) for i in terms.partition_candidates],
+            ub=[float(tightened_ub[i]) for i in terms.partition_candidates],
+            n_init=2,
+        )
+
+        with caplog.at_level(logging.WARNING, logger="discopt._jax.milp_relaxation"):
+            milp_model, varmap = self.build_milp(
+                m,
+                terms,
+                state,
+                incumbent=None,
+                bound_override=(tightened_lb, tightened_ub),
+            )
+
+        reciprocal_lifts = [
+            relax for relax in varmap["univariate_relaxations"] if relax.func_name == "reciprocal"
+        ]
+        assert len(reciprocal_lifts) >= 2
+        assert (1, -2.0) in varmap["fractional_power"]
+
+        a_ub = milp_model._A_ub.toarray()
+        exact_rows = [
+            idx
+            for idx, row in enumerate(a_ub)
+            if np.allclose(row[:2], [1.0, 1.0], atol=1e-12)
+            and np.count_nonzero(np.abs(row[2:]) > 1e-12) == 0
+        ]
+        assert any(milp_model._b_ub[idx] == pytest.approx(3.9) for idx in exact_rows)
+        assert not any(
+            "Cannot linearize non-constant division" in rec.message for rec in caplog.records
+        )
+        assert not any("Monomial (1, -2)" in rec.message for rec in caplog.records)
+
     def test_mixed_sign_odd_tangent_filter_keeps_only_global_supporting_lines(self):
         """Only tangents that stay valid on the full mixed-sign box should be used."""
         assert self.is_valid_odd_tangent(0.5, -0.5, 0.5, 5, "under") is True
@@ -2511,6 +2556,22 @@ class TestCurrentCodeWeaknesses:
         assert tightened_lb[2] == pytest.approx(-1.0)
         assert tightened_ub[2] == pytest.approx(1.0)
         assert "reciprocal_bounds" in stats.applied_rules
+
+    def test_nlp_005_010_tightening_enables_negative_power_domain(self):
+        """Issue #62: reciprocal reformulation should expose a safe y**(-2) domain."""
+        from discopt._jax.nonlinear_bound_tightening import tighten_nonlinear_bounds
+
+        instance = MINLPTESTS_NLP_BY_ID["nlp_005_010"]
+        m = instance.build_fn()
+        flat_lb, flat_ub = flat_variable_bounds(m)
+
+        tightened_lb, tightened_ub, stats = tighten_nonlinear_bounds(m, flat_lb, flat_ub)
+
+        assert tightened_ub[0] <= 3.9 + 1e-9
+        assert tightened_ub[1] <= 3.9 + 1e-9
+        assert tightened_lb[1] >= 1.0 / np.sqrt(4.4) - 1e-9
+        assert "positive_affine_reciprocal_bounds" in stats.applied_rules
+        assert "negative_power_bounds" in stats.applied_rules
 
     def test_nonlinear_bound_tightening_reports_quadratic_contradiction(self):
         """A rule proof of infeasibility should be reported explicitly."""


### PR DESCRIPTION
## Summary

- Adds safe positive-affine reciprocal support to the AMP MILP relaxation, including tangent/secant envelopes for `1 / affine`.
- Adds the exact positive-denominator row for constraints like `4 / (x + y + 0.1) >= 1`, yielding `x + y <= 3.9`.
- Adds nonlinear bound tightening for positive affine reciprocal rows and negative powers so `nlp_005_010` can safely lift `y**(-2)`.
- Adds issue #62 regression coverage for `nlp_005_010`.

## Tests run

- `/home/bernalde/.pixi/bin/pixi exec -s python=3.12 -s ipopt -s pkg-config -s c-compiler -s cxx-compiler -s gfortran -- uv venv .venv` - passed
- `/home/bernalde/.pixi/bin/pixi exec -s python=3.12 -s ipopt -s pkg-config -s c-compiler -s cxx-compiler -s gfortran -- uv pip install --python .venv/bin/python maturin pytest pytest-timeout numpy scipy jax jaxlib highspy cyipopt "ruff==0.14.6" mypy` - passed
- `/home/bernalde/.pixi/bin/pixi exec -s python=3.12 -s ipopt -s pkg-config -s c-compiler -s cxx-compiler -s gfortran -- uv pip install --python .venv/bin/python -e ".[dev,ipopt,highs]"` - passed
- `/home/bernalde/.pixi/bin/pixi exec -s python=3.12 -s ipopt -s pkg-config -s c-compiler -s cxx-compiler -s gfortran -- .venv/bin/python -m pytest python/tests/test_amp.py::test_supported_univariate_objectives_return_valid_bounds python/tests/test_amp.py::test_supported_univariate_constraint_tightens_relaxation python/tests/test_amp.py::test_nested_univariate_objective_still_returns_no_relaxation_bound python/tests/test_amp_integration.py::TestCurrentCodeWeaknesses::test_nlp_005_010_tightening_enables_negative_power_domain python/tests/test_amp_integration.py::TestAmpPhase4Coverage::test_nlp_005_010_relaxation_keeps_reciprocal_and_negative_power -q -vv --tb=short --timeout=120` - 8 passed
- `/home/bernalde/.pixi/bin/pixi exec -s python=3.12 -s ipopt -s pkg-config -s c-compiler -s cxx-compiler -s gfortran -- make test-amp-fast PYTHON=.venv/bin/python PYTEST=".venv/bin/python -m pytest"` - 59 passed
- `/home/bernalde/.pixi/bin/pixi exec -s python=3.12 -s ipopt -s pkg-config -s c-compiler -s cxx-compiler -s gfortran -- make test PYTHON=.venv/bin/python PYTEST=".venv/bin/python -m pytest"` - 2477 passed, 59 skipped, 709 deselected, 2 xfailed
- `/home/bernalde/.pixi/bin/pixi exec -s python=3.12 -s ipopt -s pkg-config -s c-compiler -s cxx-compiler -s gfortran -- make lint RUFF=".venv/bin/python -m ruff"` - passed
- `/home/bernalde/.pixi/bin/pixi exec -s python=3.12 -s ipopt -s pkg-config -s c-compiler -s cxx-compiler -s gfortran -- .venv/bin/python -m mypy python/discopt/` - passed
- `cargo test -p discopt-core` - 255 passed
- `cargo clippy -p discopt-core -- -D warnings` - passed

## Notes about tests not run

- Did not run the full opt-in `make test-amp-integration` suite because it is intentionally slow; the new issue-specific AMP integration regression tests were run directly in the fresh pixi/uv `.venv`.

Closes #62
