### PR TITLE
Fix AMP tan/abs objective lifting

### DIFF
--- a/python/discopt/_jax/milp_relaxation.py
+++ b/python/discopt/_jax/milp_relaxation.py
@@ -572,7 +572,7 @@ def _univariate_arg(expr: Expression) -> tuple[str, Expression] | None:
     """Return (operator_name, argument) for supported univariate nodes."""
     if isinstance(expr, FunctionCall) and len(expr.args) == 1:
         name = expr.func_name
-        if name in {"sqrt", "log", "log2", "log10", "exp", "abs"}:
+        if name in {"sqrt", "log", "log2", "log10", "exp", "abs", "tan"}:
             return name, expr.args[0]
     if isinstance(expr, UnaryOp) and expr.op == "abs":
         return "abs", expr.operand
@@ -595,6 +595,8 @@ def _univariate_value(func_name: str, x: float) -> float:
         return float(np.exp(x))
     if func_name == "abs":
         return float(abs(x))
+    if func_name == "tan":
+        return float(np.tan(x))
     if func_name == "reciprocal":
         return float(1.0 / x)
     raise ValueError(f"Unsupported univariate function: {func_name}")
@@ -612,9 +614,24 @@ def _univariate_grad(func_name: str, x: float) -> float:
         return float(1.0 / (x * np.log(10.0)))
     if func_name == "exp":
         return float(np.exp(x))
+    if func_name == "tan":
+        cos_x = float(np.cos(x))
+        return float(1.0 / (cos_x * cos_x))
     if func_name == "reciprocal":
         return float(-1.0 / (x * x))
     raise ValueError(f"No smooth derivative for univariate function: {func_name}")
+
+
+def _tan_domain_ok(arg_lb: float, arg_ub: float) -> bool:
+    """Return True when ``tan`` is finite and continuous on the interval."""
+    if not np.isfinite(arg_lb) or not np.isfinite(arg_ub) or arg_lb > arg_ub:
+        return False
+    half_pi = 0.5 * np.pi
+    k = np.ceil((arg_lb - half_pi) / np.pi)
+    asymptote = half_pi + k * np.pi
+    if arg_lb <= asymptote <= arg_ub:
+        return False
+    return all(_is_effectively_finite(np.tan(x)) for x in (arg_lb, arg_ub))
 
 
 def _univariate_domain_ok(func_name: str, arg_lb: float, arg_ub: float) -> bool:
@@ -631,6 +648,8 @@ def _univariate_domain_ok(func_name: str, arg_lb: float, arg_ub: float) -> bool:
         return bool(arg_ub <= _MAX_FINITE_EXP_ARG)
     if func_name == "abs":
         return True
+    if func_name == "tan":
+        return _tan_domain_ok(arg_lb, arg_ub)
     if func_name == "reciprocal":
         return bool(arg_lb > 0.0)
     return False
@@ -655,6 +674,8 @@ def _tangent_points(func_name: str, lb: float, ub: float) -> list[float]:
         if func_name == "sqrt" and pt <= 0.0:
             continue
         if func_name in {"log", "log2", "log10", "reciprocal"} and pt <= 0.0:
+            continue
+        if func_name == "tan" and not _is_effectively_finite(np.tan(pt)):
             continue
         if not np.isfinite(pt):
             continue
