### PR TITLE
Lift AMP min/max objectives

### DIFF
--- a/python/discopt/_jax/milp_relaxation.py
+++ b/python/discopt/_jax/milp_relaxation.py
@@ -65,6 +65,7 @@ _MAX_TRIG_PIECEWISE_INTERVALS = 32
 _MAX_TRIG_IMPORTED_BREAKPOINTS = _MAX_TRIG_PIECEWISE_INTERVALS + 1
 _MAX_TRIG_PIECEWISE_WIDTH = math.pi / 6.0
 _MAX_RELAXATION_PARTITION_INTERVALS = 128
+_MAX_OBJECTIVE_LIFT_POWER = 6
 
 
 def _warn_once(msg: str, *args) -> None:
@@ -194,6 +195,17 @@ class UnivariateSquareRelaxation:
     base_ub: float
 
 
+@dataclass
+class MinMaxObjectiveLift:
+    """Epigraph/hypograph lift for a supported objective-level min/max call."""
+
+    func_name: str
+    aux_col: int
+    branch_exprs: tuple[Expression, ...]
+    branch_bounds: tuple[tuple[Optional[float], Optional[float]], ...]
+    aux_bounds: tuple[float, float]
+
+
 # ---------------------------------------------------------------------------
 # Helpers: variable bounds
 # ---------------------------------------------------------------------------
@@ -289,6 +301,185 @@ def _constant_value(expr: Expression) -> Optional[float]:
     if values.size != 1:
         return None
     return float(values[0])
