### PR TITLE
Add AMP memory guardrails

### DIFF
--- a/.github/workflows/amp-integration.yml
+++ b/.github/workflows/amp-integration.yml
@@ -30,7 +30,8 @@ jobs:
       - name: Run opt-in AMP integration suite
         run: |
           source .venv/bin/activate
-          pytest python/tests/test_amp_integration.py -v --timeout=300 -m "slow or integration or amp_benchmark or requires_cyipopt"
+          scripts/run_memory_capped_pytest.sh pytest python/tests/test_amp_integration.py -v --timeout=300 -m "slow or integration or amp_benchmark or requires_cyipopt or memory_heavy"
         env:
           JAX_PLATFORMS: cpu
           JAX_ENABLE_X64: "1"
+          PYTEST_MEMORY_LIMIT_MB: "16384"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,20 +92,23 @@ jobs:
       - name: Run pytest (PR-fast, parallel)
         run: |
           source .venv/bin/activate
-          # -n auto: parallel across runner CPUs.
+          # Keep worker count bounded so JAX compilation and AMP relaxations do
+          # not multiply peak memory unexpectedly.
           # --dist loadgroup keeps tests sharing a class on the same worker
           #   so xdist-incompatible fixtures stay serialized.
           # Coverage is intentionally dropped from the PR path — see the
           # `python-coverage` job (nightly + label-triggered) for full coverage.
-          pytest python/tests/ \
+          scripts/run_memory_capped_pytest.sh pytest python/tests/ \
             -q --tb=short --timeout=120 \
-            -m "not slow and not correctness and not integration and not amp_benchmark and not requires_cyipopt" \
+            -m "not slow and not correctness and not integration and not amp_benchmark and not requires_cyipopt and not memory_heavy" \
             --ignore=python/tests/test_correctness.py \
-            -n auto --dist loadgroup \
+            -n "${PYTEST_XDIST_WORKERS}" --dist loadgroup \
             --durations=20
         env:
           JAX_PLATFORMS: cpu
           JAX_ENABLE_X64: "1"
+          PYTEST_MEMORY_LIMIT_MB: "16384"
+          PYTEST_XDIST_WORKERS: "2"
 
   python-coverage:
     name: Python coverage (3.12, ubuntu)
@@ -152,15 +155,17 @@ jobs:
       - name: Run pytest with coverage
         run: |
           source .venv/bin/activate
-          pytest python/tests/ \
+          scripts/run_memory_capped_pytest.sh pytest python/tests/ \
             -q --tb=short --timeout=120 \
-            -m "not slow and not correctness and not integration and not amp_benchmark and not requires_cyipopt" \
+            -m "not slow and not correctness and not integration and not amp_benchmark and not requires_cyipopt and not memory_heavy" \
             --ignore=python/tests/test_correctness.py \
-            -n auto --dist loadgroup \
+            -n "${PYTEST_XDIST_WORKERS}" --dist loadgroup \
             --cov=discopt --cov-report=term-missing --cov-report=xml:coverage.xml
         env:
           JAX_PLATFORMS: cpu
           JAX_ENABLE_X64: "1"
+          PYTEST_MEMORY_LIMIT_MB: "16384"
+          PYTEST_XDIST_WORKERS: "2"
       - name: Upload to Codecov
         if: always()
         uses: codecov/codecov-action@v5
@@ -188,10 +193,11 @@ jobs:
       - name: Test AMP fast battery with coverage
         run: |
           source .venv/bin/activate
-          pytest python/tests/test_amp.py -v --timeout=120 -m "not slow and not integration and not amp_benchmark and not requires_cyipopt" --cov=discopt --cov-report=term-missing --cov-report=xml:coverage-amp.xml
+          scripts/run_memory_capped_pytest.sh pytest python/tests/test_amp.py -v --timeout=120 -m "not slow and not integration and not amp_benchmark and not requires_cyipopt and not memory_heavy" --cov=discopt --cov-report=term-missing --cov-report=xml:coverage-amp.xml
         env:
           JAX_PLATFORMS: cpu
           JAX_ENABLE_X64: "1"
+          PYTEST_MEMORY_LIMIT_MB: "16384"
       - name: Upload AMP coverage to Codecov
         if: always()
         uses: codecov/codecov-action@v5

--- a/Makefile
+++ b/Makefile
@@ -312,7 +312,7 @@ test-all: build
 # may be near-empty until those markers are populated.
 test-quick: build
 	@echo "==> Running quick tests (unit + smoke)..."
-	$(PYTEST_CAPPED) python/tests/ -v --tb=short -q $(PYTEST_QUICK_FLAGS)
+	$(PYTEST) python/tests/ -v --tb=short -q $(PYTEST_QUICK_FLAGS)
 	@echo "==> Quick tests passed"
 
 # Only the slow-marked tests (backend cross-product, big instances, ML training).

--- a/Makefile
+++ b/Makefile
@@ -38,6 +38,11 @@ SHELL := /bin/bash
 PYTHON      ?= python
 MATURIN     ?= $(PYTHON) -m maturin
 PYTEST      ?= pytest
