### PR TITLE
Fix AMP unary relaxation bounds

### DIFF
--- a/python/discopt/solvers/milp_highs.py
+++ b/python/discopt/solvers/milp_highs.py
@@ -114,8 +114,10 @@ def solve_milp(
     if time_limit is not None:
         h.setOptionValue("time_limit", float(time_limit))
 
+    nonfatal_statuses = {highspy.HighsStatus.kOk, highspy.HighsStatus.kWarning}
+
     pass_status = h.passModel(lp)
-    if pass_status != highspy.HighsStatus.kOk:
+    if pass_status not in nonfatal_statuses:
         return MILPResult(status=SolveStatus.ERROR)
 
     run_status = h.run()
@@ -125,7 +127,7 @@ def solve_milp(
 
     wall_time = 0.0
     node_count = 0
-    if run_status == highspy.HighsStatus.kOk and status != SolveStatus.ERROR:
+    if run_status in nonfatal_statuses and status != SolveStatus.ERROR:
         run_time_status, run_time_value = h.getInfoValue("run_time")
         if run_time_status == highspy.HighsStatus.kOk and run_time_value is not None:
             wall_time = float(run_time_value)

--- a/python/tests/test_amp.py
+++ b/python/tests/test_amp.py
@@ -624,6 +624,60 @@ def test_supported_univariate_constraint_tightens_relaxation():
     assert varmap["univariate_relaxations"][0].func_name == "exp"
 
 
+def test_issue71_log_constraint_is_kept_in_relaxation(caplog):
+    """Safe affine log constraints should not be omitted from the AMP relaxation."""
+    m = Model("issue71_log_constraint")
+    x = m.continuous("x", lb=1.0, ub=4.0)
+    y = m.continuous("y", lb=0.0, ub=2.0)
+    m.subject_to(y <= dm.log(x) - 0.1)
+    m.maximize(y)
+
+    with caplog.at_level("WARNING", logger="discopt._jax.milp_relaxation"):
+        milp_model, varmap = _build_relaxation_for_test(m)
+        result = milp_model.solve()
+
+    assert result.status == "optimal"
+    assert milp_model._objective_bound_valid is True
+    assert result.objective is not None
+    assert {r.func_name for r in varmap["univariate_relaxations"]} == {"log"}
+    assert "Cannot linearize FunctionCall: log" not in caplog.text
+    assert "omitting constraint" not in caplog.text
+
+
+def test_issue71_maximize_sqrt_objective_uses_real_relaxation_bound(caplog):
+    """Safe affine sqrt maximization objectives should not use a feasibility objective."""
+    m = Model("issue71_sqrt_max")
+    x = m.continuous("x", lb=0.0, ub=4.0)
+    m.maximize(dm.sqrt(x + 0.1))
+
+    with caplog.at_level("WARNING", logger="discopt._jax.milp_relaxation"):
+        milp_model, varmap = _build_relaxation_for_test(m)
+        result = milp_model.solve()
+
+    assert result.status == "optimal"
+    assert milp_model._objective_bound_valid is True
+    assert result.objective is not None
+    assert result.objective == pytest.approx(-np.sqrt(4.1), abs=1e-8)
+    assert {r.func_name for r in varmap["univariate_relaxations"]} == {"sqrt"}
+    assert "falling back to a feasibility objective" not in caplog.text
+
+
+def test_issue71_milp_wrapper_accepts_nonfatal_highs_warnings():
+    """HiGHS passModel warnings from tiny AMP rows must not discard valid bounds."""
+    from discopt.solvers import SolveStatus
+    from discopt.solvers.milp_highs import solve_milp
+
+    result = solve_milp(
+        c=np.array([1.0], dtype=np.float64),
+        A_ub=np.array([[1e-15]], dtype=np.float64),
+        b_ub=np.array([1e-30], dtype=np.float64),
+        bounds=[(1e-30, 1.0)],
+    )
+
+    assert result.status == SolveStatus.OPTIMAL
+    assert result.objective is not None
+
+
 def test_x_exp_objective_uses_lifted_product_relaxation(caplog):
     """Finite-box x*exp(x) objectives should use exp lift plus McCormick product."""
     m = Model("x_exp_finite")

--- a/python/tests/test_amp_integration.py
+++ b/python/tests/test_amp_integration.py
@@ -2877,8 +2877,18 @@ class TestCurrentCodeWeaknesses:
         [
             "nlp_003_010",
             "nlp_003_011",
+            "nlp_003_012",
+            "nlp_003_013",
+            "nlp_003_014",
+            "nlp_003_015",
+            "nlp_003_016",
             "nlp_mi_003_010",
             "nlp_mi_003_011",
+            "nlp_mi_003_012",
+            "nlp_mi_003_013",
+            "nlp_mi_003_014",
+            "nlp_mi_003_015",
+            "nlp_mi_003_016",
         ],
     )
     def test_amp_reports_supported_univariate_bound_for_minlptests_cases(
@@ -2886,7 +2896,7 @@ class TestCurrentCodeWeaknesses:
         problem_id,
         caplog,
     ):
-        """Affine sqrt objectives with exp constraints should produce valid relaxation bounds."""
+        """MINLPTests exp/sqrt issue cases should produce valid relaxation bounds."""
         instances = (
             MINLPTESTS_MI_BY_ID if problem_id.startswith("nlp_mi_") else MINLPTESTS_NLP_BY_ID
         )


### PR DESCRIPTION
## Summary

- Accept nonfatal HiGHS `passModel` / `run` warnings so AMP keeps valid MILP bounds when HiGHS only warns about tiny coefficients or bounds.
- Add issue #71 regressions for safe affine `log` constraints, maximize `sqrt` objectives, and the broader translated MINLPTests `003` exp/sqrt family.

## Tests run

- `/home/bernalde/.pixi/bin/pixi exec -s python=3.12 -s ipopt -s pkg-config -s c-compiler -s cxx-compiler -s gfortran -- .venv/bin/python -m pytest python/tests/test_amp.py -v --tb=short -q --timeout=120 -k "issue71 or supported_univariate_constraint_tightens_relaxation or supported_univariate_objectives_return_valid_bounds"`
  - Result: `8 passed, 60 deselected`
- `/home/bernalde/.pixi/bin/pixi exec -s python=3.12 -s ipopt -s pkg-config -s c-compiler -s cxx-compiler -s gfortran -- .venv/bin/python -m pytest python/tests/test_amp_integration.py::TestCurrentCodeWeaknesses::test_amp_reports_supported_univariate_bound_for_minlptests_cases -v --tb=short -q --timeout=300`
  - Result: `14 passed in 278.26s`
- `/home/bernalde/.pixi/bin/pixi exec -s python=3.12 -s ipopt -s pkg-config -s c-compiler -s cxx-compiler -s gfortran -- make test-amp-fast PYTHON=.venv/bin/python PYTEST=".venv/bin/python -m pytest" MATURIN=".venv/bin/python -m maturin"`
  - Result: `68 passed in 18.65s`
- `/home/bernalde/.pixi/bin/pixi exec -s python=3.12 -s ipopt -s pkg-config -s c-compiler -s cxx-compiler -s gfortran -- make lint PYTHON=.venv/bin/python RUFF=".venv/bin/python -m ruff"`
  - Result: ruff check passed; ruff format check passed
- `/home/bernalde/.pixi/bin/pixi exec -s python=3.12 -s ipopt -s pkg-config -s c-compiler -s cxx-compiler -s gfortran -- make test PYTHON=.venv/bin/python PYTEST=".venv/bin/python -m pytest" MATURIN=".venv/bin/python -m maturin"`
  - Result: `2486 passed, 59 skipped, 719 deselected, 2 xfailed, 11 warnings in 467.06s`
- Commit hooks:
  - Result: ruff passed; ruff format passed; mypy passed; cargo fmt skipped with no Rust files

## Notes

- Full `make test-all` was not run.
- Full `make test-amp-integration` was not run; the issue-specific opt-in MINLPTests AMP regression above was run in the pixi-backed `.venv`.

Closes #71