+
+
+def _finite_bound_or_none(value: Optional[float]) -> Optional[float]:
+    if value is None:
+        return None
+    value = float(value)
+    if not _is_effectively_finite(value):
+        return None
+    return value
+
+
+def _expand_integer_powers_for_relaxation(expr: Expression, model: Model) -> Expression:
+    """Expand small integer powers of affine expressions for existing monomial lifts."""
+
+    def visit(node: Expression) -> Expression:
+        if isinstance(node, BinaryOp):
+            left = visit(node.left)
+            right = visit(node.right)
+            if node.op == "**":
+                exp = _constant_value(right)
+                if exp is not None:
+                    n = int(exp)
+                    if exp == n and 2 <= n <= _MAX_OBJECTIVE_LIFT_POWER:
+                        base = left
+                        product = base
+                        for _ in range(n - 1):
+                            product = BinaryOp("*", product, base)
+                        return distribute_products(product)
+            return distribute_products(BinaryOp(node.op, left, right))
+        if isinstance(node, UnaryOp):
+            return UnaryOp(node.op, visit(node.operand))
+        if isinstance(node, SumExpression):
+            return SumExpression(visit(node.operand), axis=node.axis)
+        if isinstance(node, SumOverExpression):
+            return SumOverExpression([visit(term) for term in node.terms])
+        # Preserve FunctionCall object identity so existing univariate lift maps
+        # keyed by id(expr) remain usable during branch linearization.
+        return node
+
+    return distribute_products(visit(expr))
+
+
+def _expression_lower_bound_for_lift(
+    expr: Expression,
+    model: Model,
+    flat_lb: np.ndarray,
+    flat_ub: np.ndarray,
+) -> Optional[float]:
+    expanded = _expand_integer_powers_for_relaxation(expr, model)
+    lower = _separable_objective_lower_bound(expanded, model, flat_lb, flat_ub)
+    return _finite_bound_or_none(lower)
+
+
+def _expression_upper_bound_for_lift(
+    expr: Expression,
+    model: Model,
+    flat_lb: np.ndarray,
+    flat_ub: np.ndarray,
+) -> Optional[float]:
+    lower_of_negated = _expression_lower_bound_for_lift(
+        UnaryOp("neg", expr),
+        model,
+        flat_lb,
+        flat_ub,
+    )
+    if lower_of_negated is None:
+        return None
+    return -lower_of_negated
+
+
+def _collect_monomial_terms_for_lift(expr: Expression, model: Model) -> set[tuple[int, int]]:
+    terms: set[tuple[int, int]] = set()
+
+    def visit(node: Expression) -> None:
+        if isinstance(node, BinaryOp):
+            if node.op == "*":
+                decomp = _decompose_product(node, model)
+                if decomp is not None:
+                    _scalar, indices = decomp
+                    unique = list(dict.fromkeys(indices))
+                    if len(unique) == 1 and len(indices) >= 2:
+                        terms.add((unique[0], len(indices)))
+            elif node.op == "**":
+                flat = _get_flat_index(node.left, model)
+                exp = _constant_value(node.right)
+                if flat is not None and exp is not None:
+                    n = int(exp)
+                    if exp == n and n >= 2:
+                        terms.add((flat, n))
+            visit(node.left)
+            visit(node.right)
+            return
+        if isinstance(node, UnaryOp):
+            visit(node.operand)
+            return
+        if isinstance(node, FunctionCall):
+            for arg in node.args:
+                visit(arg)
+            return
+        if isinstance(node, IndexExpression) and not isinstance(node.base, Variable):
+            visit(node.base)
+            return
+        if isinstance(node, SumExpression):
+            visit(node.operand)
+            return
+        if isinstance(node, SumOverExpression):
+            for term in node.terms:
+                visit(term)
+
+    visit(expr)
+    return terms
+
+
+def _build_minmax_objective_lift(
+    model: Model,
+    flat_lb: np.ndarray,
+    flat_ub: np.ndarray,
+) -> Optional[MinMaxObjectiveLift]:
+    if model._objective is None:
+        return None
+    expr = model._objective.expression
+    if not isinstance(expr, FunctionCall) or len(expr.args) < 2:
+        return None
+    if model._objective.sense == ObjectiveSense.MINIMIZE and expr.func_name != "max":
+        return None
+    if model._objective.sense == ObjectiveSense.MAXIMIZE and expr.func_name != "min":
+        return None
+    if expr.func_name not in {"min", "max"}:
+        return None
+
+    branch_exprs = tuple(_expand_integer_powers_for_relaxation(arg, model) for arg in expr.args)
+    branch_bounds = tuple(
+        (
+            _expression_lower_bound_for_lift(branch, model, flat_lb, flat_ub),
+            _expression_upper_bound_for_lift(branch, model, flat_lb, flat_ub),
+        )
+        for branch in branch_exprs
+    )
+
+    lower_bounds = [lb for lb, _ub in branch_bounds if lb is not None]
+    upper_bounds = [ub for _lb, ub in branch_bounds if ub is not None]
+    aux_lb: Optional[float]
+    aux_ub: Optional[float]
+    if expr.func_name == "max":
+        # max(f_i) is at least any available lower bound on a branch.
+        aux_lb = max(lower_bounds) if lower_bounds else None
+        # max(f_i) is at most max(ub_i) only when every branch has an upper bound.
+        aux_ub = max(upper_bounds) if len(upper_bounds) == len(branch_bounds) else None
+        directional_bound = aux_lb
+    else:
+        # min(f_i) is at least min(lb_i) only when every branch has a lower bound.
+        aux_lb = min(lower_bounds) if len(lower_bounds) == len(branch_bounds) else None
+        # min(f_i) is at most any available upper bound on a branch.
+        aux_ub = min(upper_bounds) if upper_bounds else None
+        directional_bound = aux_ub
+
+    directional_bound = _finite_bound_or_none(directional_bound)
+    if directional_bound is None:
+        return None
+
+    lb = _finite_bound_or_none(aux_lb)
+    ub = _finite_bound_or_none(aux_ub)
+    aux_bounds = (
+        lb if lb is not None else -_EFFECTIVE_INF,
+        ub if ub is not None else _EFFECTIVE_INF,
+    )
+    if aux_bounds[0] > aux_bounds[1] + 1e-9:
+        return None
+    if aux_bounds[0] > aux_bounds[1]:
+        mid = 0.5 * (aux_bounds[0] + aux_bounds[1])
+        aux_bounds = (mid, mid)
+
+    return MinMaxObjectiveLift(
+        func_name=expr.func_name,
+        aux_col=-1,
+        branch_exprs=branch_exprs,
+        branch_bounds=branch_bounds,
+        aux_bounds=aux_bounds,
+    )
 
 
 def _normalize_convhull_formulation(formulation: str) -> str:
@@ -1791,6 +1982,12 @@ def build_milp_relaxation(
         )
     generation_guardrails: list[str] = []
     generation_guardrail_keys: set[tuple[str, str, int, int]] = set()
+    objective_lift = _build_minmax_objective_lift(model, flat_lb, flat_ub)
+    objective_lift_monomials: set[tuple[int, int]] = set()
+    if objective_lift is not None:
+        for branch_expr in objective_lift.branch_exprs:
+            objective_lift_monomials.update(_collect_monomial_terms_for_lift(branch_expr, model))
+    monomial_terms = sorted(set(terms.monomial) | objective_lift_monomials)
 
     def _record_generation_guardrail(
         kind: str,
@@ -1924,7 +2121,7 @@ def build_milp_relaxation(
         multilinear_var_map[multi_term] = final_col
         multilinear_stage_map[multi_term] = stages
 
-    for var_idx, n in terms.monomial:
+    for var_idx, n in monomial_terms:
         lb_i = float(flat_lb[var_idx])
         ub_i = float(flat_ub[var_idx])
         if not (_is_effectively_finite(lb_i) and _is_effectively_finite(ub_i)):
@@ -1938,7 +2135,7 @@ def build_milp_relaxation(
         col_idx += 1
 
     monomial_pw_map: dict[tuple[int, int], list[tuple[int, float, float]]] = {}
-    for var_idx, n in terms.monomial:
+    for var_idx, n in monomial_terms:
         if (var_idx, n) not in monomial_var_map:
             continue
         lb_i = float(flat_lb[var_idx])
@@ -2237,6 +2434,12 @@ def build_milp_relaxation(
             col_idx += 1
             pw_intervals_list.append((delta_col, xbar_col, p_lo, p_hi))
         piecewise_var_map[var_idx] = pw_intervals_list
+
+    if objective_lift is not None:
+        objective_lift.aux_col = col_idx
+        all_bounds.append(objective_lift.aux_bounds)
+        integrality_flags.append(0)
+        col_idx += 1
 
     n_total = col_idx
 
@@ -2670,7 +2873,7 @@ def build_milp_relaxation(
             _add_row(row, M_k - z_lb_k * w_ub)
 
     # Monomial constraints
-    for var_idx, n in terms.monomial:
+    for var_idx, n in monomial_terms:
         if (var_idx, n) not in monomial_var_map:
             continue
         lb_i = float(flat_lb[var_idx])
@@ -3026,6 +3229,40 @@ def build_milp_relaxation(
             row[var_idx] = -secant_slope
             _add_row(row, secant_intercept)
 
+    if objective_lift is not None:
+        for branch_expr in objective_lift.branch_exprs:
+            try:
+                c_branch, const_branch = _linearize_expr(
+                    branch_expr,
+                    model,
+                    bilinear_var_map,
+                    trilinear_var_map,
+                    multilinear_var_map,
+                    monomial_var_map,
+                    univariate_var_map,
+                    n_total,
+                    fractional_power_var_map=fractional_power_var_map,
+                    univariate_square_var_map=univariate_square_var_map,
+                )
+            except ValueError as err:
+                logger.debug(
+                    "AMP: min/max objective lift uses auxiliary bounds because a branch "
+                    "could not be linearized: %s",
+                    err,
+                )
+                continue
+
+            if objective_lift.func_name == "max":
+                # minimize max(f_i): f_i <= t  ->  f_i - t <= 0
+                row = c_branch.copy()
+                row[objective_lift.aux_col] -= 1.0
+                _add_row(row, -const_branch)
+            else:
+                # maximize min(f_i): t <= f_i  ->  t - f_i <= 0
+                row = -c_branch
+                row[objective_lift.aux_col] += 1.0
+                _add_row(row, const_branch)
+
     # Model constraints
     for constraint in model._constraints:
         body = distribute_products(constraint.body)
@@ -3081,18 +3318,23 @@ def build_milp_relaxation(
     assert model._objective is not None
     obj_expr = distribute_products(model._objective.expression)
     try:
-        c_obj, const_obj = _linearize_expr(
-            obj_expr,
-            model,
-            bilinear_var_map,
-            trilinear_var_map,
-            multilinear_var_map,
-            monomial_var_map,
-            univariate_var_map,
-            n_total,
-            fractional_power_var_map=fractional_power_var_map,
-            univariate_square_var_map=univariate_square_var_map,
-        )
+        if objective_lift is not None:
+            c_obj = np.zeros(n_total)
+            c_obj[objective_lift.aux_col] = 1.0
+            const_obj = 0.0
+        else:
+            c_obj, const_obj = _linearize_expr(
+                obj_expr,
+                model,
+                bilinear_var_map,
+                trilinear_var_map,
+                multilinear_var_map,
+                monomial_var_map,
+                univariate_var_map,
+                n_total,
+                fractional_power_var_map=fractional_power_var_map,
+                univariate_square_var_map=univariate_square_var_map,
+            )
         objective_bound_valid = True
     except ValueError as err:
         fallback_lb = None
@@ -3171,6 +3413,16 @@ def build_milp_relaxation(
         "univariate_square": univariate_square_var_map,
         "univariate_square_relaxations": univariate_square_relaxations,
         "fractional_power": fractional_power_var_map,
+        "minmax_objective_lift": (
+            {
+                "func_name": objective_lift.func_name,
+                "aux_col": objective_lift.aux_col,
+                "branch_bounds": objective_lift.branch_bounds,
+                "aux_bounds": objective_lift.aux_bounds,
+            }
+            if objective_lift is not None
+            else None
+        ),
         "bilinear_pw": bilinear_pw_map,
         "bilinear_lambda": bilinear_lambda_map,
         "convhull_formulation": convhull_mode,

--- a/python/tests/test_amp.py
+++ b/python/tests/test_amp.py
@@ -706,6 +706,77 @@ def test_issue71_maximize_sqrt_objective_uses_real_relaxation_bound(caplog):
     assert "falling back to a feasibility objective" not in caplog.text
 
 
+@pytest.mark.parametrize(
+    ("sense", "func_name", "expected_relaxation_obj"),
+    [
+        ("minimize", "max", 1.5),
+        ("maximize", "min", -1.5),
+    ],
+)
+def test_issue64_affine_minmax_objective_lift_adds_correct_rows(
+    sense,
+    func_name,
+    expected_relaxation_obj,
+):
+    """Objective-level min/max calls should be lifted with epigraph/hypograph rows."""
+    m = Model(f"issue64_affine_{func_name}")
+    x = m.continuous("x", lb=0.0, ub=3.0)
+    expr = dm.maximum(x + 1.0, 2.0 - x) if func_name == "max" else dm.minimum(x + 1.0, 2.0 - x)
+    if sense == "minimize":
+        m.minimize(expr)
+    else:
+        m.maximize(expr)
+
+    milp_model, varmap = _build_relaxation_for_test(m)
+    result = milp_model.solve()
+
+    lift = varmap["minmax_objective_lift"]
+    assert lift is not None
+    assert lift["func_name"] == func_name
+    assert milp_model._objective_bound_valid is True
+    assert result.status == "optimal"
+    assert result.objective == pytest.approx(expected_relaxation_obj, abs=1e-8)
+
+
+@pytest.mark.parametrize(
+    ("sense", "func_name", "expected_relaxation_obj"),
+    [
+        ("maximize", "min", -0.75),
+        ("minimize", "max", 0.75),
+    ],
+)
+def test_issue64_minlptests_minmax_objective_uses_lifted_bound(
+    sense,
+    func_name,
+    expected_relaxation_obj,
+    caplog,
+):
+    """The nlp_009 min/max objectives should not force feasibility-objective fallback."""
+    m = Model(f"issue64_nlp_009_{func_name}")
+    x = m.continuous("x")
+    if func_name == "min":
+        expr = dm.minimum(0.75 + (x - 0.5) ** 3, 0.75 - (x - 0.5) ** 2)
+    else:
+        expr = dm.maximum(0.75 + (x - 0.5) ** 3, 0.75 + (x - 0.5) ** 2)
+    if sense == "minimize":
+        m.minimize(expr)
+    else:
+        m.maximize(expr)
+
+    with caplog.at_level(logging.WARNING, logger="discopt._jax.milp_relaxation"):
+        milp_model, varmap = _build_relaxation_for_test(m)
+        result = milp_model.solve()
+
+    lift = varmap["minmax_objective_lift"]
+    assert lift is not None
+    assert lift["func_name"] == func_name
+    assert milp_model._objective_bound_valid is True
+    assert result.status == "optimal"
+    assert result.objective == pytest.approx(expected_relaxation_obj, abs=1e-8)
+    assert "falling back to a feasibility objective" not in caplog.text
+    assert f"Cannot linearize FunctionCall: {func_name}" not in caplog.text
+
+
 def test_issue71_milp_wrapper_accepts_nonfatal_highs_warnings():
     """HiGHS passModel warnings from tiny AMP rows must not discard valid bounds."""
     from discopt.solvers import SolveStatus

--- a/python/tests/test_amp_integration.py
+++ b/python/tests/test_amp_integration.py
@@ -2833,6 +2833,7 @@ class TestCurrentCodeWeaknesses:
             "nlp_008_010",
             "nlp_008_011",
             "nlp_009_010",
+            "nlp_009_011",
         ],
     )
     @pytest.mark.requires_cyipopt
@@ -2896,6 +2897,37 @@ class TestCurrentCodeWeaknesses:
             if "falling back to a feasibility objective" in record.message
         ]
         assert not any("abs" in message or "tan" in message for message in fallback_messages)
+
+    @pytest.mark.parametrize("problem_id", ["nlp_009_010", "nlp_009_011"])
+    @pytest.mark.requires_cyipopt
+    def test_amp_reports_bound_for_minmax_objective_minlptests_cases(self, problem_id, caplog):
+        """The nlp_009 min/max objectives should not fall back to feasibility mode."""
+        if not HAS_CYIPOPT:
+            pytest.skip("requires cyipopt for pure continuous NLP recovery")
+
+        instance = MINLPTESTS_NLP_BY_ID[problem_id]
+        m = instance.build_fn()
+
+        with caplog.at_level(logging.WARNING, logger="discopt._jax.milp_relaxation"):
+            result = m.solve(
+                solver="amp",
+                nlp_solver="ipm",
+                time_limit=30.0,
+                gap_tolerance=1e-3,
+            )
+
+        assert result.status in ("optimal", "feasible")
+        assert result.objective is not None
+        tol = 1e-6 + 1e-4 * abs(instance.expected_obj)
+        assert abs(result.objective - instance.expected_obj) <= tol
+        assert result.bound is not None
+        fallback_messages = [
+            record.message
+            for record in caplog.records
+            if "falling back to a feasibility objective" in record.message
+        ]
+        assert not any("FunctionCall: min" in message for message in fallback_messages)
+        assert not any("FunctionCall: max" in message for message in fallback_messages)
 
     @pytest.mark.parametrize(
         "problem_id",


### PR DESCRIPTION
## Summary

- Lift supported objective-level `min`/`max` calls before AMP MILP objective linearization.
- Add an auxiliary objective variable for `minimize max(...)` and `maximize min(...)`, with epigraph/hypograph rows when branch expressions are linearizable.
- Use conservative branch-derived auxiliary bounds so `nlp_009_010` and `nlp_009_011` no longer fall back to a feasibility objective solely because the objective root is `FunctionCall: min` or `FunctionCall: max`.

## Tests run

- `/home/bernalde/.pixi/bin/pixi exec -s python=3.12 -s ipopt -s pkg-config -s c-compiler -s cxx-compiler -s gfortran -- /home/bernalde/.local/bin/uv venv --allow-existing .venv`  
  Result: created `.venv`.
- `/home/bernalde/.pixi/bin/pixi exec -s python=3.12 -s ipopt -s pkg-config -s c-compiler -s cxx-compiler -s gfortran -- /home/bernalde/.local/bin/uv pip install --python .venv/bin/python maturin pytest pytest-timeout numpy scipy jax jaxlib highspy cyipopt`  
  Result: success.
- `/home/bernalde/.pixi/bin/pixi exec -s python=3.12 -s ipopt -s pkg-config -s c-compiler -s cxx-compiler -s gfortran -- /home/bernalde/.local/bin/uv pip install --python .venv/bin/python -e '.[dev,ipopt,highs]'`  
  Result: success.
- `/home/bernalde/.pixi/bin/pixi exec -s python=3.12 -s ipopt -s pkg-config -s c-compiler -s cxx-compiler -s gfortran -- env -u CONDA_PREFIX VIRTUAL_ENV=/home/bernalde/repos/discopt/.venv /home/bernalde/repos/discopt/.venv/bin/python -m maturin develop --uv`  
  Result: success.
- `/home/bernalde/.pixi/bin/pixi exec -s python=3.12 -s ipopt -s pkg-config -s c-compiler -s cxx-compiler -s gfortran -- env -u CONDA_PREFIX VIRTUAL_ENV=/home/bernalde/repos/discopt/.venv /home/bernalde/repos/discopt/.venv/bin/python -m pytest python/tests/test_amp.py -q -v --tb=short -k issue64`  
  Result: 4 passed, 96 deselected.
- `/home/bernalde/.pixi/bin/pixi exec -s python=3.12 -s ipopt -s pkg-config -s c-compiler -s cxx-compiler -s gfortran -- env -u CONDA_PREFIX VIRTUAL_ENV=/home/bernalde/repos/discopt/.venv /home/bernalde/repos/discopt/.venv/bin/python -m pytest python/tests/test_amp_integration.py::TestCurrentCodeWeaknesses::test_amp_reports_bound_for_minmax_objective_minlptests_cases -q -v --tb=short`  
  Result: 2 passed.
- `/home/bernalde/.pixi/bin/pixi exec -s python=3.12 -s ipopt -s pkg-config -s c-compiler -s cxx-compiler -s gfortran -- env -u CONDA_PREFIX VIRTUAL_ENV=/home/bernalde/repos/discopt/.venv /home/bernalde/repos/discopt/.venv/bin/python -m pytest python/tests/test_amp_integration.py::TestCurrentCodeWeaknesses::test_amp_recovers_remaining_pure_continuous_minlptests_cases -q -v --tb=short -k nlp_009`  
  Result: 2 passed, 4 deselected.
- `/home/bernalde/.pixi/bin/pixi exec -s python=3.12 -s ipopt -s pkg-config -s c-compiler -s cxx-compiler -s gfortran -- env -u CONDA_PREFIX VIRTUAL_ENV=/home/bernalde/repos/discopt/.venv make test-amp-fast PYTHON=/home/bernalde/repos/discopt/.venv/bin/python MATURIN='/home/bernalde/repos/discopt/.venv/bin/python -m maturin' PYTEST='/home/bernalde/repos/discopt/.venv/bin/python -m pytest'`  
  Result: 85 passed, 15 deselected.
- `/home/bernalde/.pixi/bin/pixi exec -s python=3.12 -s ipopt -s pkg-config -s c-compiler -s cxx-compiler -s gfortran -- env -u CONDA_PREFIX VIRTUAL_ENV=/home/bernalde/repos/discopt/.venv make lint PYTHON=/home/bernalde/repos/discopt/.venv/bin/python RUFF=/home/bernalde/repos/discopt/.venv/bin/ruff`  
  Result: passed.
- `git commit -m "Fix AMP minmax objective lifting (#64)"`  
  Result: pre-commit passed Ruff, Ruff format, mypy; cargo fmt skipped because no Rust files changed.

## Notes about tests not run

- Full `make test` was attempted twice with the same uv/pixi `.venv`, but the Python process aborted in JAX lowering inside existing AlphaBB tests before reaching this change area. The isolated reported tests passed:
  - `python/tests/test_alphabb.py::TestEigenvalueMethods::test_gershgorin_diagonal`: 1 passed.
  - `python/tests/test_alphabb.py::TestEigenvalueMethods::test_gershgorin_conservative`: 1 passed.

Closes #64
