### PR TITLE
Add safe AMP trig relaxations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,9 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  schedule:
+    # Nightly coverage refresh (07:30 UTC ≈ 03:30 ET).
+    - cron: "30 7 * * *"
 
 # Cancel superseded runs on the same PR/branch — saves CI minutes when
 # pushes land in quick succession.
@@ -109,11 +112,12 @@ jobs:
 
   python-coverage:
     name: Python coverage (3.12, ubuntu)
-    # Run coverage on main pushes and on PRs explicitly opted in via the
-    # `coverage` label.  Keeping it off the default PR path is what gets
-    # the per-PR turnaround under 2 minutes (issue #68).
+    # Run coverage nightly (scheduled), or on PRs explicitly opted in via the
+    # `coverage` label. Skipped on plain main pushes so the post-merge wall
+    # clock isn't gated on the coverage instrumentation tax (~100s vs the
+    # fast job). See issue #68 for the per-PR/main turnaround target.
     if: >-
-      github.event_name == 'push' ||
+      github.event_name == 'schedule' ||
       contains(github.event.pull_request.labels.*.name, 'coverage')
     runs-on: ubuntu-latest
     steps:

--- a/Makefile
+++ b/Makefile
@@ -171,8 +171,11 @@ lint:
 # Common flags for the PR-fast tier (kept in sync with .github/workflows/ci.yml).
 # `not slow` excludes the heavy backend matrix; the curated PR correctness
 # subset (test_pr_correctness.py) is *not* slow-marked so it still runs.
+# `-n auto --dist loadgroup` parallelizes across CPUs while keeping
+# class-shared fixtures pinned to one worker (matches CI).
 PYTEST_FAST_FLAGS := --timeout=120 -m "not slow" \
-    --ignore=python/tests/test_correctness.py
+    --ignore=python/tests/test_correctness.py \
+    -n auto --dist loadgroup
 
 # File groups for slice targets. A test file may appear in more than one group.
 TEST_MODELING := \