+PYTEST_MEMORY_CAP ?= scripts/run_memory_capped_pytest.sh
+PYTEST_MEMORY_LIMIT_MB ?= 16384
+PYTEST_CPU_LIMIT_SECONDS ?= 0
+PYTEST_XDIST_WORKERS ?= 2
+PYTEST_CAPPED = PYTEST_MEMORY_LIMIT_MB=$(PYTEST_MEMORY_LIMIT_MB) PYTEST_CPU_LIMIT_SECONDS=$(PYTEST_CPU_LIMIT_SECONDS) $(PYTEST_MEMORY_CAP) $(PYTEST)
 RUFF        ?= ruff
 JUPYTER     ?= jupyter
 PRE_COMMIT  ?= pre-commit
@@ -188,12 +193,12 @@ hooks:
 # These exclusions keep the PR gate focused on ordinary feature tests plus the
 # curated `pr_correctness` subset. Full correctness, integration, and benchmark
 # coverage stay available through the explicit targets below.
-PYTEST_FAST_FLAGS := --timeout=120 -m "not slow and not correctness and not integration and not amp_benchmark and not requires_cyipopt" \
+PYTEST_FAST_FLAGS := --timeout=120 -m "not slow and not correctness and not integration and not amp_benchmark and not requires_cyipopt and not memory_heavy" \
     --ignore=python/tests/test_correctness.py
 
-PYTEST_QUICK_FLAGS := --timeout=60 -m "(unit or smoke) and not slow and not integration and not amp_benchmark and not requires_cyipopt"
+PYTEST_QUICK_FLAGS := --timeout=60 -m "(unit or smoke) and not slow and not integration and not amp_benchmark and not requires_cyipopt and not memory_heavy"
 
-PYTEST_AMP_FAST_FLAGS := --timeout=120 -m "not slow and not integration and not amp_benchmark and not requires_cyipopt"
+PYTEST_AMP_FAST_FLAGS := --timeout=120 -m "not slow and not integration and not amp_benchmark and not requires_cyipopt and not memory_heavy"
 
 # File groups for slice targets. A test file may appear in more than one group.
 TEST_MODELING := \
@@ -292,7 +297,7 @@ TEST_LLM := \
 # PR-fast: matches python-fast CI job. This is what `make test` should mean.
 test: build
 	@echo "==> Running PR-fast pytest suite (matches CI python-fast)..."
-	$(PYTEST) python/tests/ -v --tb=short -q $(PYTEST_FAST_FLAGS)
+	$(PYTEST_CAPPED) python/tests/ -v --tb=short -q $(PYTEST_FAST_FLAGS)
 	@echo "==> PR-fast tests passed"
 
 test-fast: test
@@ -300,59 +305,59 @@ test-fast: test
 # Full suite: every test, no exclusions. Use before releases or when triaging.
 test-all: build
 	@echo "==> Running full pytest suite (slow + correctness + everything)..."
-	$(PYTEST) python/tests/ -v --tb=short -q
+	$(PYTEST_CAPPED) python/tests/ -v --tb=short -q
 	@echo "==> Full suite passed"
 
 # Dev inner loop: only unit and smoke markers. Wired by Phase 3 of issue #68;
 # may be near-empty until those markers are populated.
 test-quick: build
 	@echo "==> Running quick tests (unit + smoke)..."
-	$(PYTEST) python/tests/ -v --tb=short -q $(PYTEST_QUICK_FLAGS)
+	$(PYTEST_CAPPED) python/tests/ -v --tb=short -q $(PYTEST_QUICK_FLAGS)
 	@echo "==> Quick tests passed"
 
 # Only the slow-marked tests (backend cross-product, big instances, ML training).
 test-slow: build
 	@echo "==> Running slow-marked tests..."
-	$(PYTEST) python/tests/ -v --tb=short -q -m "slow"
+	$(PYTEST_CAPPED) python/tests/ -v --tb=short -q -m "slow"
 	@echo "==> Slow tests passed"
 
 # Full known-optima validation. Heavy; not in PR gate.
 test-correctness: build
 	@echo "==> Running correctness suite (known-optima validation)..."
-	$(PYTEST) python/tests/test_correctness.py -v --tb=short -q
+	$(PYTEST_CAPPED) python/tests/test_correctness.py -v --tb=short -q
 	@echo "==> Correctness suite passed"
 
 # Slice targets: PR-fast filter applied within a subject area.
 test-modeling: build
-	$(PYTEST) $(TEST_MODELING) -v --tb=short -q $(PYTEST_FAST_FLAGS)
+	$(PYTEST_CAPPED) $(TEST_MODELING) -v --tb=short -q $(PYTEST_FAST_FLAGS)
 
 test-solvers: build
-	$(PYTEST) $(TEST_SOLVERS) -v --tb=short -q $(PYTEST_FAST_FLAGS)
+	$(PYTEST_CAPPED) $(TEST_SOLVERS) -v --tb=short -q $(PYTEST_FAST_FLAGS)
 
 test-amp: build
-	$(PYTEST) $(TEST_AMP) -v --tb=short -q $(PYTEST_FAST_FLAGS)
+	$(PYTEST_CAPPED) $(TEST_AMP) -v --tb=short -q $(PYTEST_FAST_FLAGS)
 
 test-amp-fast: build
 	@echo "==> Running fast AMP regression tests..."