@@ -2333,6 +2354,24 @@ def build_milp_relaxation(
         f_ub = _univariate_value(relax.func_name, ub_u)
         secant_slope = (f_ub - f_lb) / (ub_u - lb_u)
         secant_intercept = f_lb - secant_slope * lb_u
+
+        if relax.func_name == "tan":
+            if f_lb >= 0.0:
+                # Convex branch: tangents are lower bounds; secant is an upper bound.
+                for pt in _tangent_points(relax.func_name, lb_u, ub_u):
+                    slope = _univariate_grad(relax.func_name, pt)
+                    intercept = _univariate_value(relax.func_name, pt) - slope * pt
+                    _add_lower_line(relax, slope, intercept)
+                _add_upper_line(relax, secant_slope, secant_intercept)
+            elif f_ub <= 0.0:
+                # Concave branch: secant is a lower bound; tangents are upper bounds.
+                _add_lower_line(relax, secant_slope, secant_intercept)
+                for pt in _tangent_points(relax.func_name, lb_u, ub_u):
+                    slope = _univariate_grad(relax.func_name, pt)
+                    intercept = _univariate_value(relax.func_name, pt) - slope * pt
+                    _add_upper_line(relax, slope, intercept)
+            # Mixed-curvature intervals keep only the finite range bounds.
+            continue
 
         if relax.func_name in {"exp", "reciprocal"}:
             # Convex: tangents are lower bounds; secant is an upper bound.

--- a/python/tests/test_amp.py
+++ b/python/tests/test_amp.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 import os
 import subprocess
 import warnings
@@ -676,6 +677,28 @@ def test_issue71_milp_wrapper_accepts_nonfatal_highs_warnings():
 
     assert result.status == SolveStatus.OPTIMAL
     assert result.objective is not None
+
+
+def test_tan_abs_minlptests_objective_linearizes_without_fallback(caplog):
+    """The nlp_004-style tan/abs objective should keep a valid MILP objective."""
+    m = Model("tan_abs_obj")
+    x = m.continuous("x", lb=-1.0, ub=1.0)
+    y = m.continuous("y", lb=-4.0, ub=4.0)
+    z = m.continuous("z", lb=-4.0, ub=4.0)
+    m.minimize(dm.tan(x) + y + x * z + 0.5 * dm.abs(y))
+    m.subject_to(x**2 + y**2 + z**2 <= 10.0)
+    m.subject_to(-1.2 * x - y <= z / 1.35)
+
+    with caplog.at_level(logging.WARNING):
+        milp_model, varmap = _build_relaxation_for_test(m)
+        result = milp_model.solve()
+
+    assert result.status == "optimal"
+    assert result.objective is not None
+    assert {"abs", "tan"} <= {relax.func_name for relax in varmap["univariate_relaxations"]}
+    assert not any(
+        "could not linearize the objective" in record.message for record in caplog.records
+    )
 
 
 def test_x_exp_objective_uses_lifted_product_relaxation(caplog):

--- a/python/tests/test_amp_integration.py
+++ b/python/tests/test_amp_integration.py
@@ -2872,6 +2872,30 @@ class TestCurrentCodeWeaknesses:
         assert result.objective is not None
         assert result.gap is None or result.gap >= 0.0
 
+    def test_amp_reports_bound_for_tan_abs_nlp_004_010(self, caplog):
+        """The nlp_004 tan/abs objective should not fall back to feasibility mode."""
+        instance = MINLPTESTS_NLP_BY_ID["nlp_004_010"]
+        m = instance.build_fn()
+
+        with caplog.at_level(logging.WARNING, logger="discopt._jax.milp_relaxation"):
+            result = m.solve(
+                solver="amp",
+                nlp_solver="ipm",
+                time_limit=30.0,
+                gap_tolerance=1e-3,
+            )
+
+        assert result.status in ("optimal", "feasible")
+        assert result.objective is not None
+        assert result.bound is not None
+        assert result.gap is None or result.gap >= 0.0
+        fallback_messages = [
+            record.message
+            for record in caplog.records
+            if "falling back to a feasibility objective" in record.message
+        ]
+        assert not any("abs" in message or "tan" in message for message in fallback_messages)
+
     @pytest.mark.parametrize(
         "problem_id",
         [


### PR DESCRIPTION
Summary
- Adds branch-safe affine `tan` lifting to AMP's MILP univariate relaxation path.
- Keeps mixed-curvature `tan` intervals conservative with finite range bounds, and adds tangent/secant rows on convex or concave branches.
- Adds regressions for the `nlp_004`-style `tan(x) + y + x*z + 0.5*abs(y)` objective and the translated `nlp_004_010` AMP solve path so AMP reports a real bound instead of feasibility-objective fallback.

Tests run
- `/home/bernalde/.pixi/bin/pixi exec -s python=3.12 -s ipopt -s pkg-config -s c-compiler -s cxx-compiler -s gfortran -- .venv/bin/python -m pytest python/tests/test_amp.py::test_supported_univariate_objectives_return_valid_bounds python/tests/test_amp.py::test_supported_univariate_constraint_tightens_relaxation python/tests/test_amp.py::test_tan_abs_minlptests_objective_linearizes_without_fallback python/tests/test_amp.py::test_x_exp_objective_uses_lifted_product_relaxation -v --tb=short -q` -> 7 passed.
- `/home/bernalde/.pixi/bin/pixi exec -s python=3.12 -s ipopt -s pkg-config -s c-compiler -s cxx-compiler -s gfortran -- .venv/bin/python -m pytest python/tests/test_amp_integration.py::TestCurrentCodeWeaknesses::test_amp_does_not_certify_invalid_negative_gap_on_nlp_004_010 python/tests/test_amp_integration.py::TestCurrentCodeWeaknesses::test_amp_reports_bound_for_tan_abs_nlp_004_010 -v --tb=short -q` -> 2 passed.
- `/home/bernalde/.pixi/bin/pixi exec -s python=3.12 -s ipopt -s pkg-config -s c-compiler -s cxx-compiler -s gfortran -- make test-amp-fast PYTHON=.venv/bin/python "PYTEST=.venv/bin/python -m pytest" "MATURIN=.venv/bin/python -m maturin" "RUFF=.venv/bin/python -m ruff"` -> 66 passed.
- `/home/bernalde/.pixi/bin/pixi exec -s python=3.12 -s ipopt -s pkg-config -s c-compiler -s cxx-compiler -s gfortran -- make lint PYTHON=.venv/bin/python "PYTEST=.venv/bin/python -m pytest" "MATURIN=.venv/bin/python -m maturin" "RUFF=.venv/bin/python -m ruff"` -> passed; ruff check passed and 278 files already formatted.
- `/home/bernalde/.pixi/bin/pixi exec -s python=3.12 -s ipopt -s pkg-config -s c-compiler -s cxx-compiler -s gfortran -- .venv/bin/python -m mypy python/discopt/` -> success, no issues found in 170 source files.
- `cargo test -p discopt-core` -> 250 unit tests passed, 4 integration tests passed, 1 doc test passed.
- `cargo clippy -p discopt-core -- -D warnings` -> passed.
- `/home/bernalde/.pixi/bin/pixi exec -s python=3.12 -s ipopt -s pkg-config -s c-compiler -s cxx-compiler -s gfortran -- make test PYTHON=.venv/bin/python "PYTEST=.venv/bin/python -m pytest" "MATURIN=.venv/bin/python -m maturin" "RUFF=.venv/bin/python -m ruff"` -> 2484 passed, 59 skipped, 710 deselected, 2 xfailed.

300s motivated-case verification
- `/home/bernalde/.pixi/bin/pixi exec -s python=3.12 -s ipopt -s pkg-config -s c-compiler -s cxx-compiler -s gfortran -- .venv/bin/python -c '<script>'` with `solver="amp"`, `nlp_solver="ipm"`, `time_limit=300.0`, `gap_tolerance=1e-6`, `max_iter=1000`:
  - `nlp_004_010`: `status=feasible`, `objective=-4.872159040788694`, expected `-4.87215904079771`, `diff=9.02e-12`, `bound=-5.319919586133065`, `gap=0.09190187380908828`, `gap_certified=False`, `time=165.06s`, incumbent check passed.
  - `nlp_mi_004_010`: `status=feasible`, `objective=-4.675441761541782`, expected `-4.675441713398929`, `diff=4.81e-08`, `bound=-6.138546554739092`, `gap=0.3129340216003106`, `gap_certified=False`, `time=188.14s`, incumbent check passed.
  - `nlp_mi_004_011`: `status=feasible`, `objective=-4.675441761541782`, expected `-4.675441713398929`, `diff=4.81e-08`, `bound=-6.138546554739092`, `gap=0.3129340216003106`, `gap_certified=False`, `time=143.01s`, incumbent check passed.

Notes about tests not run
- Did not run the full opt-in `make test-amp-integration` suite because it includes longer Alpine/incidence coverage; the issue-specific translated MINLPTests paths above were run directly in the fresh uv `.venv` under pixi-provided solver libraries.
- The current local translated continuous MINLPTests registry contains `nlp_004_010`; I did not find a local continuous `nlp_004_011` builder on this branch. The local tan/abs `004_011` case is `nlp_mi_004_011`, which was verified above.
- The 300s checks show these cases are solvable to the expected incumbent with AMP and now produce bounds, but they do not certify the 1e-6 optimality gap within 300s.

Closes #73