--- a/discopt_benchmarks/benchmarks/runner.py
+++ b/discopt_benchmarks/benchmarks/runner.py
@@ -24,9 +24,10 @@ from benchmarks.metrics import (
 @dataclass
 class SolverConfig:
     """Configuration for a solver executable."""
+
     name: str
     command: str
-    solver_type: str          # "internal" (discopt) or "external"
+    solver_type: str  # "internal" (discopt) or "external"
     nl_interface: bool = False
     options: dict = None
 
@@ -38,6 +39,7 @@ class SolverConfig:
 @dataclass
 class BenchmarkConfig:
     """Configuration for a benchmark run."""
+
     suite_name: str
     time_limit: int = 3600
     memory_limit_mb: int = 32768
@@ -104,12 +106,14 @@ class BenchmarkRunner:
         total = len(instances) * len(self.config.solvers) * self.config.num_runs
         completed = 0
 
-        print(f"\n{'='*70}")
+        print(f"\n{'=' * 70}")
         print(f"discopt Benchmark: {self.config.suite_name}")
-        print(f"Instances: {len(instances)} | Solvers: {len(self.config.solvers)} "
-              f"| Runs: {self.config.num_runs} | Total: {total}")
+        print(
+            f"Instances: {len(instances)} | Solvers: {len(self.config.solvers)} "
+            f"| Runs: {self.config.num_runs} | Total: {total}"
+        )
         print(f"Time limit: {self.config.time_limit}s | Memory: {self.config.memory_limit_mb}MB")
-        print(f"{'='*70}\n")
+        print(f"{'=' * 70}\n")
 
         for solver_config in self.config.solvers:
             print(f"\n--- Solver: {solver_config.name} ---")
@@ -118,17 +122,18 @@ class BenchmarkRunner:
                 best_result = None
 
                 for run_idx in range(self.config.num_runs):
-                    result = self._run_single(
-                        solver_config, instance_name, run_idx
-                    )
+                    result = self._run_single(solver_config, instance_name, run_idx)
                     run_times.append(result.wall_time)
 
                     # Keep the result from the median-time run
-                    if best_result is None or (
-                        result.is_solved and not best_result.is_solved
-                    ) or (
-                        result.is_solved and best_result.is_solved
-                        and result.wall_time < best_result.wall_time
+                    if (
+                        best_result is None
+                        or (result.is_solved and not best_result.is_solved)
+                        or (
+                            result.is_solved
+                            and best_result.is_solved
+                            and result.wall_time < best_result.wall_time
+                        )
                     ):
                         best_result = result
 
@@ -147,9 +152,7 @@ class BenchmarkRunner:
                             )
 
                 # Check determinism
-                if self.config.num_runs > 1 and all(
-                    t < float("inf") for t in run_times
-                ):
+                if self.config.num_runs > 1 and all(t < float("inf") for t in run_times):
                     cv = _coefficient_of_variation(run_times)
                     if cv > 0.1:
                         print(
@@ -217,7 +220,15 @@ class BenchmarkRunner:
         Run discopt solver on a .nl instance.
 
         Uses the Python API directly, capturing layer profiling data.
+
+        A daemon-thread watchdog joins with ``time_limit + grace`` so a
+        single hung instance (e.g. a JAX while_loop that ignored the
+        wall clock, see issue #80) cannot hold the whole sweep hostage.
+        The aborted thread is left to drain in the background; the
+        returned result reflects the time-limit verdict.
         """
+        import threading
+
         start_time = time.monotonic()
         try:
             import discopt.modeling as dm
@@ -241,12 +252,41 @@ class BenchmarkRunner:
             max_nodes = opts.pop("max_nodes", 100_000)
             opts.pop("gpu", None)  # legacy option, ignored
 
-            result = model.solve(
-                time_limit=time_limit,
-                gap_tolerance=gap_tol,
-                max_nodes=max_nodes,
-                **opts,
-            )
+            box: dict = {}
+
+            def _do_solve() -> None:
+                try:
+                    box["result"] = model.solve(
+                        time_limit=time_limit,
+                        gap_tolerance=gap_tol,
+                        max_nodes=max_nodes,
+                        **opts,
+                    )
+                except BaseException as e:  # propagate to caller
+                    box["error"] = e
+
+            grace = 30.0  # mirrors the external-solver path
+            worker = threading.Thread(target=_do_solve, daemon=True)
+            worker.start()
+            worker.join(timeout=float(time_limit) + grace)
+            if worker.is_alive():
+                # Watchdog tripped: a JAX-compiled loop or other in-process
+                # call ignored time_limit. Surface a TIME_LIMIT result and
+                # let the daemon thread drain in the background.
+                elapsed = time.monotonic() - start_time
+                print(
+                    f"  WATCHDOG {instance}: in-process solve exceeded "
+                    f"time_limit+{int(grace)}s, abandoning thread"
+                )
+                return SolveResult(
+                    instance=instance,
+                    solver=solver.name,
+                    status=SolveStatus.TIME_LIMIT,
+                    wall_time=elapsed,
+                )
+            if "error" in box:
+                raise box["error"]
+            result = box["result"]
 
             # Map discopt status to benchmark status
             status_map = {
@@ -398,6 +438,7 @@ def _coefficient_of_variation(values: list[float]) -> float:
     if len(values) < 2:
         return 0.0
     import numpy as np
+
     arr = np.array(values)
     mean = np.mean(arr)
     if mean < 1e-6:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ xgboost = ["xgboost>=1.7"]
 lightgbm = ["lightgbm>=4.0"]
 gnn = ["equinox>=0.13.8", "optax>=0.1"]
 learned = ["equinox>=0.13.8", "optax>=0.1"]
-dev = ["pytest", "pytest-timeout", "pytest-cov", "ruff", "mypy", "highspy"]
+dev = ["pytest", "pytest-timeout", "pytest-cov", "pytest-xdist", "ruff", "mypy", "highspy"]
 all = ["discopt[ipopt,highs,cutest,llm,gnn,nn,ml]"]
 
 [project.scripts]

--- a/python/discopt/_jax/deadline.py
+++ b/python/discopt/_jax/deadline.py
@@ -1,0 +1,100 @@
+"""Wall-clock deadline plumbing for JAX-compiled solver loops.
+
+Python orchestration enforces ``time_limit`` between B&B nodes and between
+sub-solver calls, but once a ``jax.lax.while_loop`` (e.g. IPM iteration) is
+running the XLA runtime spins until ``cond_fn`` returns false. There is no
+path for Python to interrupt it mid-execution.
+
+This module exposes a process-global deadline that a ``cond_fn`` can poll via
+a host callback (``jax.experimental.io_callback``). One callback per outer
+iteration is cheap compared to the iteration body (matrix factor / KKT solve),
+so the predicate short-circuits the loop within ``time_limit + ε``.
+
+Usage::
+
+    from discopt._jax.deadline import deadline_scope, deadline_exceeded_jax
+
+    with deadline_scope(time_limit_seconds):
+        ...  # any JAX call whose cond_fn uses deadline_exceeded_jax()
+
+The deadline is cleared on scope exit; if no deadline is set,
+``deadline_exceeded_jax()`` returns ``False`` unconditionally.
+"""
+
+from __future__ import annotations
+
+import time
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+from jax.experimental import io_callback
+
+_deadline_monotonic: float | None = None
+
+
+def set_deadline(seconds_from_now: float | None) -> None:
+    """Set a process-global wall-clock deadline ``seconds_from_now`` ahead.
+
+    ``None`` clears any existing deadline.
+    """
+    global _deadline_monotonic
+    if seconds_from_now is None:
+        _deadline_monotonic = None
+        return
+    _deadline_monotonic = time.monotonic() + max(0.0, float(seconds_from_now))
+
+
+def clear_deadline() -> None:
+    """Clear the process-global deadline."""
+    global _deadline_monotonic
+    _deadline_monotonic = None
+
+
+def get_deadline() -> float | None:
+    """Return the monotonic deadline timestamp, or None if unset."""
+    return _deadline_monotonic
+
+
+def deadline_exceeded() -> bool:
+    """True iff a deadline is set and the wall clock has reached it."""
+    d = _deadline_monotonic
+    return d is not None and time.monotonic() >= d
+
+
+class deadline_scope:
+    """Context manager that installs (and on exit restores) the global deadline."""
+
+    def __init__(self, seconds_from_now: float | None):
+        self._seconds = seconds_from_now
+        self._prev: float | None = None
+
+    def __enter__(self) -> "deadline_scope":
+        self._prev = _deadline_monotonic
+        set_deadline(self._seconds)
+        return self
+
+    def __exit__(self, *_exc: object) -> None:
+        global _deadline_monotonic
+        _deadline_monotonic = self._prev
+
+
+def _host_check() -> np.ndarray:
+    return np.asarray(deadline_exceeded(), dtype=np.bool_)
+
+
+def deadline_exceeded_jax() -> jnp.ndarray:
+    """JAX-side predicate: 0-d bool array, True iff the deadline has passed.
+
+    Safe to call inside ``jax.lax.while_loop`` ``cond_fn``. Uses
+    ``ordered=True`` so the host callback fires once per iteration in
+    order, which is what we want for a self-terminating loop. Note this
+    means the predicate cannot be used under ``jax.vmap`` — call sites
+    that vmap must compile the cond_fn without the deadline check.
+    """
+    result: jnp.ndarray = io_callback(
+        _host_check,
+        jax.ShapeDtypeStruct((), jnp.bool_),
+        ordered=True,
+    )
+    return result

--- a/python/discopt/_jax/ipm.py
+++ b/python/discopt/_jax/ipm.py
@@ -21,6 +21,8 @@ from typing import Callable, NamedTuple, Optional
 import jax
 import jax.numpy as jnp
 
+from discopt._jax.deadline import deadline_exceeded_jax
+
 # ---------------------------------------------------------------------------
 # Data structures (NamedTuples for JAX pytree compatibility)
 # ---------------------------------------------------------------------------
@@ -1186,6 +1188,8 @@ def ipm_solve(
     g_l: Optional[jnp.ndarray] = None,
     g_u: Optional[jnp.ndarray] = None,
     options: Optional[IPMOptions] = None,
+    *,
+    check_deadline: bool = True,
 ) -> IPMState:
     """
     Solve an NLP using a pure-JAX interior point method.
@@ -1199,6 +1203,11 @@ def ipm_solve(
         g_l: Lower constraint bounds (m,).
         g_u: Upper constraint bounds (m,).
         options: IPMOptions.
+        check_deadline: When True (default), the cond_fn polls the process-
+            global wall-clock deadline via host callback so the while_loop
+            self-terminates on time-out (issue #80). Must be set to False
+            when this function is wrapped in ``jax.vmap``; the host callback
+            does not survive a batched predicate.
 
     Returns:
         Final IPMState with solution in state.x.
@@ -1226,8 +1235,20 @@ def ipm_solve(
     state = _initialize_state(obj_fn, con_fn_safe, x0, pd, opts)
     body = _make_iteration_body(obj_fn, con_fn_safe, pd, opts)
 
-    def cond(st):
-        return st.converged == 0
+    if check_deadline:
+
+        def cond(st):
+            # Self-terminate on a process-global wall-clock deadline (#80).
+            # solve_nlp_ipm's post-hoc check maps elapsed > max_wall_time to
+            # ITERATION_LIMIT, so partial state on early exit is handled.
+            return jnp.logical_and(
+                st.converged == 0,
+                jnp.logical_not(deadline_exceeded_jax()),
+            )
+    else:
+
+        def cond(st):
+            return st.converged == 0
 
     return jax.lax.while_loop(cond, body, state)  # type: ignore[no-any-return]
 
@@ -1349,9 +1370,11 @@ def solve_nlp_ipm(
         if fields:
             ipm_opts = ipm_opts._replace(**fields)
 
-    # Enforce max_wall_time by capping max_iter. The JIT-compiled
-    # jax.lax.while_loop cannot check wall clock, so we limit iterations
-    # upfront and verify after the solve (issue #5).
+    # max_wall_time backstop: the in-loop deadline check (issue #80)
+    # interrupts the JAX while_loop within ~1 host callback, but we still
+    # cross-check post-hoc so callers that pass max_wall_time without
+    # entering a deadline_scope still see the correct ITERATION_LIMIT
+    # status (issue #5).
     max_wall_time = options.get("max_wall_time") if options else None
 
     obj_fn = evaluator._obj_fn
@@ -1497,6 +1520,7 @@ def solve_nlp_batch(
             g_l,
             g_u,
             options,
+            check_deadline=False,  # host callback unsupported under vmap (#80)
         )
 
     return jax.vmap(_solve_single)(x0_batch, xl_batch, xu_batch)  # type: ignore[no-any-return]

--- a/python/discopt/_jax/ipm_iterative.py
+++ b/python/discopt/_jax/ipm_iterative.py
@@ -481,6 +481,7 @@ def solve_nlp_iterative_batch(
             g_l,
             g_u,
             options,
+            check_deadline=False,  # host callback unsupported under vmap (#80)
         )
 
     return jax.vmap(_solve_single)(  # type: ignore[no-any-return]

--- a/python/discopt/_jax/lp_ipm.py
+++ b/python/discopt/_jax/lp_ipm.py
@@ -30,6 +30,8 @@ import jax
 import jax.numpy as jnp
 import jax.scipy.linalg as jsla
 
+from discopt._jax.deadline import deadline_exceeded_jax
+
 # ---------------------------------------------------------------------------
 # Constants
 # ---------------------------------------------------------------------------
@@ -544,8 +546,8 @@ def _iteration_body(carry: LPCarry, tol: float, max_iter: int, tau_min: float) -
 # ---------------------------------------------------------------------------
 
 
-@functools.partial(jax.jit, static_argnums=(5, 6, 7, 8))
-def _lp_ipm_solve_jit(c, A, b, x_l, x_u, tol, max_iter, tau_min, bound_push):
+@functools.partial(jax.jit, static_argnums=(5, 6, 7, 8, 9))
+def _lp_ipm_solve_jit(c, A, b, x_l, x_u, tol, max_iter, tau_min, bound_push, check_deadline):
     """JIT-compiled LP IPM core (m > 0 path).
 
     By wrapping the entire solve (init + while_loop) in @jax.jit, all JAX
@@ -556,14 +558,30 @@ def _lp_ipm_solve_jit(c, A, b, x_l, x_u, tol, max_iter, tau_min, bound_push):
     Options (tol, max_iter, tau_min, bound_push) are static_argnums so they
     become compile-time constants.  Different option values cause recompilation,
     but benchmarks typically use the same options for all runs.
+
+    ``check_deadline`` is also static so the cond_fn is compiled with or
+    without the host-callback predicate. The vmap'd batch path passes
+    False because ``io_callback`` does not survive a batched while_loop
+    predicate (issue #80).
     """
     pd = _make_problem_data(c, A, b, x_l, x_u)
     opts = LPIPMOptions(tol=tol, max_iter=max_iter, tau_min=tau_min, bound_push=bound_push)
     state = _initialize_state(pd, opts)
     carry = LPCarry(state=state, pd=pd)
 
-    def cond(carry):
-        return carry.state.converged == 0
+    if check_deadline:
+
+        def cond(carry):
+            # Self-terminate if the process-global wall-clock deadline
+            # trips mid-solve (issue #80).
+            return jnp.logical_and(
+                carry.state.converged == 0,
+                jnp.logical_not(deadline_exceeded_jax()),
+            )
+    else:
+
+        def cond(carry):
+            return carry.state.converged == 0
 
     def body(carry):
         return _iteration_body(carry, tol, max_iter, tau_min)
@@ -579,6 +597,8 @@ def lp_ipm_solve(
     x_l: jnp.ndarray,
     x_u: jnp.ndarray,
     options: LPIPMOptions | None = None,
+    *,
+    check_deadline: bool = True,
 ) -> LPIPMState:
     """Solve an LP using a pure-JAX Mehrotra predictor-corrector IPM.
 
@@ -630,7 +650,16 @@ def lp_ipm_solve(
         return state  # type: ignore[no-any-return]
 
     state = _lp_ipm_solve_jit(
-        c, A, b, x_l, x_u, opts.tol, opts.max_iter, opts.tau_min, opts.bound_push
+        c,
+        A,
+        b,
+        x_l,
+        x_u,
+        opts.tol,
+        opts.max_iter,
+        opts.tau_min,
+        opts.bound_push,
+        check_deadline,
     )
     if factors.applied:
         x_us, y_us, zl_us, zu_us = unscale_lp_solution(
@@ -667,7 +696,10 @@ def lp_ipm_solve_batch(
     """
 
     def _solve_single(xl_single, xu_single):
-        return lp_ipm_solve(c, A, b, xl_single, xu_single, options)
+        # Host-callback deadline check doesn't survive a batched while_loop
+        # predicate; the Python orchestration layer caps the batch call
+        # externally (issue #80).
+        return lp_ipm_solve(c, A, b, xl_single, xu_single, options, check_deadline=False)
 
     result: LPIPMState = jax.vmap(_solve_single)(xl_batch, xu_batch)
     return result

--- a/python/discopt/_jax/milp_relaxation.py
+++ b/python/discopt/_jax/milp_relaxation.py
@@ -21,6 +21,7 @@ Theory: Nagarajan et al., JOGO 2018, Section 4 (piecewise McCormick relaxation).
 from __future__ import annotations
 
 import logging
+import math
 from dataclasses import dataclass
 from typing import Optional, Union
 
@@ -39,6 +40,7 @@ from discopt.modeling.core import (
     BinaryOp,
     Constant,
     Expression,
+    FunctionCall,
     IndexExpression,
     Model,
     ObjectiveSense,
@@ -177,6 +179,203 @@ def _normalize_convhull_formulation(formulation: str) -> str:
         ) from err
 
 
+def _trig_expr_key(expr: FunctionCall) -> tuple[str, str]:
+    """Return a stable key for a supported unary trigonometric call."""
+    return (expr.func_name, repr(expr.args[0]))
+
+
+def _is_supported_trig_call(expr: Expression) -> bool:
+    return (
+        isinstance(expr, FunctionCall)
+        and expr.func_name in {"sin", "cos", "tan"}
+        and len(expr.args) == 1
+    )
+
+
+def _linearize_affine_expr(expr: Expression, model: Model, n_orig: int) -> tuple[np.ndarray, float]:
+    """Return coeff/constant for an affine expression over original variables."""
+    coeff = np.zeros(n_orig, dtype=np.float64)
+    const_acc = [0.0]
+
+    def visit(e: Expression, scale: float) -> None:
+        if isinstance(e, Constant):
+            const_acc[0] += scale * float(e.value)
+            return
+        if isinstance(e, Variable):
+            offset = _compute_var_offset(e, model)
+            if e.size != 1:
+                raise ValueError(f"Non-scalar variable in affine expression: {e}")
+            coeff[offset] += scale
+            return
+        if isinstance(e, IndexExpression):
+            flat = _get_flat_index(e, model)
+            if flat is None:
+                raise ValueError(f"Cannot linearize affine IndexExpression: {e}")
+            coeff[flat] += scale
+            return
+        if isinstance(e, UnaryOp):
+            if e.op != "neg":
+                raise ValueError(f"Cannot linearize affine UnaryOp: {e.op}")
+            visit(e.operand, -scale)
+            return
+        if isinstance(e, BinaryOp):
+            if e.op == "+":
+                visit(e.left, scale)
+                visit(e.right, scale)
+                return
+            if e.op == "-":
+                visit(e.left, scale)
+                visit(e.right, -scale)
+                return
+            if e.op == "/":
+                if not isinstance(e.right, Constant):
+                    raise ValueError(f"Cannot linearize non-constant affine division: {e}")
+                visit(e.left, scale / float(e.right.value))
+                return
+            if e.op == "*":
+                if isinstance(e.left, Constant):
+                    visit(e.right, scale * float(e.left.value))
+                    return
+                if isinstance(e.right, Constant):
+                    visit(e.left, scale * float(e.right.value))
+                    return
+                raise ValueError(f"Cannot linearize non-affine product: {e}")
+        if isinstance(e, SumExpression):
+            visit(e.operand, scale)
+            return
+        if isinstance(e, SumOverExpression):
+            for term in e.terms:
+                visit(term, scale)
+            return
+        raise ValueError(f"Cannot linearize affine {type(e).__name__}: {e}")
+
+    visit(expr, 1.0)
+    return coeff, const_acc[0]
+
+
+def _affine_interval(
+    coeff: np.ndarray,
+    const: float,
+    flat_lb: np.ndarray,
+    flat_ub: np.ndarray,
+) -> tuple[float, float] | None:
+    """Compute the exact interval of an affine expression over a bound box."""
+    lo = float(const)
+    hi = float(const)
+    for c_i, lb_i, ub_i in zip(coeff, flat_lb, flat_ub):
+        c_i = float(c_i)
+        if abs(c_i) <= 0.0:
+            continue
+        if not (np.isfinite(lb_i) and np.isfinite(ub_i)):
+            return None
+        if c_i >= 0.0:
+            lo += c_i * float(lb_i)
+            hi += c_i * float(ub_i)
+        else:
+            lo += c_i * float(ub_i)
+            hi += c_i * float(lb_i)
+    return lo, hi
+
+
+def _critical_points_in_interval(start: float, period: float, lb: float, ub: float) -> list[float]:
+    tol = 1e-12
+    k_min = math.ceil((lb - start - tol) / period)
+    k_max = math.floor((ub - start + tol) / period)
+    return [start + k * period for k in range(k_min, k_max + 1)]
+
+
+def _trig_value(func: str, x: float) -> float:
+    if func == "sin":
+        return math.sin(x)
+    if func == "cos":
+        return math.cos(x)
+    if func == "tan":
+        return math.tan(x)
+    raise ValueError(f"Unsupported trig function: {func}")
+
+
+def _trig_derivative(func: str, x: float) -> float:
+    if func == "sin":
+        return math.cos(x)
+    if func == "cos":
+        return -math.sin(x)
+    if func == "tan":
+        c = math.cos(x)
+        return 1.0 / (c * c)
+    raise ValueError(f"Unsupported trig function: {func}")
+
+
+def _tan_range(lb: float, ub: float) -> tuple[float, float] | None:
+    """Return tan interval bounds only when [lb, ub] stays on one safe branch."""
+    if not (np.isfinite(lb) and np.isfinite(ub)):
+        return None
+    margin = 1e-7
+    k_min = math.floor((lb - math.pi / 2.0) / math.pi) - 1
+    k_max = math.ceil((ub - math.pi / 2.0) / math.pi) + 1
+    for k in range(k_min, k_max + 1):
+        asymptote = math.pi / 2.0 + k * math.pi
+        if lb - margin <= asymptote <= ub + margin:
+            return None
+    vals = [math.tan(lb), math.tan(ub)]
+    if not all(np.isfinite(v) for v in vals):
+        return None
+    return min(vals), max(vals)
+
+
+def _trig_range(func: str, lb: float, ub: float) -> tuple[float, float] | None:
+    """Compute exact range bounds for supported trig functions on [lb, ub]."""
+    if lb > ub:
+        lb, ub = ub, lb
+    if func == "tan":
+        return _tan_range(lb, ub)
+    if not (np.isfinite(lb) and np.isfinite(ub)):
+        return None
+    if ub - lb >= 2.0 * math.pi:
+        return -1.0, 1.0
+    points = [lb, ub]
+    if func == "sin":
+        points.extend(_critical_points_in_interval(math.pi / 2.0, math.pi, lb, ub))
+    elif func == "cos":
+        points.extend(_critical_points_in_interval(0.0, math.pi, lb, ub))
+    else:
+        return None
+    vals = [_trig_value(func, p) for p in points if lb - 1e-12 <= p <= ub + 1e-12]
+    return min(vals), max(vals)
+
+
+def _trig_curvature(func: str, value_lb: float, value_ub: float) -> str | None:
+    """Classify univariate trig curvature over an interval, if sign-certifiable."""
+    tol = 1e-12
+    if func in {"sin", "cos"}:
+        if value_lb >= -tol:
+            return "concave"
+        if value_ub <= tol:
+            return "convex"
+    elif func == "tan":
+        if value_lb >= -tol:
+            return "convex"
+        if value_ub <= tol:
+            return "concave"
+    return None
+
+
+def _line_at(func: str, x: float) -> tuple[float, float]:
+    """Return slope/intercept for the tangent line to f at x."""
+    slope = _trig_derivative(func, x)
+    intercept = _trig_value(func, x) - slope * x
+    return slope, intercept
+
+
+def _secant_line(func: str, lb: float, ub: float) -> tuple[float, float] | None:
+    if abs(ub - lb) <= 1e-12:
+        return None
+    f_lb = _trig_value(func, lb)
+    f_ub = _trig_value(func, ub)
+    slope = (f_ub - f_lb) / (ub - lb)
+    intercept = f_lb - slope * lb
+    return slope, intercept
+
+
 def _choose_trilinear_pair(
     term: tuple[int, int, int],
     partitioned_vars: set[int],
@@ -262,6 +461,8 @@ def _linearize_expr(
     monomial_var_map: dict[tuple[int, int], int],
     n_total_vars: int,
     fractional_power_var_map: Optional[dict[tuple[int, float], int]] = None,
+    trig_var_map: Optional[dict[tuple[str, str], int]] = None,
+    trig_square_var_map: Optional[dict[tuple[tuple[str, str], int], int]] = None,
 ) -> tuple[np.ndarray, float]:
     """Walk expression tree and return (coeff, constant) for linearized form.
 
@@ -310,6 +511,18 @@ def _linearize_expr(
                     raise ValueError(f"Cannot linearize non-constant division: {e}")
 
             elif e.op == "**":
+                if (
+                    isinstance(e.left, FunctionCall)
+                    and _is_supported_trig_call(e.left)
+                    and isinstance(e.right, Constant)
+                    and float(e.right.value) == 2.0
+                ):
+                    trig_key = _trig_expr_key(e.left)
+                    square_key = (trig_key, 2)
+                    if trig_square_var_map and square_key in trig_square_var_map:
+                        coeff[trig_square_var_map[square_key]] += scale
+                        return
+                    raise ValueError(f"Trig square {square_key} has no aux column")
                 flat = _get_flat_index(e.left, model)
                 if flat is not None and isinstance(e.right, Constant):
                     exp_val = float(e.right.value)
@@ -388,6 +601,14 @@ def _linearize_expr(
                 visit(e.operand, -scale)
             else:
                 raise ValueError(f"Cannot linearize UnaryOp: {e.op}")
+
+        elif isinstance(e, FunctionCall):
+            if _is_supported_trig_call(e):
+                trig_key = _trig_expr_key(e)
+                if trig_var_map and trig_key in trig_var_map:
+                    coeff[trig_var_map[trig_key]] += scale
+                    return
+            raise ValueError(f"Cannot linearize FunctionCall: {e}")
 
         elif isinstance(e, SumExpression):
             op = e.operand
@@ -591,6 +812,114 @@ def build_milp_relaxation(
 
     for key in bilinear_with_fp_keys:
         bilinear_var_map[key] = _ensure_bilinear_aux(*key)
+
+    # ── Lifted affine-argument trig aux columns ────────────────────────────
+    trig_var_map: dict[tuple[str, str], int] = {}
+    trig_square_var_map: dict[tuple[tuple[str, str], int], int] = {}
+    trig_specs: list[dict] = []
+    trig_square_specs: list[dict] = []
+
+    def _ensure_trig_aux(expr: FunctionCall) -> int | None:
+        nonlocal col_idx
+        if not _is_supported_trig_call(expr):
+            return None
+        key = _trig_expr_key(expr)
+        if key in trig_var_map:
+            return trig_var_map[key]
+        try:
+            arg_coeff, arg_const = _linearize_affine_expr(expr.args[0], model, n_orig)
+        except ValueError:
+            return None
+        arg_interval = _affine_interval(arg_coeff, arg_const, flat_lb, flat_ub)
+        if arg_interval is None:
+            return None
+        arg_lb, arg_ub = arg_interval
+        value_interval = _trig_range(expr.func_name, arg_lb, arg_ub)
+        if value_interval is None:
+            return None
+        value_lb, value_ub = value_interval
+        trig_var_map[key] = col_idx
+        all_bounds.append((float(value_lb), float(value_ub)))
+        integrality_flags.append(0)
+        trig_specs.append(
+            {
+                "func": expr.func_name,
+                "arg_coeff": arg_coeff,
+                "arg_const": float(arg_const),
+                "arg_lb": float(arg_lb),
+                "arg_ub": float(arg_ub),
+                "value_lb": float(value_lb),
+                "value_ub": float(value_ub),
+                "col": col_idx,
+                "convexity": _trig_curvature(expr.func_name, value_lb, value_ub),
+            }
+        )
+        col_idx += 1
+        return trig_var_map[key]
+
+    def _ensure_trig_square_aux(expr: FunctionCall) -> int | None:
+        nonlocal col_idx
+        trig_col = _ensure_trig_aux(expr)
+        if trig_col is None:
+            return None
+        trig_key = _trig_expr_key(expr)
+        square_key = (trig_key, 2)
+        if square_key in trig_square_var_map:
+            return trig_square_var_map[square_key]
+        trig_lb, trig_ub = [float(v) for v in all_bounds[trig_col]]
+        vals = [trig_lb * trig_lb, trig_ub * trig_ub]
+        if trig_lb <= 0.0 <= trig_ub:
+            vals.append(0.0)
+        trig_square_var_map[square_key] = col_idx
+        all_bounds.append((min(vals), max(vals)))
+        integrality_flags.append(0)
+        trig_square_specs.append(
+            {
+                "base_col": trig_col,
+                "col": col_idx,
+                "base_lb": trig_lb,
+                "base_ub": trig_ub,
+            }
+        )
+        col_idx += 1
+        return trig_square_var_map[square_key]
+
+    def _scan_trig_expr(expr: Expression) -> None:
+        if isinstance(expr, FunctionCall) and _is_supported_trig_call(expr):
+            _ensure_trig_aux(expr)
+            for arg in expr.args:
+                _scan_trig_expr(arg)
+            return
+        if isinstance(expr, BinaryOp):
+            if (
+                expr.op == "**"
+                and isinstance(expr.left, FunctionCall)
+                and _is_supported_trig_call(expr.left)
+                and isinstance(expr.right, Constant)
+                and float(expr.right.value) == 2.0
+            ):
+                _ensure_trig_square_aux(expr.left)
+            _scan_trig_expr(expr.left)
+            _scan_trig_expr(expr.right)
+            return
+        if isinstance(expr, UnaryOp):
+            _scan_trig_expr(expr.operand)
+            return
+        if isinstance(expr, FunctionCall):
+            for arg in expr.args:
+                _scan_trig_expr(arg)
+            return
+        if isinstance(expr, SumExpression):
+            _scan_trig_expr(expr.operand)
+            return
+        if isinstance(expr, SumOverExpression):
+            for term in expr.terms:
+                _scan_trig_expr(term)
+
+    if model._objective is not None:
+        _scan_trig_expr(distribute_products(model._objective.expression))
+    for constraint in model._constraints:
+        _scan_trig_expr(distribute_products(constraint.body))
 
     bilinear_pw_map: dict[tuple[int, int], list] = {}
     bilinear_lambda_map: dict[tuple[int, int], dict] = {}
@@ -1242,6 +1571,70 @@ def build_milp_relaxation(
             row[var_idx] = -secant_slope
             _add_row(row, secant_intercept)
 
+    # ── Lifted trig envelope constraints ───────────────────────────────────
+    def _add_univariate_lower(spec: dict, slope: float, intercept: float) -> None:
+        # y >= slope * arg + intercept
+        row = np.zeros(n_total)
+        row[int(spec["col"])] = -1.0
+        row[:n_orig] += slope * np.asarray(spec["arg_coeff"], dtype=np.float64)
+        rhs = -intercept - slope * float(spec["arg_const"])
+        _add_row(row, rhs)
+
+    def _add_univariate_upper(spec: dict, slope: float, intercept: float) -> None:
+        # y <= slope * arg + intercept
+        row = np.zeros(n_total)
+        row[int(spec["col"])] = 1.0
+        row[:n_orig] -= slope * np.asarray(spec["arg_coeff"], dtype=np.float64)
+        rhs = intercept + slope * float(spec["arg_const"])
+        _add_row(row, rhs)
+
+    for spec in trig_specs:
+        func = str(spec["func"])
+        arg_lb = float(spec["arg_lb"])
+        arg_ub = float(spec["arg_ub"])
+        convexity = spec["convexity"]
+        if convexity not in {"convex", "concave"}:
+            continue
+        tangent_pts = [arg_lb, arg_ub]
+        mid = 0.5 * (arg_lb + arg_ub)
+        if abs(arg_ub - arg_lb) > 1e-10 and all(abs(mid - t) > 1e-10 for t in tangent_pts):
+            tangent_pts.append(mid)
+        secant = _secant_line(func, arg_lb, arg_ub)
+        if convexity == "convex":
+            for t in tangent_pts:
+                slope, intercept = _line_at(func, t)
+                _add_univariate_lower(spec, slope, intercept)
+            if secant is not None:
+                _add_univariate_upper(spec, *secant)
+        else:
+            if secant is not None:
+                _add_univariate_lower(spec, *secant)
+            for t in tangent_pts:
+                slope, intercept = _line_at(func, t)
+                _add_univariate_upper(spec, slope, intercept)
+
+    # q = s^2 for lifted trig calls. This composes the existing square
+    # relaxation pattern with the trig range/lift, so trig-square constraints
+    # stay in the MILP even when the trig graph itself has mixed curvature.
+    for spec in trig_square_specs:
+        base_col = int(spec["base_col"])
+        q_col = int(spec["col"])
+        lb_i = float(spec["base_lb"])
+        ub_i = float(spec["base_ub"])
+        tangent_pts = [lb_i, ub_i]
+        if lb_i <= 0.0 <= ub_i:
+            tangent_pts.append(0.0)
+        for t in sorted(set(tangent_pts)):
+            row = np.zeros(n_total)
+            row[q_col] = -1.0
+            row[base_col] = 2.0 * t
+            _add_row(row, t * t)
+        if abs(ub_i - lb_i) > 1e-12:
+            row = np.zeros(n_total)
+            row[q_col] = 1.0
+            row[base_col] = -(lb_i + ub_i)
+            _add_row(row, -lb_i * ub_i)
+
     # Model constraints
     for constraint in model._constraints:
         body = distribute_products(constraint.body)
@@ -1255,6 +1648,8 @@ def build_milp_relaxation(
                 monomial_var_map,
                 n_total,
                 fractional_power_var_map=fractional_power_var_map,
+                trig_var_map=trig_var_map,
+                trig_square_var_map=trig_square_var_map,
             )
             # body ≤ 0  →  c @ z + const ≤ 0  →  c @ z ≤ -const
             if sense == "<=":
@@ -1295,6 +1690,8 @@ def build_milp_relaxation(
             monomial_var_map,
             n_total,
             fractional_power_var_map=fractional_power_var_map,
+            trig_var_map=trig_var_map,
+            trig_square_var_map=trig_square_var_map,
         )
         objective_bound_valid = True
     except ValueError as err:
@@ -1351,6 +1748,8 @@ def build_milp_relaxation(
         "monomial": monomial_var_map,
         "bilinear_pw": bilinear_pw_map,
         "bilinear_lambda": bilinear_lambda_map,
+        "trig": trig_var_map,
+        "trig_square": trig_square_var_map,
         "convhull_formulation": convhull_mode,
     }
 

--- a/python/discopt/_jax/qp_ipm.py
+++ b/python/discopt/_jax/qp_ipm.py
@@ -30,6 +30,8 @@ import jax
 import jax.numpy as jnp
 import jax.scipy.linalg as jsla
 
+from discopt._jax.deadline import deadline_exceeded_jax
+
 # ---------------------------------------------------------------------------
 # Constants
 # ---------------------------------------------------------------------------
@@ -524,21 +526,36 @@ def _iteration_body(carry: QPCarry, tol: float, max_iter: int, tau_min: float) -
 # ---------------------------------------------------------------------------
 
 
-@functools.partial(jax.jit, static_argnums=(6, 7, 8, 9))
-def _qp_ipm_solve_jit(Q, c, A, b, x_l, x_u, tol, max_iter, tau_min, bound_push):
+@functools.partial(jax.jit, static_argnums=(6, 7, 8, 9, 10))
+def _qp_ipm_solve_jit(Q, c, A, b, x_l, x_u, tol, max_iter, tau_min, bound_push, check_deadline):
     """JIT-compiled QP IPM core.
 
     Wraps the entire solve (init + while_loop) in @jax.jit so all JAX
     operations compile into a single XLA program, eliminating Python
     dispatch overhead (~75x speedup on warm calls).
+
+    ``check_deadline`` is static so the cond_fn is compiled with or
+    without the host-callback predicate. The vmap'd batch path passes
+    False because ``io_callback`` doesn't survive a batched while_loop
+    predicate (issue #80).
     """
     pd = _make_problem_data(Q, c, A, b, x_l, x_u)
     opts = QPIPMOptions(tol=tol, max_iter=max_iter, tau_min=tau_min, bound_push=bound_push)
     state = _initialize_state(pd, opts)
     carry = QPCarry(state=state, pd=pd)
 
-    def cond(carry):
-        return carry.state.converged == 0
+    if check_deadline:
+
+        def cond(carry):
+            # Self-terminate on a process-global wall-clock deadline (#80).
+            return jnp.logical_and(
+                carry.state.converged == 0,
+                jnp.logical_not(deadline_exceeded_jax()),
+            )
+    else:
+
+        def cond(carry):
+            return carry.state.converged == 0
 
     def body(carry):
         return _iteration_body(carry, tol, max_iter, tau_min)
@@ -555,6 +572,8 @@ def qp_ipm_solve(
     x_l: jnp.ndarray,
     x_u: jnp.ndarray,
     options: QPIPMOptions | None = None,
+    *,
+    check_deadline: bool = True,
 ) -> QPIPMState:
     """Solve a QP using a pure-JAX Mehrotra predictor-corrector IPM.
 
@@ -593,7 +612,17 @@ def qp_ipm_solve(
     x_u = jnp.asarray(x_u, dtype=jnp.float64)
 
     return _qp_ipm_solve_jit(  # type: ignore[no-any-return]
-        Q, c, A, b, x_l, x_u, opts.tol, opts.max_iter, opts.tau_min, opts.bound_push
+        Q,
+        c,
+        A,
+        b,
+        x_l,
+        x_u,
+        opts.tol,
+        opts.max_iter,
+        opts.tau_min,
+        opts.bound_push,
+        check_deadline,
     )
 
 
@@ -624,6 +653,9 @@ def qp_ipm_solve_batch(
     """
 
     def _solve_single(xl_single, xu_single):
-        return qp_ipm_solve(Q, c, A, b, xl_single, xu_single, options)
+        # Host-callback deadline check doesn't survive a batched while_loop
+        # predicate; the Python orchestration layer caps the batch call
+        # externally (issue #80).
+        return qp_ipm_solve(Q, c, A, b, xl_single, xu_single, options, check_deadline=False)
 
     return jax.vmap(_solve_single)(xl_batch, xu_batch)  # type: ignore[no-any-return]

--- a/python/discopt/_jax/taylor_model.py
+++ b/python/discopt/_jax/taylor_model.py
@@ -40,10 +40,10 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 
-import jax
 import jax.numpy as jnp
 import numpy as np
 import numpy.polynomial.polynomial as np_poly
+from jax.experimental.jet import jet
 
 # ---------------------------------------------------------------------------
 # Helpers (interval arithmetic + polynomial range)
@@ -253,27 +253,27 @@ def _taylor_coefficients(f_callable, x0: float, half_width: float, degree: int) 
     so ``sum_k coeffs[k] * s^k`` approximates ``f(x0 + half_width * s)`` for
     ``s ∈ [-1, 1]``.
 
-    Derivatives are computed via repeated ``jax.grad`` on a JAX-traceable
-    wrapper. ``f_callable`` must accept and return JAX-compatible scalars
-    (the standard NumPy unary functions ``np.exp``, ``np.log``, etc. work
-    because JAX's ``jnp`` versions have the same API and ``jax.grad`` traces
-    through the chosen elementary operations of the wrapper).
+    Uses ``jax.experimental.jet.jet`` to evaluate the entire Taylor tower in a
+    single tracing pass. That replaces the older chained ``jax.grad`` approach,
+    which retraced + recompiled at every order (the dominant cost for
+    high-degree univariate compositions).
     """
-
-    def _f(u):
-        # Wrap to ensure jax can trace; rely on caller passing jax-compatible f.
-        return f_callable(u)
-
+    x0_jax = jnp.asarray(x0, dtype=jnp.float64)
+    if degree == 0:
+        return np.array([float(f_callable(x0_jax))])
+    # For x(t) = x0 + t, the input series is (1, 0, 0, ...). ``jet`` returns
+    # ``y_terms[k-1] = f^(k)(x0)`` (raw higher derivatives, not divided by k!)
+    # and ``y0 = f(x0)``.
+    series = ((1.0,) + (0.0,) * (degree - 1),)
+    y0, y_terms = jet(f_callable, (x0_jax,), series)
     coeffs = np.zeros(degree + 1)
-    deriv = _f
+    coeffs[0] = float(y0)
+    hw_pow = half_width
     factorial = 1.0
-    hw_pow = 1.0
-    for k in range(degree + 1):
-        val = float(deriv(jnp.asarray(x0, dtype=jnp.float64)))
-        coeffs[k] = val * hw_pow / factorial
-        deriv = jax.grad(deriv)
+    for k in range(1, degree + 1):
+        factorial *= k
+        coeffs[k] = float(y_terms[k - 1]) * hw_pow / factorial
         hw_pow *= half_width
-        factorial *= k + 1
     return coeffs
 
 
@@ -323,7 +323,7 @@ def compose_unary(f_callable, g: TaylorModel) -> TaylorModel:
     M = _COMPOSE_VALIDATE_GRID
     fine_s = np.linspace(-1.0, 1.0, M)
     fine_u = x0 + half_width * fine_s
-    f_fine = np.array([float(f_callable(jnp.asarray(float(u)))) for u in fine_u])
+    f_fine = np.asarray(f_callable(jnp.asarray(fine_u, dtype=jnp.float64)))
     p_fine = np_poly.polyval(fine_s, f_coeffs)
     resid = np.abs(f_fine - p_fine)
     resid_max = float(resid.max())

--- a/python/discopt/modeling/core.py
+++ b/python/discopt/modeling/core.py
@@ -1906,27 +1906,33 @@ class Model:
                 time_limit=time_limit, gap_tolerance=gap_tolerance, **kwargs
             )
 
+        from discopt._jax.deadline import deadline_scope
         from discopt.solver import solve_model
 
         if solver is not None:
             kwargs["solver"] = solver
 
-        result = solve_model(
-            self,
-            time_limit=time_limit,
-            gap_tolerance=gap_tolerance,
-            threads=threads,
-            deterministic=deterministic,
-            partitions=partitions,
-            branching_policy=branching_policy,
-            initial_point=_x0_flat,
-            skip_convex_check=skip_convex_check,
-            nlp_bb=nlp_bb,
-            lazy_constraints=lazy_constraints,
-            incumbent_callback=incumbent_callback,
-            node_callback=node_callback,
-            **kwargs,
-        )
+        # Install a process-global wall-clock deadline that JAX-compiled
+        # while_loops (LP/QP/NLP IPM) can poll via host callback so they
+        # self-terminate within ``time_limit + ε`` instead of running to
+        # XLA convergence after Python's budget is gone (issue #80).
+        with deadline_scope(time_limit):
+            result = solve_model(
+                self,
+                time_limit=time_limit,
+                gap_tolerance=gap_tolerance,
+                threads=threads,
+                deterministic=deterministic,
+                partitions=partitions,
+                branching_policy=branching_policy,
+                initial_point=_x0_flat,
+                skip_convex_check=skip_convex_check,
+                nlp_bb=nlp_bb,
+                lazy_constraints=lazy_constraints,
+                incumbent_callback=incumbent_callback,
+                node_callback=node_callback,
+                **kwargs,
+            )
 
         # Attach model reference and auto-generate LLM explanation
         result._model = self

--- a/python/discopt/modeling/core.py
+++ b/python/discopt/modeling/core.py
@@ -883,6 +883,9 @@ class SolveResult:
     nlp_bb: bool = False
     gap_certified: bool = True
 
+    # Examiner-style validation report (populated if validate=True).
+    validation_report: Optional[object] = None
+
     # LLM explanation (populated if llm=True)
     _explanation: Optional[str] = None
     _model: Optional["Model"] = None
@@ -1804,6 +1807,7 @@ class Model:
         incumbent_callback: Optional[Callable] = None,
         node_callback: Optional[Callable] = None,
         solver: Optional[str] = None,
+        validate: bool = False,
         **kwargs,
     ) -> Union[SolveResult, Iterator["SolveUpdate"]]:
         r"""
@@ -1864,6 +1868,11 @@ class Model:
         node_callback : callable, optional
             Node callback. Called after each batch of nodes is processed.
             Should accept ``(ctx, model)`` and return ``None``.
+        validate : bool, default False
+            If True, run Examiner-style KKT validation on the returned
+            point and attach the :class:`~discopt.validation.ExaminerReport`
+            to ``result.validation_report``. Errors during validation are
+            swallowed and leave ``validation_report`` as ``None``.
         \*\*kwargs
             Additional keyword arguments passed to the solver backend.
 
@@ -1941,6 +1950,14 @@ class Model:
                 result._explanation = result._explain_with_llm()
             except Exception:
                 pass
+
+        if validate and result.x is not None:
+            try:
+                from discopt.validation.examiner import examine
+
+                result.validation_report = examine(result, self)
+            except Exception:
+                result.validation_report = None
 
         return result
 

--- a/python/discopt/solver.py
+++ b/python/discopt/solver.py
@@ -3165,9 +3165,57 @@ def _solve_nlp_bb(
         if obj_val >= _SENTINEL_THRESHOLD:
             incumbent = None
 
+    constraint_duals = None
+    bound_duals_lower = None
+    bound_duals_upper = None
+
     if incumbent is not None:
         sol_flat = np.array(sol_array)
         x_dict = _unpack_solution(model, sol_flat)
+
+        # Recover relaxation duals at the incumbent by re-solving the NLP with
+        # integer variables fixed. Best-effort — failures leave duals as None
+        # and the examiner falls back to its LSQ recovery.
+        try:
+            fix_lb = lb.copy()
+            fix_ub = ub.copy()
+            for off, sz in zip(int_offsets, int_sizes):
+                for k in range(int(sz)):
+                    val = float(round(float(sol_flat[off + k])))
+                    fix_lb[off + k] = val
+                    fix_ub[off + k] = val
+            recover_opts = dict(opts)
+            recover_opts["max_wall_time"] = max(
+                0.1, min(5.0, time_limit - (time.perf_counter() - t_start))
+            )
+            recover_opts.setdefault("print_level", 0)
+            nlp_recovered = _solve_node_nlp_ipopt(
+                evaluator, sol_flat, fix_lb, fix_ub, constraint_bounds, recover_opts
+            )
+            if nlp_recovered.status in (
+                SolveStatus.OPTIMAL,
+                SolveStatus.ITERATION_LIMIT,
+            ):
+                constraint_duals = _unpack_constraint_duals(evaluator, nlp_recovered.multipliers)
+                bound_duals_lower = _unpack_bound_duals(
+                    model, nlp_recovered.bound_multipliers_lower
+                )
+                bound_duals_upper = _unpack_bound_duals(
+                    model, nlp_recovered.bound_multipliers_upper
+                )
+                # Zero bound multipliers on integer columns: they reflect the
+                # cost of fixing the integer, not bound activity in the
+                # original model. The examiner already drops integer columns
+                # from stationarity, so zeros are safe here.
+                if bound_duals_lower is not None or bound_duals_upper is not None:
+                    for v in model._variables:
+                        if v.var_type in (VarType.BINARY, VarType.INTEGER):
+                            if bound_duals_lower is not None and v.name in bound_duals_lower:
+                                bound_duals_lower[v.name] = np.zeros_like(bound_duals_lower[v.name])
+                            if bound_duals_upper is not None and v.name in bound_duals_upper:
+                                bound_duals_upper[v.name] = np.zeros_like(bound_duals_upper[v.name])
+        except Exception as _exc:
+            logger.debug("NLP-BB dual recovery failed: %s", _exc)
 
         assert model._objective is not None
         if model._objective.sense == ObjectiveSense.MAXIMIZE:
@@ -3206,6 +3254,9 @@ def _solve_nlp_bb(
         python_time=python_time,
         nlp_bb=True,
         gap_certified=_gap_certified,
+        constraint_duals=constraint_duals,
+        bound_duals_lower=bound_duals_lower,
+        bound_duals_upper=bound_duals_upper,
     )
 
 
@@ -3747,16 +3798,259 @@ def _solve_node_nlp_ipopt(
     status_code = info["status"]
     status = _IPOPT_STATUS_MAP.get(status_code, SolveStatus.ERROR)
 
+    mult_g = info.get("mult_g")
+    mult_x_L = info.get("mult_x_L")
+    mult_x_U = info.get("mult_x_U")
+
     return NLPResult(
         status=status,
         x=np.asarray(x),
         objective=float(info["obj_val"]),
+        multipliers=np.asarray(mult_g) if mult_g is not None else None,
+        bound_multipliers_lower=np.asarray(mult_x_L) if mult_x_L is not None else None,
+        bound_multipliers_upper=np.asarray(mult_x_U) if mult_x_U is not None else None,
     )
 
 
 # ---------------------------------------------------------------------------
 # Specialized LP/QP solvers
 # ---------------------------------------------------------------------------
+
+
+def _scalar_constraint_layout(
+    model: Model,
+) -> Optional[tuple[list[str], list[tuple[str, str]]]]:
+    """Return per-row identity for the LP/QP fast paths, when all constraints
+    are scalar.
+
+    The algebraic and repr-based extractors used by ``extract_lp_data`` /
+    ``extract_qp_data`` partition rows into ``[equalities..., inequalities...]``
+    in the order constraints appear in ``model._constraints``. This helper
+    returns parallel lists ``(eq_names, ub_info)``:
+
+      - ``eq_names[i]`` is the constraint name for the ``i``-th equality row.
+      - ``ub_info[j] = (name, original_sense)`` for the ``j``-th inequality
+        row, where ``original_sense`` is ``"<="`` or ``">="`` (used to flip
+        the dual sign for ``">="`` constraints that the extractor negated).
+
+    Returns ``None`` if any constraint body is non-scalar — vector-bodied
+    constraints don't have a one-row-per-constraint mapping the LP path can
+    rely on, and the LP fast path's algebraic/repr extractors don't handle
+    them either.
+    """
+    eq_names: list[str] = []
+    ub_info: list[tuple[str, str]] = []
+    for idx, con in enumerate(model._constraints):
+        if not isinstance(con, Constraint):
+            continue
+        body_shape = getattr(con.body, "shape", ())
+        if body_shape not in ((), (1,)):
+            return None
+        name = con.name if con.name else f"c{idx}"
+        if con.sense == "==":
+            eq_names.append(name)
+        elif con.sense in ("<=", ">="):
+            ub_info.append((name, con.sense))
+        else:
+            return None
+    return eq_names, ub_info
+
+
+def _lp_qp_unpack_duals(
+    model: Model,
+    *,
+    row_dual: Optional[np.ndarray],
+    col_dual: Optional[np.ndarray],
+    n_eq: int,
+    n_ub: int,
+    n_orig: int,
+) -> tuple[
+    Optional[dict[str, np.ndarray]],
+    Optional[dict[str, np.ndarray]],
+    Optional[dict[str, np.ndarray]],
+]:
+    """Translate HiGHS row duals + reduced costs into discopt's named-dual
+    convention.
+
+    HiGHS row dual layout matches the constraint matrix the wrapper assembles:
+    ``A_ub`` rows first (multipliers ≥ 0), then ``A_eq`` rows (free).
+    ``_decompose_eq_slack_form`` emits inequalities to ``A_ub`` in declared
+    order, flipping the row sign for ``">="`` so HiGHS sees ``-body ≤ 0``;
+    we flip the multiplier back so the returned dual reflects the original
+    ``">="`` body (giving ``μ ≤ 0`` in the examiner convention).
+
+    Reduced costs are split into lower- and upper-bound multipliers using the
+    examiner's convention ``λ_lb = max(rc, 0)``, ``λ_ub = max(-rc, 0)``.
+
+    Returns ``(constraint_duals, bound_duals_lower, bound_duals_upper)``;
+    any entry may be ``None`` if the underlying solver did not return that
+    family of multipliers, or the row layout cannot be mapped (vector body,
+    extractor mismatch, etc.).
+    """
+    layout = _scalar_constraint_layout(model)
+    if layout is None:
+        return None, None, None
+    eq_names, ub_info = layout
+    if len(eq_names) != n_eq or len(ub_info) != n_ub:
+        return None, None, None
+
+    constraint_duals: Optional[dict[str, np.ndarray]] = None
+    if row_dual is not None and row_dual.size == n_ub + n_eq:
+        # HiGHS reports row duals as ∂obj/∂b. The examiner uses the Lagrangian
+        # convention μ s.t. ∇f + ∇body·μ = 0, with μ ≥ 0 for "<=" and μ ≤ 0
+        # for ">=", so we negate for "<=" and "==" rows. For ">=" the
+        # extractor already flipped the row to "-body ≤ const", which (after
+        # composing the two negations) leaves the HiGHS row_dual unflipped.
+        out: dict[str, np.ndarray] = {}
+        for j, (name, original_sense) in enumerate(ub_info):
+            rd = float(row_dual[j])
+            mu = rd if original_sense == ">=" else -rd
+            out[name] = np.asarray(mu, dtype=float).reshape(())
+        for i, name in enumerate(eq_names):
+            mu = -float(row_dual[n_ub + i])
+            out[name] = np.asarray(mu, dtype=float).reshape(())
+        constraint_duals = out
+
+    bound_duals_lower: Optional[dict[str, np.ndarray]] = None
+    bound_duals_upper: Optional[dict[str, np.ndarray]] = None
+    if col_dual is not None and col_dual.size >= n_orig:
+        rc = np.asarray(col_dual[:n_orig], dtype=float)
+        lam_lb = np.maximum(rc, 0.0)
+        lam_ub = np.maximum(-rc, 0.0)
+        lo: dict[str, np.ndarray] = {}
+        up: dict[str, np.ndarray] = {}
+        offset = 0
+        for v in model._variables:
+            sz = int(v.size)
+            chunk_lo = lam_lb[offset : offset + sz]
+            chunk_up = lam_ub[offset : offset + sz]
+            if v.shape == () or v.shape == (1,):
+                lo[v.name] = chunk_lo.reshape(v.shape) if v.shape == (1,) else chunk_lo.reshape(())
+                up[v.name] = chunk_up.reshape(v.shape) if v.shape == (1,) else chunk_up.reshape(())
+            else:
+                lo[v.name] = chunk_lo.reshape(v.shape)
+                up[v.name] = chunk_up.reshape(v.shape)
+            offset += sz
+        bound_duals_lower = lo
+        bound_duals_upper = up
+
+    return constraint_duals, bound_duals_lower, bound_duals_upper
+
+
+def _mip_recover_relaxation_duals(
+    model: Model,
+    *,
+    lp_data,
+    x_flat: np.ndarray,
+    n_orig: int,
+    A_ub: Optional[np.ndarray],
+    b_ub: Optional[np.ndarray],
+    A_eq: Optional[np.ndarray],
+    b_eq: Optional[np.ndarray],
+    time_limit: Optional[float] = None,
+    Q_orig: Optional[np.ndarray] = None,
+) -> tuple[
+    Optional[dict[str, np.ndarray]],
+    Optional[dict[str, np.ndarray]],
+    Optional[dict[str, np.ndarray]],
+]:
+    """Re-solve the relaxation with integer variables fixed at their MIP
+    incumbent so HiGHS returns row duals + reduced costs we can map back to
+    discopt's named-dual convention.
+
+    Pass ``Q_orig`` for QP-style relaxations; omit it for LP-style. Returns
+    ``(None, None, None)`` if recovery is unavailable (HiGHS missing, the
+    fix-and-resolve LP/QP itself fails, or layout mismatch).
+
+    Bound multipliers on the fixing bounds for integer columns are zeroed in
+    the returned dicts — they reflect the act of fixing, not feasibility of
+    the original integer-feasible point.
+    """
+    try:
+        if Q_orig is None:
+            from discopt.solvers.lp_highs import solve_lp as _highs_solve_lp
+        else:
+            from discopt.solvers.qp_highs import solve_qp as _highs_solve_qp
+    except ImportError:
+        return None, None, None
+
+    from discopt.solvers import SolveStatus
+
+    bounds_fixed: list[tuple[float, float]] = []
+    is_integer_col = np.zeros(n_orig, dtype=bool)
+    offset = 0
+    for v in model._variables:
+        sz = int(v.size)
+        is_int = v.var_type in (VarType.BINARY, VarType.INTEGER)
+        for k in range(sz):
+            if is_int:
+                val = float(round(float(x_flat[offset + k])))
+                bounds_fixed.append((val, val))
+                is_integer_col[offset + k] = True
+            else:
+                lb_k = float(np.asarray(lp_data.x_l[offset + k]))
+                ub_k = float(np.asarray(lp_data.x_u[offset + k]))
+                bounds_fixed.append((lb_k, ub_k))
+        offset += sz
+
+    c_orig = np.asarray(lp_data.c[:n_orig])
+
+    try:
+        relax: Any
+        if Q_orig is None:
+            relax = _highs_solve_lp(
+                c=c_orig,
+                A_ub=A_ub,
+                b_ub=b_ub,
+                A_eq=A_eq,
+                b_eq=b_eq,
+                bounds=bounds_fixed,
+                time_limit=time_limit,
+            )
+        else:
+            relax = _highs_solve_qp(
+                Q=Q_orig,
+                c=c_orig,
+                A_ub=A_ub,
+                b_ub=b_ub,
+                A_eq=A_eq,
+                b_eq=b_eq,
+                bounds=bounds_fixed,
+                integrality=None,
+                time_limit=time_limit,
+            )
+    except Exception as exc:
+        logger.debug("MIP-relaxation dual recovery failed: %s", exc)
+        return None, None, None
+
+    if relax.status != SolveStatus.OPTIMAL:
+        return None, None, None
+
+    n_eq_rows = A_eq.shape[0] if A_eq is not None else 0
+    n_ub_rows = A_ub.shape[0] if A_ub is not None else 0
+    cd, bdl, bdu = _lp_qp_unpack_duals(
+        model,
+        row_dual=relax.dual_values,
+        col_dual=relax.reduced_costs,
+        n_eq=n_eq_rows,
+        n_ub=n_ub_rows,
+        n_orig=n_orig,
+    )
+
+    # Zero out bound multipliers on the fix-bounds of integer columns; they
+    # quantify the cost of fixing, not bound activity in the original model.
+    if (bdl is not None or bdu is not None) and is_integer_col.any():
+        offset = 0
+        for v in model._variables:
+            sz = int(v.size)
+            if v.var_type in (VarType.BINARY, VarType.INTEGER):
+                if bdl is not None and v.name in bdl:
+                    bdl[v.name] = np.zeros_like(bdl[v.name])
+                if bdu is not None and v.name in bdu:
+                    bdu[v.name] = np.zeros_like(bdu[v.name])
+            offset += sz
+
+    return cd, bdl, bdu
 
 
 def _decompose_eq_slack_form(
@@ -3923,6 +4217,17 @@ def _solve_lp_highs(
         if model._objective.sense == ObjectiveSense.MAXIMIZE:
             obj_val = -obj_val
 
+        n_eq_rows = A_eq.shape[0] if A_eq is not None else 0
+        n_ub_rows = A_ub.shape[0] if A_ub is not None else 0
+        cd, bdl, bdu = _lp_qp_unpack_duals(
+            model,
+            row_dual=result.dual_values,
+            col_dual=result.reduced_costs,
+            n_eq=n_eq_rows,
+            n_ub=n_ub_rows,
+            n_orig=n_orig,
+        )
+
         sr = SolveResult(
             status="optimal",
             objective=obj_val,
@@ -3934,6 +4239,9 @@ def _solve_lp_highs(
             rust_time=0.0,
             jax_time=0.0,
             python_time=wall_time,
+            constraint_duals=cd,
+            bound_duals_lower=bdl,
+            bound_duals_upper=bdu,
         )
         sr.convex_fast_path = True
         return sr
@@ -4029,6 +4337,33 @@ def _solve_qp_highs(
         if model._objective.sense == ObjectiveSense.MAXIMIZE:
             obj_val = -obj_val
 
+        n_eq_rows = A_eq.shape[0] if A_eq is not None else 0
+        n_ub_rows = A_ub.shape[0] if A_ub is not None else 0
+        if integrality is None:
+            cd, bdl, bdu = _lp_qp_unpack_duals(
+                model,
+                row_dual=result.dual_values,
+                col_dual=result.reduced_costs,
+                n_eq=n_eq_rows,
+                n_ub=n_ub_rows,
+                n_orig=n_orig,
+            )
+        else:
+            # MIQP: HiGHS doesn't expose MIP duals. Recover by re-solving the
+            # QP relaxation with integers fixed at the MIP incumbent.
+            cd, bdl, bdu = _mip_recover_relaxation_duals(
+                model,
+                lp_data=qp_data,
+                x_flat=np.asarray(x_flat, dtype=float),
+                n_orig=n_orig,
+                A_ub=A_ub,
+                b_ub=b_ub,
+                A_eq=A_eq,
+                b_eq=b_eq,
+                time_limit=time_limit,
+                Q_orig=Q_orig,
+            )
+
         sr = SolveResult(
             status="optimal",
             objective=obj_val,
@@ -4040,6 +4375,9 @@ def _solve_qp_highs(
             rust_time=0.0,
             jax_time=0.0,
             python_time=wall_time,
+            constraint_duals=cd,
+            bound_duals_lower=bdl,
+            bound_duals_upper=bdu,
         )
         # A detected QP with PSD Q is a convex problem solved directly without
         # B&B -- semantically the same as the convex NLP fast path.
@@ -4122,6 +4460,17 @@ def _solve_milp_highs(
         obj_val = result.objective + lp_data.obj_const
         if sense == ObjectiveSense.MAXIMIZE:
             obj_val = -obj_val
+        cd, bdl, bdu = _mip_recover_relaxation_duals(
+            model,
+            lp_data=lp_data,
+            x_flat=np.asarray(x_flat, dtype=float),
+            n_orig=n_orig,
+            A_ub=A_ub,
+            b_ub=b_ub,
+            A_eq=A_eq,
+            b_eq=b_eq,
+            time_limit=time_limit,
+        )
         return SolveResult(
             status="optimal",
             objective=obj_val,
@@ -4133,6 +4482,9 @@ def _solve_milp_highs(
             rust_time=0.0,
             jax_time=0.0,
             python_time=wall_time,
+            constraint_duals=cd,
+            bound_duals_lower=bdl,
+            bound_duals_upper=bdu,
         )
     elif result.status == SolveStatus.INFEASIBLE:
         return SolveResult(status="infeasible", wall_time=wall_time, node_count=result.node_count)
@@ -4357,9 +4709,37 @@ def _solve_milp_bb(
         if obj_val >= _SENTINEL_THRESHOLD:
             incumbent = None
 
+    constraint_duals = None
+    bound_duals_lower = None
+    bound_duals_upper = None
+
     if incumbent is not None:
         sol_flat = np.array(sol_array)
         x_dict = _unpack_solution(model, sol_flat)
+
+        # Recover relaxation duals at the integer-feasible incumbent by
+        # re-solving the LP relaxation with integer variables fixed.
+        try:
+            n_total = lp_data.A_eq.shape[1] if lp_data.A_eq.shape[0] > 0 else n_orig
+            n_slack = n_total - n_orig
+            A_eq_full = np.asarray(lp_data.A_eq)
+            b_eq_full = np.asarray(lp_data.b_eq)
+            A_ub, b_ub_, A_eq, b_eq = _decompose_eq_slack_form(
+                A_eq_full, b_eq_full, n_orig, n_slack
+            )
+            constraint_duals, bound_duals_lower, bound_duals_upper = _mip_recover_relaxation_duals(
+                model,
+                lp_data=lp_data,
+                x_flat=np.asarray(sol_flat[:n_orig], dtype=float),
+                n_orig=n_orig,
+                A_ub=A_ub,
+                b_ub=b_ub_,
+                A_eq=A_eq,
+                b_eq=b_eq,
+                time_limit=max(0.1, time_limit - (time.perf_counter() - t_start)),
+            )
+        except Exception as _exc:
+            logger.debug("MILP-BB dual recovery failed: %s", _exc)
 
         # Negate objective back for maximization (B&B tree tracks minimization)
         from discopt.modeling.core import ObjectiveSense
@@ -4401,6 +4781,9 @@ def _solve_milp_bb(
         rust_time=rust_time,
         jax_time=jax_time,
         python_time=python_time,
+        constraint_duals=constraint_duals,
+        bound_duals_lower=bound_duals_lower,
+        bound_duals_upper=bound_duals_upper,
     )
 
 
@@ -4579,9 +4962,39 @@ def _solve_miqp_bb(
         if obj_val >= _SENTINEL_THRESHOLD:
             incumbent = None
 
+    constraint_duals = None
+    bound_duals_lower = None
+    bound_duals_upper = None
+
     if incumbent is not None:
         sol_flat = np.array(sol_array)
         x_dict = _unpack_solution(model, sol_flat)
+
+        # Recover relaxation duals at the integer-feasible incumbent by
+        # re-solving the QP relaxation with integer variables fixed.
+        try:
+            n_total = qp_data.A_eq.shape[1] if qp_data.A_eq.shape[0] > 0 else n_orig
+            n_slack_local = n_total - n_orig
+            A_eq_full = np.asarray(qp_data.A_eq)
+            b_eq_full = np.asarray(qp_data.b_eq)
+            A_ub_, b_ub_, A_eq_, b_eq_ = _decompose_eq_slack_form(
+                A_eq_full, b_eq_full, n_orig, n_slack_local
+            )
+            Q_orig = np.asarray(qp_data.Q[:n_orig, :n_orig])
+            constraint_duals, bound_duals_lower, bound_duals_upper = _mip_recover_relaxation_duals(
+                model,
+                lp_data=qp_data,
+                x_flat=np.asarray(sol_flat[:n_orig], dtype=float),
+                n_orig=n_orig,
+                A_ub=A_ub_,
+                b_ub=b_ub_,
+                A_eq=A_eq_,
+                b_eq=b_eq_,
+                time_limit=max(0.1, time_limit - (time.perf_counter() - t_start)),
+                Q_orig=Q_orig,
+            )
+        except Exception as _exc:
+            logger.debug("MIQP-BB dual recovery failed: %s", _exc)
 
         # Negate objective back for maximization (B&B tree tracks minimization)
         from discopt.modeling.core import ObjectiveSense
@@ -4623,4 +5036,7 @@ def _solve_miqp_bb(
         rust_time=rust_time,
         jax_time=jax_time,
         python_time=python_time,
+        constraint_duals=constraint_duals,
+        bound_duals_lower=bound_duals_lower,
+        bound_duals_upper=bound_duals_upper,
     )

--- a/python/discopt/solvers/__init__.py
+++ b/python/discopt/solvers/__init__.py
@@ -57,6 +57,7 @@ class QPResult:
     x: Optional[np.ndarray] = None
     objective: Optional[float] = None
     dual_values: Optional[np.ndarray] = None
+    reduced_costs: Optional[np.ndarray] = None
     node_count: int = 0
     iterations: int = 0
     wall_time: float = 0.0

--- a/python/discopt/solvers/qp_highs.py
+++ b/python/discopt/solvers/qp_highs.py
@@ -214,10 +214,21 @@ def solve_qp(
             _, node_count_f = h.getInfoValue("mip_node_count")
             node_count = int(node_count_f)
 
+        # HiGHS does not produce duals for MIP problems, only for continuous QP.
+        dual_values: Optional[np.ndarray] = None
+        reduced_costs: Optional[np.ndarray] = None
+        if integrality is None:
+            row_dual_raw = np.array(getattr(sol, "row_dual", []), dtype=np.float64)
+            col_dual_raw = np.array(getattr(sol, "col_dual", []), dtype=np.float64)
+            dual_values = row_dual_raw if row_dual_raw.size else None
+            reduced_costs = col_dual_raw if col_dual_raw.size else None
+
         return QPResult(
             status=status,
             x=x,
             objective=obj,
+            dual_values=dual_values,
+            reduced_costs=reduced_costs,
             node_count=node_count,
             wall_time=float(wall_time),
         )

--- a/python/tests/test_amp.py
+++ b/python/tests/test_amp.py
@@ -26,6 +26,8 @@ Sections:
 
 from __future__ import annotations
 
+import logging
+import math
 import os
 
 os.environ["JAX_PLATFORMS"] = "cpu"
@@ -973,6 +975,121 @@ class TestMilpRelaxation:
         assert result.status == "optimal"
         assert result.objective is None
         assert result.x is not None
+
+    def test_affine_trig_constraints_are_retained_in_relaxation(self, caplog):
+        """Affine-argument sin/cos constraints should be lifted instead of omitted."""
+        from discopt._jax.discretization import DiscretizationState
+
+        m = Model("nlp_cvx_106_trig_relax")
+        x = m.continuous("x", lb=-3.0, ub=3.0)
+        y = m.continuous("y", lb=-1.0, ub=1.0)
+        m.minimize(-x - y)
+        m.subject_to(dm.sin(-x - 1.0) + x / 2 + 0.5 <= y)
+        m.subject_to(dm.cos(x - 0.5) + x / 4 - 0.5 >= y)
+
+        terms = self.classify(m)
+        with caplog.at_level(logging.WARNING, logger="discopt._jax.milp_relaxation"):
+            milp_model, varmap = self.build_milp(
+                m,
+                terms,
+                DiscretizationState(partitions={}),
+                incumbent=None,
+            )
+
+        result = milp_model.solve()
+
+        assert len(varmap["trig"]) == 2
+        assert "omitting constraint" not in caplog.text
+        assert result.status == "optimal"
+        assert result.objective is not None
+
+    def test_trig_square_constraints_apply_range_bounds(self):
+        """sin(x)^2 and cos(y)^2 constraints should constrain the MILP relaxation."""
+        from discopt._jax.discretization import DiscretizationState
+
+        sin_model = Model("sin_square_relax")
+        x = sin_model.integer("x", lb=0, ub=4)
+        y = sin_model.integer("y", lb=0, ub=4)
+        sin_model.maximize(y)
+        sin_model.subject_to(y <= dm.sin(x) ** 2 + 2)
+
+        terms = self.classify(sin_model)
+        sin_relax, sin_varmap = self.build_milp(
+            sin_model,
+            terms,
+            DiscretizationState(partitions={}),
+            incumbent=None,
+        )
+        sin_result = sin_relax.solve()
+
+        assert len(sin_varmap["trig_square"]) == 1
+        assert sin_result.status == "optimal"
+        assert sin_result.x is not None
+        assert sin_result.x[1] <= 3.0 + 1e-8
+
+        cos_model = Model("cos_square_relax")
+        z = cos_model.integer("z", lb=1, ub=4)
+        b = cos_model.binary("b")
+        cos_model.maximize(z)
+        cos_model.subject_to(z <= dm.cos(b) ** 2 + 1.5)
+
+        terms = self.classify(cos_model)
+        cos_relax, cos_varmap = self.build_milp(
+            cos_model,
+            terms,
+            DiscretizationState(partitions={}),
+            incumbent=None,
+        )
+        cos_result = cos_relax.solve()
+
+        assert len(cos_varmap["trig_square"]) == 1
+        assert cos_result.status == "optimal"
+        assert cos_result.x is not None
+        assert cos_result.x[0] <= 2.0 + 1e-8
+
+    def test_safe_tan_objective_keeps_relaxation_bound(self):
+        """tan(x) should be lifted when the argument interval avoids asymptotes."""
+        from discopt._jax.discretization import DiscretizationState
+
+        m = Model("safe_tan_objective")
+        x = m.continuous("x", lb=-1.0, ub=1.0)
+        m.minimize(dm.tan(x))
+
+        terms = self.classify(m)
+        milp_model, varmap = self.build_milp(
+            m,
+            terms,
+            DiscretizationState(partitions={}),
+            incumbent=None,
+        )
+        result = milp_model.solve()
+
+        assert len(varmap["trig"]) == 1
+        assert result.status == "optimal"
+        assert result.objective == pytest.approx(math.tan(-1.0), abs=1e-8)
+
+    def test_unsafe_tan_objective_still_falls_back(self, caplog):
+        """tan(x) intervals crossing an asymptote should remain unsupported."""
+        from discopt._jax.discretization import DiscretizationState
+
+        m = Model("unsafe_tan_objective")
+        x = m.continuous("x", lb=1.0, ub=2.0)
+        m.minimize(dm.tan(x))
+
+        terms = self.classify(m)
+        with caplog.at_level(logging.WARNING, logger="discopt._jax.milp_relaxation"):
+            milp_model, varmap = self.build_milp(
+                m,
+                terms,
+                DiscretizationState(partitions={}),
+                incumbent=None,
+            )
+        result = milp_model.solve()
+
+        assert varmap["trig"] == {}
+        assert result.status == "optimal"
+        assert result.objective is None
+        assert "could not linearize the objective" in caplog.text
 
     def test_piecewise_interval_rows_force_inactive_wbar_to_zero_with_negative_bounds(self):
         """Disaggregated intervals must include the lower δ-forcing row even when wk_lo < 0."""

--- a/python/tests/test_deadline.py
+++ b/python/tests/test_deadline.py
@@ -1,0 +1,151 @@
+"""Tests for the JAX-side wall-clock deadline plumbing (issue #80).
+
+These verify that ``deadline_scope`` actually interrupts a JAX-compiled
+``while_loop`` mid-execution, that an unset deadline leaves convergence
+behavior unchanged, and that the host-callback predicate behaves on the
+process-global state.
+"""
+
+from __future__ import annotations
+
+import time
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+import pytest
+from discopt._jax.deadline import (
+    clear_deadline,
+    deadline_exceeded,
+    deadline_exceeded_jax,
+    deadline_scope,
+    set_deadline,
+)
+
+
+@pytest.fixture(autouse=True)
+def _reset_deadline():
+    """Ensure no leaked deadline from a previous test."""
+    clear_deadline()
+    yield
+    clear_deadline()
+
+
+def test_deadline_unset_returns_false():
+    assert deadline_exceeded() is False
+
+
+def test_deadline_scope_set_and_clear():
+    with deadline_scope(60.0):
+        assert deadline_exceeded() is False  # 60s in the future
+    assert deadline_exceeded() is False  # cleared on exit
+
+
+def test_deadline_scope_trips_after_sleep():
+    with deadline_scope(0.05):
+        assert deadline_exceeded() is False
+        time.sleep(0.1)
+        assert deadline_exceeded() is True
+
+
+def test_set_deadline_none_clears():
+    set_deadline(60.0)
+    set_deadline(None)
+    assert deadline_exceeded() is False
+
+
+def test_deadline_exceeded_jax_in_while_loop_terminates_loop():
+    """A jax.lax.while_loop guarded by deadline_exceeded_jax() must exit
+    promptly once the deadline trips, instead of running to its bound."""
+
+    @jax.jit
+    def run(n_max):
+        def cond(c):
+            return jnp.logical_and(c < n_max, jnp.logical_not(deadline_exceeded_jax()))
+
+        def body(c):
+            return c + 1
+
+        return jax.lax.while_loop(cond, body, jnp.int32(0))
+
+    # Warm-compile under a wide deadline.
+    with deadline_scope(60.0):
+        _ = int(run(jnp.int32(1_000)))
+
+    # Now trip the deadline mid-loop.
+    with deadline_scope(0.1):
+        t0 = time.perf_counter()
+        iters = int(run(jnp.int32(10_000_000)))
+        elapsed = time.perf_counter() - t0
+
+    assert iters < 10_000_000, "while_loop ran to its bound; deadline was not honored"
+    assert elapsed < 2.0, f"deadline trip took {elapsed:.2f}s — should be ≲ 1s"
+
+
+def test_lp_ipm_honors_deadline():
+    """LP IPM (lp_ipm.py main solve) must self-terminate on deadline."""
+    from discopt._jax.lp_ipm import LPIPMOptions, lp_ipm_solve
+
+    # Small, well-conditioned LP so without a deadline the solver converges
+    # quickly; we then re-run with a tight deadline and verify the wall is
+    # bounded.
+    rng = np.random.default_rng(0)
+    n, m = 20, 5
+    A = rng.standard_normal((m, n))
+    x_star = np.abs(rng.standard_normal(n))
+    b = A @ x_star
+    c = rng.standard_normal(n)
+    x_l = jnp.zeros(n)
+    x_u = jnp.full(n, 1e6)
+
+    # Warm-compile.
+    state_ok = lp_ipm_solve(
+        jnp.asarray(c),
+        jnp.asarray(A),
+        jnp.asarray(b),
+        x_l,
+        x_u,
+        options=LPIPMOptions(max_iter=200),
+    )
+    assert int(state_ok.converged) in (1, 2, 3)
+
+    # Trip the deadline before calling.
+    set_deadline(-1.0)  # already past
+    t0 = time.perf_counter()
+    _ = lp_ipm_solve(
+        jnp.asarray(c),
+        jnp.asarray(A),
+        jnp.asarray(b),
+        x_l,
+        x_u,
+        options=LPIPMOptions(max_iter=10_000),  # would otherwise iterate long
+    )
+    elapsed = time.perf_counter() - t0
+    clear_deadline()
+
+    # The loop should exit immediately. converged stays at 0 (running) when
+    # the deadline trips before the first iteration completes — that's the
+    # expected signal to callers that the solve was preempted.
+    assert elapsed < 1.0, f"deadline-tripped LP IPM took {elapsed:.2f}s"
+
+
+def test_lp_ipm_unchanged_when_no_deadline():
+    """A normal solve (no deadline) must still converge to optimal."""
+    from discopt._jax.lp_ipm import LPIPMOptions, lp_ipm_solve
+
+    rng = np.random.default_rng(1)
+    n, m = 15, 4
+    A = rng.standard_normal((m, n))
+    x_star = np.abs(rng.standard_normal(n))
+    b = A @ x_star
+    c = rng.standard_normal(n)
+
+    state = lp_ipm_solve(
+        jnp.asarray(c),
+        jnp.asarray(A),
+        jnp.asarray(b),
+        jnp.zeros(n),
+        jnp.full(n, 1e6),
+        options=LPIPMOptions(max_iter=200),
+    )
+    assert int(state.converged) in (1, 2)

--- a/python/tests/test_deadline.py
+++ b/python/tests/test_deadline.py
@@ -98,14 +98,16 @@ def test_lp_ipm_honors_deadline():
     x_l = jnp.zeros(n)
     x_u = jnp.full(n, 1e6)
 
-    # Warm-compile.
+    # Warm-compile with the SAME options used in the timed call below.
+    # max_iter is a static_argnum for _lp_ipm_solve_jit, so a different value
+    # triggers a recompile that can dominate the wall-clock measurement on CI.
     state_ok = lp_ipm_solve(
         jnp.asarray(c),
         jnp.asarray(A),
         jnp.asarray(b),
         x_l,
         x_u,
-        options=LPIPMOptions(max_iter=200),
+        options=LPIPMOptions(max_iter=10_000),
     )
     assert int(state_ok.converged) in (1, 2, 3)
 

--- a/python/tests/test_solver_duals.py
+++ b/python/tests/test_solver_duals.py
@@ -1,0 +1,181 @@
+"""End-to-end tests for solver-supplied duals on the LP / QP / B&B paths.
+
+Each test runs a real solve and asserts that ``constraint_duals`` /
+``bound_duals_lower`` / ``bound_duals_upper`` are populated with the
+expected sign and magnitude, then optionally re-runs through the
+Examiner to confirm the duals satisfy KKT.
+"""
+
+from __future__ import annotations
+
+import discopt.modeling as dm
+import numpy as np
+import pytest
+
+
+def _scalar(name: str, vec: dict[str, np.ndarray]) -> float:
+    return float(np.asarray(vec[name]).ravel()[0])
+
+
+# ── LP fast path ────────────────────────────────────────────────────────
+
+
+def test_lp_path_returns_constraint_and_bound_duals():
+    """min x + 2y s.t. x + y >= 4, 0<=x,y<=10 → x*=4, y*=0."""
+    m = dm.Model("lp")
+    x = m.continuous("x", lb=0.0, ub=10.0)
+    y = m.continuous("y", lb=0.0, ub=10.0)
+    m.minimize(x + 2 * y)
+    m.subject_to(x + y >= 4, name="c1")
+
+    res = m.solve()
+
+    assert res.status == "optimal"
+    assert res.constraint_duals is not None
+    assert res.bound_duals_lower is not None
+    assert res.bound_duals_upper is not None
+
+    assert _scalar("x", res.x) == pytest.approx(4.0, abs=1e-6)
+    assert _scalar("y", res.x) == pytest.approx(0.0, abs=1e-6)
+
+    # ">=" row binding from below → μ ≥ 0 in the discopt convention.
+    mu = _scalar("c1", res.constraint_duals)
+    assert mu == pytest.approx(1.0, abs=1e-6)
+
+    # Bound on y at lb=0 is active; reduced cost is 2 - mu = 1 (>= 0).
+    lam_lb_y = _scalar("y", res.bound_duals_lower)
+    assert lam_lb_y == pytest.approx(1.0, abs=1e-6)
+
+    # Bound on x is inactive; multiplier ≈ 0.
+    assert _scalar("x", res.bound_duals_lower) == pytest.approx(0.0, abs=1e-6)
+    assert _scalar("x", res.bound_duals_upper) == pytest.approx(0.0, abs=1e-6)
+
+
+def test_lp_equality_constraint_dual_sign():
+    """Equality row dual is free; verify magnitude matches reduced LP."""
+    m = dm.Model("lp_eq")
+    x = m.continuous("x", lb=0.0, ub=10.0)
+    y = m.continuous("y", lb=0.0, ub=10.0)
+    m.minimize(x + 3 * y)
+    m.subject_to(x + y == 4, name="ceq")
+
+    res = m.solve()
+    assert res.status == "optimal"
+    assert res.constraint_duals is not None
+    # x*=4, y*=0; ∇f = [1, 3]; KKT (Examiner convention ∇f + ∇body·μ = 0)
+    # gives 1 + 1·μ = 0 → μ = -1 (equality multipliers are free in sign).
+    mu = _scalar("ceq", res.constraint_duals)
+    assert mu == pytest.approx(-1.0, abs=1e-6)
+
+
+# ── QP fast path ────────────────────────────────────────────────────────
+
+
+def test_qp_path_returns_duals_at_active_constraint():
+    """min (x-0.5)^2 + (y-0.5)^2 s.t. x+y >= 5, 0<=x,y<=10."""
+    m = dm.Model("qp_active")
+    x = m.continuous("x", lb=0.0, ub=10.0)
+    y = m.continuous("y", lb=0.0, ub=10.0)
+    m.minimize((x - 0.5) ** 2 + (y - 0.5) ** 2)
+    m.subject_to(x + y >= 5, name="c1")
+
+    res = m.solve()
+    assert res.status == "optimal"
+    assert res.constraint_duals is not None
+    assert res.bound_duals_lower is not None
+
+    # Symmetric → x* = y* = 2.5; ∇f = [2(x-0.5), 2(y-0.5)] = [4, 4].
+    # ">=" with μ ≥ 0 gives 4 - μ = 0 → μ = 4.
+    mu = _scalar("c1", res.constraint_duals)
+    assert mu == pytest.approx(4.0, abs=1e-4)
+
+
+# ── MILP B&B path ───────────────────────────────────────────────────────
+
+
+def test_milp_returns_relaxation_duals_at_incumbent():
+    """min x + 2y, integer, s.t. x+y >= 5. Optimum x=5,y=0 with all-integer
+    fix-and-resolve degenerating to zero free continuous columns; the
+    recovery should still attach a dict (possibly all zeros) without
+    raising."""
+    m = dm.Model("milp")
+    x = m.integer("x", lb=0, ub=10)
+    y = m.integer("y", lb=0, ub=10)
+    m.minimize(x + 2 * y)
+    m.subject_to(x + y >= 5, name="c1")
+
+    res = m.solve()
+    assert res.status == "optimal"
+    assert _scalar("x", res.x) == pytest.approx(5.0, abs=1e-6)
+    assert _scalar("y", res.x) == pytest.approx(0.0, abs=1e-6)
+    # Recovery returns dicts (even if all zero — fully integer fix gives
+    # no free columns; what matters is the plumbing wires through).
+    assert res.constraint_duals is not None
+    assert "c1" in res.constraint_duals
+    assert res.bound_duals_lower is not None
+    assert "x" in res.bound_duals_lower
+    assert "y" in res.bound_duals_lower
+
+
+def test_miqp_returns_relaxation_duals_at_incumbent():
+    """min (x-0.5)^2 + (y-0.5)^2 s.t. x+y >= 5, x cont, y int.
+
+    With y fixed at incumbent (=3), the LP relaxation is min (x-0.5)^2
+    s.t. x >= 2, x in [0,10] → x*=2, μ=3 on the ">=" row.
+    """
+    m = dm.Model("miqp")
+    x = m.continuous("x", lb=0.0, ub=10.0)
+    y = m.integer("y", lb=0, ub=10)
+    m.minimize((x - 0.5) ** 2 + (y - 0.5) ** 2)
+    m.subject_to(x + y >= 5, name="c1")
+
+    res = m.solve()
+    assert res.status == "optimal"
+    assert res.constraint_duals is not None
+    mu = _scalar("c1", res.constraint_duals)
+    assert mu == pytest.approx(3.0, abs=1e-3)
+
+
+# ── validate=True hook ──────────────────────────────────────────────────
+
+
+def test_solve_with_validate_attaches_examiner_report():
+    m = dm.Model("lp_validate")
+    x = m.continuous("x", lb=0.0, ub=10.0)
+    y = m.continuous("y", lb=0.0, ub=10.0)
+    m.minimize(x + 2 * y)
+    m.subject_to(x + y >= 4, name="c1")
+
+    res = m.solve(validate=True)
+    assert res.validation_report is not None
+    rep = res.validation_report
+    assert rep.passed, rep.summary(verbose=True)
+    # The solver-duals branch should have run, since the LP fast path
+    # populated constraint_duals.
+    assert rep.solver_duals_used
+
+
+def test_solve_without_validate_leaves_report_none():
+    m = dm.Model("lp_no_validate")
+    x = m.continuous("x", lb=0.0, ub=10.0)
+    m.minimize(x)
+    m.subject_to(x >= 1, name="c1")
+    res = m.solve()
+    assert res.validation_report is None
+
+
+def test_validate_true_on_milp_attaches_report():
+    m = dm.Model("milp_validate")
+    x = m.integer("x", lb=0, ub=10)
+    y = m.integer("y", lb=0, ub=10)
+    m.minimize(x + 2 * y)
+    m.subject_to(x + y >= 5, name="c1")
+
+    res = m.solve(validate=True)
+    assert res.validation_report is not None
+    # We don't assert .passed — pure-integer fix-and-resolve degenerates;
+    # the contract is that the report exists and primal checks pass.
+    rep = res.validation_report
+    primal = [c for c in rep.checks if c.name.startswith("primal_")]
+    assert primal, "expected at least one primal check"
+    assert all(c.passed for c in primal), rep.summary(verbose=True)


### PR DESCRIPTION
Summary:
- Adds safe affine-argument trig lifting in the AMP MILP relaxation for `sin`, `cos`, and branch-safe `tan`.
- Computes exact range bounds for lifted trig auxiliaries, adds tangent/secant rows only on certified convex/concave intervals, and leaves mixed-curvature intervals range-only.
- Supports composed `sin(x) ** 2` and `cos(y) ** 2` constraints through a trig auxiliary plus square relaxation.
- Adds focused regression coverage for the `nlp_cvx_106`-style trig constraints, trig-square incidence constraints, and safe/unsafe `tan` objective handling.

Dependency status:
- This PR is a scoped trig-lifting patch. It does not by itself make every motivating MINLPTests instance solve or certify within 300 seconds.
- Depends on #70 for partition-aware mixed-curvature `sin`/`cos` relaxations needed by the `nlp_cvx_106_*` family.
- Depends on #71 for generic `exp`/`log`/`sqrt` unary relaxations needed by the `nlp_002_*`, `nlp_003_*`, `nlp_mi_002_*`, and `nlp_mi_003_*` families.
- Depends on #72 for exact finite-domain integer trig-square formulations needed by `nlp_mi_002_010` and `nlp_mi_003_*`, especially `nlp_mi_003_014` and `nlp_mi_003_015`.
- Depends on #73 for `abs` objective lifting needed by `nlp_004_010` and `nlp_004_011`.
- Related existing issue: #61 tracks `x * exp(x)` objective/product relaxations and separable lower bounds.

Targeted 300s follow-up evidence:
- `nlp_cvx_106_010` now returns the expected incumbent quickly, but the bound is still weak (`gap=1.15`, `bound=-4.0`).
- `nlp_cvx_106_011` still returns `iteration_limit` with no incumbent.
- `nlp_003_010` and several easier `nlp_003_*` variants recover the expected incumbent quickly, but objective bounds are still missing or weak because `exp`/`sqrt` are not yet relaxed.
- `nlp_003_014` found the expected objective but still hit the 300s limit with a nonclosed gap.
- `nlp_mi_003_014` and `nlp_mi_003_015` still fail quickly with a weak relaxation bound near `19` versus expected objective `11`.

Tests run:
- `uv venv --python 3.12 --clear .venv` -> passed.
- `uv pip install --python .venv/bin/python maturin jax jaxlib numpy scipy highspy pytest pytest-timeout pytest-xdist ruff==0.14.6 mypy` -> passed.
- `env -u CONDA_PREFIX VIRTUAL_ENV=/tmp/discopt-issue60/.venv PATH=/tmp/discopt-issue60/.venv/bin:/home/bernalde/.local/bin:/home/bernalde/.cargo/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin ./.venv/bin/maturin develop --uv` -> passed.
- `/home/bernalde/.pixi/bin/pixi exec -s highspy env -u CONDA_PREFIX VIRTUAL_ENV=/tmp/discopt-issue60/.venv PATH=/tmp/discopt-issue60/.venv/bin:/home/bernalde/.local/bin:/home/bernalde/.cargo/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin ./.venv/bin/python -m pytest python/tests/test_amp.py::TestMilpRelaxation::test_affine_trig_constraints_are_retained_in_relaxation python/tests/test_amp.py::TestMilpRelaxation::test_trig_square_constraints_apply_range_bounds python/tests/test_amp.py::TestMilpRelaxation::test_safe_tan_objective_keeps_relaxation_bound python/tests/test_amp.py::TestMilpRelaxation::test_unsafe_tan_objective_still_falls_back -q` -> 4 passed.
- `/home/bernalde/.pixi/bin/pixi exec -s highspy env -u CONDA_PREFIX VIRTUAL_ENV=/tmp/discopt-issue60/.venv PATH=/tmp/discopt-issue60/.venv/bin:/home/bernalde/.local/bin:/home/bernalde/.cargo/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin ./.venv/bin/python -m pytest python/tests/test_amp.py::TestMilpRelaxation -q` -> 16 passed.
- `env -u CONDA_PREFIX VIRTUAL_ENV=/tmp/discopt-issue60/.venv PATH=/tmp/discopt-issue60/.venv/bin:/home/bernalde/.local/bin:/home/bernalde/.cargo/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin ./.venv/bin/ruff check python/` -> passed.
- `env -u CONDA_PREFIX VIRTUAL_ENV=/tmp/discopt-issue60/.venv PATH=/tmp/discopt-issue60/.venv/bin:/home/bernalde/.local/bin:/home/bernalde/.cargo/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin ./.venv/bin/ruff format --check python/` -> 277 files already formatted.
- `env -u CONDA_PREFIX VIRTUAL_ENV=/tmp/discopt-issue60/.venv PATH=/tmp/discopt-issue60/.venv/bin:/home/bernalde/.local/bin:/home/bernalde/.cargo/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin ./.venv/bin/mypy python/discopt/` -> success, no issues found in 168 source files.
- `cargo test -p discopt-core` -> 249 unit tests passed, 4 integration tests passed, 1 doc test passed.
- `/home/bernalde/.pixi/bin/pixi exec -s ipopt -s highspy env -u CONDA_PREFIX VIRTUAL_ENV=/tmp/discopt-issue60/.venv PATH=/tmp/discopt-issue60/.venv/bin:/home/bernalde/.local/bin:/home/bernalde/.cargo/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin ./.venv/bin/python -m pytest python/tests/test_amp.py::TestAmpEndToEnd::test_pure_quadratic_convex python/tests/test_amp.py::TestAmpEndToEnd::test_amp_solver_warns_on_ignored_options python/tests/test_amp.py::TestAmpConvergenceProperties::test_gap_certified_after_convergence python/tests/test_amp.py::TestAmpConvergenceProperties::test_early_termination_when_gap_closes -q --tb=short` -> 4 passed.

Notes about tests not run:
- A full `python/tests/test_amp.py -q --tb=short` run was attempted through pixi/highspy before `cyipopt` was installed. It produced 89 passed, 1 skipped, 2 xfailed, and 5 failed in 513.76s; four failures were missing `cyipopt`, and one unrelated solver-heavy test (`test_bilinear_minlp_global`) hit the existing 60s AMP time limit with a small residual gap. After installing `cyipopt` into the uv `.venv` using pixi-provided Ipopt, the four `cyipopt`-blocked tests passed; `test_bilinear_minlp_global` still returned `time_limit` when rerun alone.
- I did not run the full PR-fast pytest suite locally because the relevant broader AMP file already exceeded eight minutes and retained the unrelated time-limit-sensitive failure above.
- Representative 300s MINLPTests AMP runs were executed to evaluate whether this PR solved the motivating cases. Those runs showed partial improvement but also motivated #70, #71, #72, and #73.

Addresses #60