-	$(PYTEST) python/tests/test_amp.py -v --tb=short -q $(PYTEST_AMP_FAST_FLAGS)
+	$(PYTEST_CAPPED) python/tests/test_amp.py -v --tb=short -q $(PYTEST_AMP_FAST_FLAGS)
 	@echo "==> Fast AMP tests passed"
 
 test-amp-integration: build
 	@echo "==> Running opt-in AMP Alpine/incidence tests..."
-	$(PYTEST) python/tests/test_amp_integration.py -v --tb=short -q -m "slow or integration or amp_benchmark or requires_cyipopt"
+	$(PYTEST_CAPPED) python/tests/test_amp_integration.py -v --tb=short -q -m "slow or integration or amp_benchmark or requires_cyipopt or memory_heavy"
 	@echo "==> AMP integration tests passed"
 
 test-nn: build
-	$(PYTEST) $(TEST_NN) -v --tb=short -q $(PYTEST_FAST_FLAGS)
+	$(PYTEST_CAPPED) $(TEST_NN) -v --tb=short -q $(PYTEST_FAST_FLAGS)
 
 test-convexity: build
-	$(PYTEST) $(TEST_CONVEXITY) -v --tb=short -q $(PYTEST_FAST_FLAGS)
+	$(PYTEST_CAPPED) $(TEST_CONVEXITY) -v --tb=short -q $(PYTEST_FAST_FLAGS)
 
 test-jax: build
-	$(PYTEST) $(TEST_JAX) -v --tb=short -q $(PYTEST_FAST_FLAGS)
+	$(PYTEST_CAPPED) $(TEST_JAX) -v --tb=short -q $(PYTEST_FAST_FLAGS)
 
 test-llm: build
-	$(PYTEST) $(TEST_LLM) -v --tb=short -q $(PYTEST_FAST_FLAGS)
+	$(PYTEST_CAPPED) $(TEST_LLM) -v --tb=short -q $(PYTEST_FAST_FLAGS)
 
 # --- Results directory --------------------------------------------------------
 
@@ -407,7 +412,7 @@ bench-phase3-gate: build | $(RESULTS_DIR)
 
 bench-tests: build | $(RESULTS_DIR)
 	@echo "==> Running benchmark test suite..."
-	$(PYTEST) discopt_benchmarks/tests/ -v --tb=short -q \
+	$(PYTEST_CAPPED) discopt_benchmarks/tests/ -v --tb=short -q \
 		--junitxml=$(RESULTS_DIR)/bench_tests_$(TS).xml 2>&1 \
 		| tee $(RESULTS_DIR)/bench_tests_$(TS).log
 	@echo "==> Benchmark tests saved to $(RESULTS_DIR)/bench_tests_$(TS).*"

--- a/README.md
+++ b/README.md
@@ -136,10 +136,11 @@ remain available through the explicit Make targets.
 Routine AMP development uses a fast default regression battery. The fast
 environment uses solver-independent checks plus HiGHS-backed MILP relaxations,
 and excludes optional cyipopt, longer Alpine, MINLPTests, and incidence-style
-AMP benchmark coverage. Make targets run pytest through
+AMP benchmark coverage. AMP and PR-fast Make targets run pytest through
 `scripts/run_memory_capped_pytest.sh`, which applies a 16 GB address-space cap
 with `prlimit` when available. Override with `PYTEST_MEMORY_LIMIT_MB=...`, or
-set `PYTEST_MEMORY_LIMIT_MB=0` to disable the cap.
+set `PYTEST_MEMORY_LIMIT_MB=0` to disable the cap. The broad `make test-quick`
+dev-loop target remains uncapped and excludes `memory_heavy` tests.
 
 ```bash
 make test-amp-fast

--- a/README.md
+++ b/README.md
@@ -136,7 +136,10 @@ remain available through the explicit Make targets.
 Routine AMP development uses a fast default regression battery. The fast
 environment uses solver-independent checks plus HiGHS-backed MILP relaxations,
 and excludes optional cyipopt, longer Alpine, MINLPTests, and incidence-style
-AMP benchmark coverage:
+AMP benchmark coverage. Make targets run pytest through
+`scripts/run_memory_capped_pytest.sh`, which applies a 16 GB address-space cap
+with `prlimit` when available. Override with `PYTEST_MEMORY_LIMIT_MB=...`, or
+set `PYTEST_MEMORY_LIMIT_MB=0` to disable the cap.
 
 ```bash
 make test-amp-fast
@@ -155,6 +158,20 @@ uv pip install -e ".[dev,ipopt,highs]"
 maturin develop
 make test-amp-integration
 ```
+
+For WSL or memory-constrained machines, keep broad AMP/JAX runs capped and use a
+bounded xdist worker count rather than `-n auto`:
+
+```bash
+PYTEST_MEMORY_LIMIT_MB=16384 PYTEST_XDIST_WORKERS=2 make test
+PYTEST_MEMORY_LIMIT_MB=16384 make test-amp-integration
+```
+
+WSL users should also set explicit memory and swap limits in `.wslconfig` so a
+single uncapped compile-heavy test cannot restart the host session. A stricter
+12 GB cap is useful for reproducing memory pressure, but the current JAX/XLA
+CPU stack can reserve more than 12 GB of virtual address space during AMP runs;
+use the `memory_heavy` marker selection when running with tighter caps.
 
 The full Python test suite remains available with `make test-all`.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -190,6 +190,7 @@ markers = [
     "slow: long-running tests (backend cross-product, mid-size instances, ML training)",
     "integration: end-to-end multi-component workflows (DOE, discrimination, CUTEst)",
     "amp_benchmark: opt-in AMP Alpine, MINLPTests, or incidence benchmark coverage",
+    "memory_heavy: tests that can compile or solve enough AMP/JAX work to require memory caps",
     "requires_cyipopt: requires the optional cyipopt/Ipopt solver stack",
     "gpu: requires GPU",
     "correctness: known-optima validation tests; usually also `slow`",

--- a/python/discopt/_jax/milp_relaxation.py
+++ b/python/discopt/_jax/milp_relaxation.py
@@ -64,6 +64,7 @@ _MAX_TRIG_PIECEWISE_SPAN = 2.0 * math.pi
 _MAX_TRIG_PIECEWISE_INTERVALS = 32
 _MAX_TRIG_IMPORTED_BREAKPOINTS = _MAX_TRIG_PIECEWISE_INTERVALS + 1
 _MAX_TRIG_PIECEWISE_WIDTH = math.pi / 6.0
+_MAX_RELAXATION_PARTITION_INTERVALS = 128
 
 
 def _warn_once(msg: str, *args) -> None:
@@ -1788,6 +1789,49 @@ def build_milp_relaxation(
         raise ValueError(
             "convhull_ebd is only supported with convhull_formulation='sos2' or its 'lambda' alias."
         )
+    generation_guardrails: list[str] = []
+    generation_guardrail_keys: set[tuple[str, str, int, int]] = set()
+
+    def _record_generation_guardrail(
+        kind: str,
+        target: object,
+        interval_count: int,
+        limit: int,
+    ) -> None:
+        key = (kind, repr(target), int(interval_count), int(limit))
+        if key in generation_guardrail_keys:
+            return
+        generation_guardrail_keys.add(key)
+        note = (
+            f"skipped {kind} refinement for {target}: "
+            f"{interval_count} intervals exceeds cap {limit}"
+        )
+        generation_guardrails.append(note)
+        logger.debug("AMP: %s", note)
+
+    def _guarded_partition_points(
+        kind: str,
+        target: object,
+        points: list[float] | np.ndarray,
+    ) -> Optional[list[float]]:
+        finite_points = [float(p) for p in points if np.isfinite(float(p))]
+        guarded = _sorted_unique_points(finite_points)
+        interval_count = max(0, len(guarded) - 1)
+        if interval_count > _MAX_RELAXATION_PARTITION_INTERVALS:
+            _record_generation_guardrail(
+                kind,
+                target,
+                interval_count,
+                _MAX_RELAXATION_PARTITION_INTERVALS,
+            )
+            return None
+        return guarded
+
+    def _coarse_monomial_breakpoints(lb_i: float, ub_i: float) -> list[float]:
+        points = [lb_i, ub_i]
+        if lb_i < 0.0 < ub_i:
+            points.append(0.0)
+        return _sorted_unique_points(points)
 
     # ── Assign MILP column indices ──────────────────────────────────────────
     # Original variables keep columns 0..n_orig-1. Additional columns are created
@@ -1907,7 +1951,13 @@ def build_milp_relaxation(
         ):
             continue
 
-        breakpoints = _monomial_breakpoints(var_idx, lb_i, ub_i, disc_state)
+        breakpoints = _guarded_partition_points(
+            "monomial piecewise",
+            (var_idx, n),
+            _monomial_breakpoints(var_idx, lb_i, ub_i, disc_state),
+        )
+        if breakpoints is None:
+            continue
         if len(breakpoints) < 3:
             continue
 
@@ -2057,7 +2107,13 @@ def build_milp_relaxation(
         else:
             continue
 
-        pts = disc_state.partitions[part_var]
+        pts = _guarded_partition_points(
+            "bilinear piecewise",
+            (lhs_col, rhs_col),
+            disc_state.partitions[part_var],
+        )
+        if pts is None:
+            continue
         other_lb, other_ub = all_bounds[other_var]
 
         if convhull_mode == "disaggregated":
@@ -2154,7 +2210,13 @@ def build_milp_relaxation(
 
     piecewise_var_map: dict[int, list[tuple[int, int, float, float]]] = {}
     for var_idx in sorted(pw_candidate_vars):
-        pw_pts = list(disc_state.partitions[var_idx])
+        pw_pts = _guarded_partition_points(
+            "fractional-power piecewise",
+            var_idx,
+            disc_state.partitions[var_idx],
+        )
+        if pw_pts is None:
+            continue
         if len(pw_pts) < 3:
             # With only 2 breakpoints there's just one interval; the global
             # secant already coincides with the piecewise secant.
@@ -2614,7 +2676,13 @@ def build_milp_relaxation(
         lb_i = float(flat_lb[var_idx])
         ub_i = float(flat_ub[var_idx])
         s_col = monomial_var_map[(var_idx, n)]
-        breakpoints = _monomial_breakpoints(var_idx, lb_i, ub_i, disc_state)
+        breakpoints = _guarded_partition_points(
+            "monomial tangent",
+            (var_idx, n),
+            _monomial_breakpoints(var_idx, lb_i, ub_i, disc_state),
+        )
+        if breakpoints is None:
+            breakpoints = _coarse_monomial_breakpoints(lb_i, ub_i)
 
         def _add_under_tangent(t: float) -> None:
             slope, intercept = _power_tangent_line(t, n)
@@ -2879,7 +2947,15 @@ def build_milp_relaxation(
         # Tangent points: include partition breakpoints when available so the
         # relaxation tightens monotonically as AMP refines.
         if var_idx in disc_state.partitions and len(disc_state.partitions[var_idx]) >= 2:
-            tangent_pts = [float(t) for t in disc_state.partitions[var_idx]]
+            guarded_tangent_pts = _guarded_partition_points(
+                "fractional-power tangent",
+                (var_idx, p),
+                disc_state.partitions[var_idx],
+            )
+            if guarded_tangent_pts is None:
+                tangent_pts = [lb_i, ub_i]
+            else:
+                tangent_pts = [float(t) for t in guarded_tangent_pts]
         else:
             tangent_pts = [lb_i, ub_i]
         # Avoid degenerate tangents at zero when the slope or value is undefined.
@@ -3100,6 +3176,7 @@ def build_milp_relaxation(
         "convhull_formulation": convhull_mode,
         "convhull_ebd": convhull_ebd,
         "convhull_ebd_encoding": convhull_ebd_encoding,
+        "generation_guardrails": generation_guardrails,
     }
 
     return milp_model, varmap

--- a/python/tests/test_amp.py
+++ b/python/tests/test_amp.py
@@ -78,6 +78,7 @@ def test_amp_integration_suite_is_opt_in():
     assert "pytest.mark.integration" in text
     assert "pytest.mark.amp_benchmark" in text
     assert "pytest.mark.requires_cyipopt" in text
+    assert "pytest.mark.memory_heavy" in text
 
 
 def _make_dry_run(target: str) -> str:
@@ -106,8 +107,9 @@ def test_quick_test_tier_excludes_amp_integration_markers():
 
     assert (
         '-m "(unit or smoke) and not slow and not integration '
-        'and not amp_benchmark and not requires_cyipopt"'
+        'and not amp_benchmark and not requires_cyipopt and not memory_heavy"'
     ) in output
+    assert "scripts/run_memory_capped_pytest.sh python -m pytest" in output
 
 
 def test_pr_fast_tier_excludes_heavy_manual_markers():
@@ -116,9 +118,10 @@ def test_pr_fast_tier_excludes_heavy_manual_markers():
 
     assert (
         '-m "not slow and not correctness and not integration '
-        'and not amp_benchmark and not requires_cyipopt"'
+        'and not amp_benchmark and not requires_cyipopt and not memory_heavy"'
     ) in output
     assert "--ignore=python/tests/test_correctness.py" in output
+    assert "scripts/run_memory_capped_pytest.sh python -m pytest" in output
 
 
 def test_amp_fast_tier_excludes_optional_solver_markers():
@@ -126,8 +129,46 @@ def test_amp_fast_tier_excludes_optional_solver_markers():
     output = _make_dry_run("test-amp-fast")
 
     assert (
-        '-m "not slow and not integration and not amp_benchmark and not requires_cyipopt"'
+        '-m "not slow and not integration and not amp_benchmark '
+        'and not requires_cyipopt and not memory_heavy"'
     ) in output
+    assert "scripts/run_memory_capped_pytest.sh python -m pytest" in output
+
+
+def test_amp_integration_tier_selects_memory_heavy_marker():
+    """The opt-in AMP integration target should include memory-heavy tests under the cap."""
+    output = _make_dry_run("test-amp-integration")
+
+    assert '-m "slow or integration or amp_benchmark or requires_cyipopt or memory_heavy"' in output
+    assert "scripts/run_memory_capped_pytest.sh python -m pytest" in output
+
+
+def test_memory_capped_pytest_wrapper_dry_run():
+    """The pytest wrapper should expose the command and resource caps for diagnosis."""
+    repo = Path(__file__).resolve().parents[2]
+    script = repo / "scripts" / "run_memory_capped_pytest.sh"
+    env = {
+        **os.environ,
+        "RUN_MEMORY_CAPPED_PYTEST_DRY_RUN": "1",
+        "PYTEST_MEMORY_LIMIT_MB": "64",
+        "PYTEST_CPU_LIMIT_SECONDS": "5",
+    }
+
+    result = subprocess.run(
+        [str(script), "python", "-m", "pytest", "python/tests/test_amp.py", "-q"],
+        cwd=repo,
+        check=True,
+        text=True,
+        capture_output=True,
+        env=env,
+    )
+
+    assert "python" in result.stdout
+    assert "pytest" in result.stdout
+    assert "python/tests/test_amp.py" in result.stdout
+    if "prlimit" in result.stdout:
+        assert "--as=67108864" in result.stdout
+        assert "--cpu=5" in result.stdout
 
 
 def test_amp_helper_defaults_cover_semifinite_domains():
@@ -241,6 +282,7 @@ def test_shifted_square_constraint_linearizes_and_proves_infeasible(caplog):
     assert "omitting constraint" not in caplog.text
 
 
+@pytest.mark.memory_heavy
 def test_amp_reports_shifted_square_minlptests_case_infeasible():
     """Regression for MINLPTests nlp_mi_007_020."""
     m = _make_shifted_square_infeasible()
@@ -781,6 +823,57 @@ def test_trig_piecewise_relaxation_caps_dense_partitions():
     assert len(piecewise[0].intervals) < 96
 
 
+def test_dense_bilinear_partitions_fall_back_to_global_relaxation(caplog):
+    """Oversized bilinear partition refinements should keep the global McCormick path."""
+    from discopt._jax.milp_relaxation import _MAX_RELAXATION_PARTITION_INTERVALS
+
+    m = Model("dense_bilinear_guard")
+    x = m.continuous("x", lb=0.0, ub=1.0)
+    y = m.continuous("y", lb=0.0, ub=1.0)
+    m.minimize(x * y)
+
+    with caplog.at_level(logging.DEBUG, logger="discopt._jax.milp_relaxation"):
+        milp_model, varmap = _build_relaxation_for_test(
+            m,
+            part_vars=[0],
+            lbs=[0.0],
+            ubs=[1.0],
+            n_init=_MAX_RELAXATION_PARTITION_INTERVALS + 1,
+        )
+
+    assert (0, 1) in varmap["bilinear"]
+    assert varmap["bilinear_pw"] == {}
+    assert varmap["bilinear_lambda"] == {}
+    assert any("bilinear piecewise" in note for note in varmap["generation_guardrails"])
+    assert "skipped bilinear piecewise refinement" in caplog.text
+    assert milp_model._A_ub.shape[0] < 20
+
+
+def test_dense_monomial_partitions_use_coarse_global_relaxation(caplog):
+    """Oversized monomial partitions should avoid allocating one binary per interval."""
+    from discopt._jax.milp_relaxation import _MAX_RELAXATION_PARTITION_INTERVALS
+
+    m = Model("dense_monomial_guard")
+    x = m.continuous("x", lb=-1.0, ub=1.0)
+    m.minimize(x**2)
+
+    with caplog.at_level(logging.DEBUG, logger="discopt._jax.milp_relaxation"):
+        milp_model, varmap = _build_relaxation_for_test(
+            m,
+            part_vars=[0],
+            lbs=[-1.0],
+            ubs=[1.0],
+            n_init=_MAX_RELAXATION_PARTITION_INTERVALS + 1,
+        )
+
+    assert (0, 2) in varmap["monomial"]
+    assert varmap["monomial_pw"] == {}
+    assert any("monomial piecewise" in note for note in varmap["generation_guardrails"])
+    assert any("monomial tangent" in note for note in varmap["generation_guardrails"])
+    assert "skipped monomial piecewise refinement" in caplog.text
+    assert milp_model._A_ub.shape[0] < 20
+
+
 def test_trig_piecewise_relaxation_skips_huge_argument_span():
     """Very wide trig spans should use range bounds, not many piecewise rows."""
     from discopt._jax.milp_relaxation import _MAX_TRIG_PIECEWISE_SPAN
@@ -1144,6 +1237,7 @@ def test_amp_adaptive_keeps_monomial_fallback_partitions(monkeypatch):
     assert result.gap_certified is False
 
 
+@pytest.mark.memory_heavy
 def test_amp_adaptive_refines_weymouth_like_monomials(monkeypatch):
     """Adaptive selection should keep square-balance variables when products also exist."""
     import discopt._jax.discretization as disc_mod
@@ -1565,6 +1659,7 @@ def test_amp_rejects_nonfinite_direct_initial_point(bad_value):
         )
 
 
+@pytest.mark.memory_heavy
 def test_amp_does_not_accept_start_with_nonfinite_objective(monkeypatch):
     """A finite start with NaN objective is not a valid AMP incumbent."""
     import discopt._jax.nlp_evaluator as nlp_eval
@@ -2192,6 +2287,7 @@ def test_refresh_partitions_for_bounds_prunes_stale_partition_entries():
         ({"alphabb_cutoff_obbt": False, "obbt_with_cutoff": True}, 1),
     ],
 )
+@pytest.mark.memory_heavy
 def test_alphabb_cutoff_obbt_option_controls_prerequisite_pass(
     monkeypatch,
     solver_kwargs,
@@ -2312,6 +2408,7 @@ def test_run_cutoff_obbt_returns_without_time_after_deadline(monkeypatch):
     assert build_calls == []
 
 
+@pytest.mark.memory_heavy
 def test_alphabb_cutoff_obbt_prerequisite_respects_expired_deadline(monkeypatch):
     """The default alpha-BB prerequisite pass must honor the global AMP deadline."""
     from discopt._jax.milp_relaxation import MilpRelaxationResult
@@ -2377,6 +2474,7 @@ def test_alphabb_cutoff_obbt_prerequisite_respects_expired_deadline(monkeypatch)
     assert cutoff_obbt_calls == []
 
 
+@pytest.mark.memory_heavy
 def test_objective_cutoff_bounds_enable_alphabb_for_issue_63_instances():
     """The exact nlp_008 objective cutoff should create finite alpha-BB bounds."""
     from discopt._jax.convexity import classify_oa_cut_convexity
@@ -2442,6 +2540,7 @@ def test_objective_cutoff_bounds_enable_alphabb_for_issue_63_instances():
     assert len(cuts) == 1
 
 
+@pytest.mark.memory_heavy
 def test_amp_restores_model_bounds_after_objective_cutoff_tightening(monkeypatch):
     """Internal cutoff/FBBT bounds must not leak back to the caller's model."""
     from discopt._jax.milp_relaxation import MilpRelaxationResult
@@ -2495,6 +2594,7 @@ def test_amp_restores_model_bounds_after_objective_cutoff_tightening(monkeypatch
     np.testing.assert_allclose(restored_ub, original_ub)
 
 
+@pytest.mark.memory_heavy
 def test_amp_restores_model_bounds_when_callback_raises_after_cutoff(monkeypatch):
     """Propagated callback errors must still restore temporary AMP bounds."""
     from discopt._jax.milp_relaxation import MilpRelaxationResult
@@ -2552,6 +2652,7 @@ def test_amp_restores_model_bounds_when_callback_raises_after_cutoff(monkeypatch
     np.testing.assert_allclose(restored_ub, original_ub)
 
 
+@pytest.mark.memory_heavy
 def test_amp_appends_alphabb_cut_for_issue_63_quadratic(monkeypatch):
     """AMP should append an alpha-BB cut for the nonconvex quadratic row."""
     import discopt._jax.cutting_planes as cutting_planes
@@ -2612,6 +2713,7 @@ def test_amp_appends_alphabb_cut_for_issue_63_quadratic(monkeypatch):
     assert np.isfinite(rhs)
 
 
+@pytest.mark.memory_heavy
 def test_amp_keeps_direct_oa_when_alphabb_generation_fails(monkeypatch):
     """Alpha-BB failures should not suppress already generated convex OA cuts."""
     import discopt._jax.cutting_planes as cutting_planes
@@ -2685,6 +2787,7 @@ def test_amp_keeps_direct_oa_when_alphabb_generation_fails(monkeypatch):
     assert rhs == pytest.approx(2.0)
 
 
+@pytest.mark.memory_heavy
 def test_amp_root_presolve_preserves_heterogeneous_array_bounds():
     """Root FBBT must not narrow every array element to the first element's bound."""
     m = Model("amp_heterogeneous_array_bounds")
@@ -2745,6 +2848,7 @@ def test_small_integer_domain_fallback_enumerates_complete_domain(monkeypatch):
     assert sorted(float(candidate[0]) for candidate in selected_candidates) == [0.0, 1.0, 2.0]
 
 
+@pytest.mark.memory_heavy
 def test_obbt_presolve_tightens_bilinear_demo_bounds():
     """OBBT should shrink the initial [0, 10]^2 box to the linear hull x + y = 1."""
     from discopt._jax.obbt import run_obbt
@@ -2769,6 +2873,7 @@ def test_amp_returns_infeasible_for_nonlinear_tightening_contradiction():
     assert result.x is None
 
 
+@pytest.mark.memory_heavy
 def test_amp_max_iter_without_gap_certificate_returns_feasible():
     """An incumbent without a certified gap should not be labeled optimal."""
     m = _make_nlp1()

--- a/python/tests/test_amp.py
+++ b/python/tests/test_amp.py
@@ -102,14 +102,15 @@ def _make_dry_run(target: str) -> str:
 
 
 def test_quick_test_tier_excludes_amp_integration_markers():
-    """The quick tier must not select opt-in AMP smoke tests."""
+    """The quick tier must not select opt-in AMP smoke tests or use prlimit."""
     output = _make_dry_run("test-quick")
 
     assert (
         '-m "(unit or smoke) and not slow and not integration '
         'and not amp_benchmark and not requires_cyipopt and not memory_heavy"'
     ) in output
-    assert "scripts/run_memory_capped_pytest.sh python -m pytest" in output
+    assert "python -m pytest python/tests/" in output
+    assert "scripts/run_memory_capped_pytest.sh python -m pytest" not in output
 
 
 def test_pr_fast_tier_excludes_heavy_manual_markers():

--- a/python/tests/test_amp_integration.py
+++ b/python/tests/test_amp_integration.py
@@ -50,6 +50,7 @@ pytestmark = [
     pytest.mark.slow,
     pytest.mark.integration,
     pytest.mark.amp_benchmark,
+    pytest.mark.memory_heavy,
 ]
 
 

--- a/scripts/run_memory_capped_pytest.sh
+++ b/scripts/run_memory_capped_pytest.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ "$#" -eq 0 ]]; then
+    echo "usage: $0 <pytest-command> [pytest-args...]" >&2
+    exit 2
+fi
+
+memory_mb="${PYTEST_MEMORY_LIMIT_MB:-16384}"
+cpu_seconds="${PYTEST_CPU_LIMIT_SECONDS:-0}"
+dry_run="${RUN_MEMORY_CAPPED_PYTEST_DRY_RUN:-0}"
+
+cmd=("$@")
+limits=()
+
+export XLA_PYTHON_CLIENT_PREALLOCATE="${XLA_PYTHON_CLIENT_PREALLOCATE:-false}"
+export XLA_PYTHON_CLIENT_MEM_FRACTION="${XLA_PYTHON_CLIENT_MEM_FRACTION:-0.60}"
+
+if [[ "$memory_mb" != "0" ]]; then
+    memory_bytes=$((memory_mb * 1024 * 1024))
+    limits+=("--as=${memory_bytes}")
+fi
+
+if [[ "$cpu_seconds" != "0" ]]; then
+    limits+=("--cpu=${cpu_seconds}")
+fi
+
+if command -v prlimit >/dev/null 2>&1 && [[ "${#limits[@]}" -gt 0 ]]; then
+    echo "==> pytest resource limits: memory=${memory_mb}MB cpu=${cpu_seconds}s"
+    echo "==> JAX allocator: preallocate=${XLA_PYTHON_CLIENT_PREALLOCATE} mem_fraction=${XLA_PYTHON_CLIENT_MEM_FRACTION}"
+    if [[ "$dry_run" == "1" ]]; then
+        printf 'prlimit'
+        printf ' %q' "${limits[@]}"
+        printf ' --'
+        printf ' %q' "${cmd[@]}"
+        printf '\n'
+        exit 0
+    fi
+    exec prlimit "${limits[@]}" -- "${cmd[@]}"
+fi
+
+if [[ "$dry_run" == "1" ]]; then
+    printf '%q' "${cmd[0]}"
+    printf ' %q' "${cmd[@]:1}"
+    printf '\n'
+    exit 0
+fi
+
+if [[ "${#limits[@]}" -gt 0 ]]; then
+    echo "warning: prlimit unavailable; running pytest without resource caps" >&2
+fi
+exec "${cmd[@]}"


### PR DESCRIPTION
Summary
- Added `scripts/run_memory_capped_pytest.sh` to run pytest under `prlimit` when available, with JAX allocator defaults that reduce preallocation.
- Wired Makefile and CI pytest commands through the wrapper, bounded CI xdist workers, and added/excluded a `memory_heavy` marker from fast paths.
- Added per-term AMP MILP relaxation generation caps so oversized dense partitions fall back to global/coarse relaxations with debug/varmap guardrail notes.
- Documented capped AMP/JAX testing and WSL guidance.

Tests run
- `/home/bernalde/.pixi/bin/pixi exec -s python=3.12 -s ipopt -s pkg-config -s c-compiler -s cxx-compiler -s gfortran -- /home/bernalde/.local/bin/uv venv --allow-existing .venv` -> created/reused `.venv`.
- `/home/bernalde/.pixi/bin/pixi exec -s python=3.12 -s ipopt -s pkg-config -s c-compiler -s cxx-compiler -s gfortran -- /home/bernalde/.local/bin/uv pip install --python .venv/bin/python maturin pytest pytest-timeout pytest-xdist pytest-cov numpy scipy jax jaxlib highspy cyipopt ruff==0.14.6 mypy` -> dependencies present/installed.
- `/home/bernalde/.pixi/bin/pixi exec -s python=3.12 -s ipopt -s pkg-config -s c-compiler -s cxx-compiler -s gfortran -- .venv/bin/python -m maturin develop --release --uv` -> passed.
- `bash -n scripts/run_memory_capped_pytest.sh` -> passed.
- `RUN_MEMORY_CAPPED_PYTEST_DRY_RUN=1 PYTEST_MEMORY_LIMIT_MB=64 PYTEST_CPU_LIMIT_SECONDS=5 scripts/run_memory_capped_pytest.sh python -m pytest python/tests/test_amp.py -q` -> passed; printed capped `prlimit` command.
- `PYTEST_MEMORY_LIMIT_MB=16384 scripts/run_memory_capped_pytest.sh .venv/bin/python -m pytest python/tests/test_amp.py::test_memory_capped_pytest_wrapper_dry_run python/tests/test_amp.py::test_amp_fast_tier_excludes_optional_solver_markers python/tests/test_amp.py::test_dense_bilinear_partitions_fall_back_to_global_relaxation python/tests/test_amp.py::test_dense_monomial_partitions_use_coarse_global_relaxation -q` -> 4 passed.
- `make lint RUFF=.venv/bin/ruff` -> passed.
- `make test-amp-fast PYTHON=.venv/bin/python PYTEST='.venv/bin/python -m pytest' MATURIN='.venv/bin/python -m maturin' RUFF=.venv/bin/ruff` -> 81 passed, 15 deselected.
- `.venv/bin/mypy python/discopt/` -> success, no issues found.

Notes about tests not run
- `make test-quick PYTHON=.venv/bin/python PYTEST='.venv/bin/python -m pytest' MATURIN='.venv/bin/python -m maturin' RUFF=.venv/bin/ruff` was attempted under the cap; it aborted in `highspy` during existing `test_partitioned_square_secants_tighten_circle_superlevel_bound` after collecting 3,376 tests. The narrower documented AMP fast target passes under the same environment and cap.
- Full `make test` / `make test-all` were not run locally because the broader quick suite already hit the local solver-binary abort described above.

Closes #81
