### PR TITLE
Fix AMP tan/abs nlp_004 bounds

### DIFF
--- a/python/discopt/_jax/milp_relaxation.py
+++ b/python/discopt/_jax/milp_relaxation.py
@@ -1082,17 +1082,20 @@ def _trig_partition_breakpoints(
     """Return safe breakpoints for a mixed-curvature trig argument interval."""
     lb = float(relax.arg_lb)
     ub = float(relax.arg_ub)
-    if relax.func_name not in {"sin", "cos"} or not (np.isfinite(lb) and np.isfinite(ub)):
+    if relax.func_name not in {"sin", "cos", "tan"} or not (np.isfinite(lb) and np.isfinite(ub)):
         return [lb, ub]
 
     points = [lb, ub]
     if relax.func_name == "sin":
         curvature_start, critical_start = 0.0, math.pi / 2.0
-    else:
+        points.extend(_critical_points_in_interval(critical_start, math.pi, lb, ub))
+    elif relax.func_name == "cos":
         curvature_start, critical_start = math.pi / 2.0, 0.0
+        points.extend(_critical_points_in_interval(critical_start, math.pi, lb, ub))
+    else:
+        curvature_start = 0.0
 
     points.extend(_critical_points_in_interval(curvature_start, math.pi, lb, ub))
-    points.extend(_critical_points_in_interval(critical_start, math.pi, lb, ub))
 
     nz = np.flatnonzero(np.abs(relax.arg_coeff) > 1e-12)
     if nz.size == 1:
@@ -1125,8 +1128,8 @@ def _trig_piecewise_interval_specs(
     disc_state: DiscretizationState,
     n_orig: int,
 ) -> list[tuple[float, float, Optional[str]]]:
-    """Build certified curvature subintervals for mixed-curvature sin/cos."""
-    if relax.func_name not in {"sin", "cos"}:
+    """Build certified curvature subintervals for mixed-curvature trig functions."""
+    if relax.func_name not in {"sin", "cos", "tan"}:
         return []
     if not (np.isfinite(relax.arg_lb) and np.isfinite(relax.arg_ub)):
         return []
@@ -2857,7 +2860,19 @@ def build_milp_relaxation(
                     yj_lb,
                     yj_ub,
                 )
-                M_k = _compute_piecewise_big_m(corners)
+
+                def _inactive_big_m(other_coeff: float, rhs: float) -> float:
+                    violations = [
+                        float(other_coeff) * yj_lb - float(rhs),
+                        float(other_coeff) * yj_ub - float(rhs),
+                    ]
+                    max_violation = max(0.0, *violations)
+                    if max_violation <= 0.0:
+                        return 0.0
+                    return max_violation * (1.0 + 1e-4) + max(
+                        1e-9,
+                        1e-9 * max_violation,
+                    )
 
                 # x̄_k ≥ a_k * δ_k  (x̄_k is in [a_k, b_k] when δ_k=1)
                 row = np.zeros(n_total)
@@ -2878,51 +2893,59 @@ def build_milp_relaxation(
                 row[delta_col] = -wk_hi
                 _add_row(row, 0.0)
 
-                # w̄_k ≥ wk_lo * δ_k  → w̄_k=0 when δ_k=0 (for wk_lo ≥ 0 case)
-                if wk_lo > 0:
-                    row = np.zeros(n_total)
-                    row[wbar_col] = -1.0
-                    row[delta_col] = wk_lo
-                    _add_row(row, 0.0)
+                # w̄_k ≥ wk_lo * δ_k. Together with the upper row this forces
+                # w̄_k=0 when the interval is inactive, even for negative products.
+                row = np.zeros(n_total)
+                row[wbar_col] = -1.0
+                row[delta_col] = wk_lo
+                _add_row(row, 0.0)
 
                 # Per-interval McCormick with big-M relaxation.
                 # The big-M term LOOSENS the constraint when δ_k=0 (interval inactive).
                 #
                 # cv1: w̄_k ≥ a_k*y + x̄_k*y_lb - a_k*y_lb - M*(1-δ_k)
                 #   → -w̄_k + a_k*y + x̄_k*y_lb + M*δ_k ≤ a_k*y_lb + M
+                rhs = a_k * yj_lb
+                big_m = _inactive_big_m(a_k, rhs)
                 row = np.zeros(n_total)
                 row[wbar_col] = -1.0
                 row[other_var] += a_k
                 row[xbar_col] += yj_lb
-                row[delta_col] = M_k  # +M_k so constraint loosens when δ_k=0
-                _add_row(row, a_k * yj_lb + M_k)
+                row[delta_col] = big_m
+                _add_row(row, rhs + big_m)
 
                 # cv2: w̄_k ≥ b_k*y + x̄_k*y_ub - b_k*y_ub - M*(1-δ_k)
                 #   → -w̄_k + b_k*y + x̄_k*y_ub + M*δ_k ≤ b_k*y_ub + M
+                rhs = b_k * yj_ub
+                big_m = _inactive_big_m(b_k, rhs)
                 row = np.zeros(n_total)
                 row[wbar_col] = -1.0
                 row[other_var] += b_k
                 row[xbar_col] += yj_ub
-                row[delta_col] = M_k
-                _add_row(row, b_k * yj_ub + M_k)
+                row[delta_col] = big_m
+                _add_row(row, rhs + big_m)
 
                 # cc1: w̄_k ≤ b_k*y + x̄_k*y_lb - b_k*y_lb + M*(1-δ_k)
                 #   → w̄_k - b_k*y - x̄_k*y_lb + M*δ_k ≤ M - b_k*y_lb
+                rhs = -b_k * yj_lb
+                big_m = _inactive_big_m(-b_k, rhs)
                 row = np.zeros(n_total)
                 row[wbar_col] = 1.0
                 row[other_var] -= b_k
                 row[xbar_col] -= yj_lb
-                row[delta_col] = M_k  # +M_k so constraint loosens when δ_k=0
-                _add_row(row, M_k - b_k * yj_lb)
+                row[delta_col] = big_m
+                _add_row(row, rhs + big_m)
 
                 # cc2: w̄_k ≤ a_k*y + x̄_k*y_ub - a_k*y_ub + M*(1-δ_k)
                 #   → w̄_k - a_k*y - x̄_k*y_ub + M*δ_k ≤ M - a_k*y_ub
+                rhs = -a_k * yj_ub
+                big_m = _inactive_big_m(-a_k, rhs)
                 row = np.zeros(n_total)
                 row[wbar_col] = 1.0
                 row[other_var] -= a_k
                 row[xbar_col] -= yj_ub
-                row[delta_col] = M_k
-                _add_row(row, M_k - a_k * yj_ub)
+                row[delta_col] = big_m
+                _add_row(row, rhs + big_m)
 
         else:
             # ── Standard (global) McCormick ──────────────────────────────────

--- a/python/discopt/solvers/amp.py
+++ b/python/discopt/solvers/amp.py
@@ -1135,12 +1135,17 @@ def _square_monomial_vars_in_expr(expr: Expression, model: Model) -> set[int]:
 
 
 def _equality_square_monomial_partition_candidates(model: Model, terms: Any) -> list[int]:
-    """Select square monomials from equality balances for AMP refinement.
+    """Select coupled square monomials that benefit from AMP refinement.
 
     Weymouth constraints have the form ``f^2 = C * (p_in^2 - p_out^2)``:
     multiple square monomials coupled by one equality.  Partitioning those
     variables lets the monomial tangent cuts adapt around the MILP point without
     making every monomial in every model a partition candidate.
+
+    Sphere/ball constraints such as ``x^2 + y^2 + z^2 <= r`` need the same
+    treatment: the tangent under-estimators for each square must tighten
+    together, otherwise an unpartitioned square can leave too much room in the
+    convex quadratic upper-bound constraint.
     """
     known_squares = {
         int(var_idx) for var_idx, exp in getattr(terms, "monomial", []) if int(exp) == 2
@@ -1150,7 +1155,7 @@ def _equality_square_monomial_partition_candidates(model: Model, terms: Any) -> 
 
     candidates: set[int] = set()
     for constraint in model._constraints:
-        if constraint.sense != "==":
+        if constraint.sense not in {"==", "<="}:
             continue
         square_vars = _square_monomial_vars_in_expr(constraint.body, model) & known_squares
         if len(square_vars) >= 2:

--- a/python/tests/test_amp.py
+++ b/python/tests/test_amp.py
@@ -219,7 +219,7 @@ def test_amp_normalizes_initial_point_length_and_bounds():
 
 
 def test_weymouth_like_squares_extend_builtin_partition_selection():
-    """Square-balance equalities should add monomial vars without changing classifier output."""
+    """Coupled square constraints should add monomial vars without changing classifier output."""
     from discopt._jax.term_classifier import classify_nonlinear_terms
     from discopt.solvers import amp as amp_mod
 
@@ -234,6 +234,20 @@ def test_weymouth_like_squares_extend_builtin_partition_selection():
     assert (3, 2) in terms.monomial
     assert set(terms.partition_candidates) == {0, 1}
     assert set(amp_mod._equality_square_monomial_partition_candidates(m, terms)) == {2, 3}
+
+    sphere = Model("sphere_candidates")
+    y = sphere.continuous("y", lb=-4.0, ub=4.0, shape=(3,))
+    sphere.minimize(y[0] * y[2])
+    sphere.subject_to(y[0] ** 2 + y[1] ** 2 + y[2] ** 2 <= 10.0)
+
+    sphere_terms = classify_nonlinear_terms(sphere)
+
+    assert set(sphere_terms.partition_candidates) == {0, 2}
+    assert set(amp_mod._equality_square_monomial_partition_candidates(sphere, sphere_terms)) == {
+        0,
+        1,
+        2,
+    }
 
 
 def test_partitioned_square_secants_tighten_circle_superlevel_bound():
@@ -813,6 +827,57 @@ def test_tan_abs_minlptests_objective_linearizes_without_fallback(caplog):
     assert not any(
         "could not linearize the objective" in record.message for record in caplog.records
     )
+
+
+def test_mixed_curvature_tan_relaxation_respects_fixed_argument():
+    """Piecewise tan envelopes should tighten a mixed-curvature lifted objective."""
+    m = Model("tan_fixed_arg")
+    x = m.continuous("x", lb=-1.0, ub=1.0)
+    m.minimize(dm.tan(x))
+    m.subject_to(x == 0.0)
+
+    milp_model, varmap = _build_relaxation_for_test(m)
+    result = milp_model.solve()
+
+    assert result.status == "optimal"
+    assert result.objective == pytest.approx(0.0, abs=1e-8)
+    piecewise = varmap["univariate_piecewise_relaxations"]
+    assert [relax.relax.func_name for relax in piecewise] == ["tan"]
+    assert {interval.curvature for interval in piecewise[0].intervals} == {"concave", "convex"}
+
+
+def test_disaggregated_piecewise_bilinear_big_m_keeps_negative_endpoint_feasible():
+    """Inactive piecewise McCormick rows need enough slack on negative intervals."""
+    from discopt._jax.discretization import DiscretizationState
+    from discopt._jax.milp_relaxation import build_milp_relaxation
+    from discopt._jax.term_classifier import classify_nonlinear_terms
+
+    z_value = 2.85671038
+    z_bound = float(np.sqrt(10.0))
+    m = Model("fixed_negative_bilinear")
+    x = m.continuous("x", lb=-1.0, ub=1.0)
+    z = m.continuous("z", lb=-z_bound, ub=z_bound)
+    m.minimize(x * z)
+    m.subject_to(x == -1.0)
+    m.subject_to(z == z_value)
+
+    state = DiscretizationState(
+        partitions={
+            0: np.array([-1.0, -0.99, -0.9, 0.0, 1.0], dtype=np.float64),
+            1: np.array([-z_bound, 0.0, 2.687936011, 2.956729612, z_bound]),
+        }
+    )
+    milp_model, _ = build_milp_relaxation(
+        m,
+        classify_nonlinear_terms(m),
+        state,
+        incumbent=None,
+        convhull_formulation="disaggregated",
+    )
+    result = milp_model.solve()
+
+    assert result.status == "optimal"
+    assert result.objective == pytest.approx(-z_value, abs=1e-8)
 
 
 def test_affine_trig_constraints_are_retained_in_relaxation(caplog):

--- a/python/tests/test_amp_integration.py
+++ b/python/tests/test_amp_integration.py
@@ -2857,22 +2857,27 @@ class TestCurrentCodeWeaknesses:
         tol = 1e-6 + 1e-4 * abs(instance.expected_obj)
         assert abs(result.objective - instance.expected_obj) <= tol
 
-    def test_amp_does_not_certify_invalid_negative_gap_on_nlp_004_010(self):
-        """A lower bound above the incumbent must not be reported as certified optimality."""
+    def test_amp_certifies_tan_abs_nlp_004_010_at_issue_gap(self):
+        """The continuous tan/abs nlp_004 case should certify the issue-79 gap."""
         instance = MINLPTESTS_NLP_BY_ID["nlp_004_010"]
         m = instance.build_fn()
 
         result = m.solve(
             solver="amp",
             nlp_solver="ipm",
-            time_limit=30.0,
-            gap_tolerance=1e-3,
+            time_limit=300.0,
+            gap_tolerance=1e-6,
+            max_iter=1000,
         )
 
-        assert result.status == "feasible"
-        assert result.gap_certified is False
+        assert result.status == "optimal"
         assert result.objective is not None
-        assert result.gap is None or result.gap >= 0.0
+        assert abs(result.objective - instance.expected_obj) <= 1e-6
+        assert result.bound is not None
+        assert result.bound <= result.objective + 1e-6
+        assert result.gap is not None
+        assert result.gap <= 1e-6
+        assert result.gap_certified is True
 
     def test_amp_reports_bound_for_tan_abs_nlp_004_010(self, caplog):
         """The nlp_004 tan/abs objective should not fall back to feasibility mode."""
@@ -3062,6 +3067,29 @@ class TestCurrentCodeWeaknesses:
         assert result.objective is not None
         tol = 1e-6 + 1e-4 * abs(instance.expected_obj)
         assert abs(result.objective - instance.expected_obj) <= tol
+
+    @pytest.mark.parametrize("problem_id", ["nlp_mi_004_010", "nlp_mi_004_011"])
+    def test_amp_certifies_tan_abs_integer_nlp_004_cases_at_issue_gap(self, problem_id):
+        """The mixed-integer tan/abs nlp_004 cases should certify the issue-79 gap."""
+        instance = MINLPTESTS_MI_BY_ID[problem_id]
+        m = instance.build_fn()
+
+        result = m.solve(
+            solver="amp",
+            nlp_solver="ipm",
+            time_limit=300.0,
+            gap_tolerance=1e-6,
+            max_iter=1000,
+        )
+
+        assert result.status == "optimal"
+        assert result.objective is not None
+        assert abs(result.objective - instance.expected_obj) <= 1e-6
+        assert result.bound is not None
+        assert result.bound <= result.objective + 1e-6
+        assert result.gap is not None
+        assert result.gap <= 1e-6
+        assert result.gap_certified is True
 
     @pytest.mark.requires_cyipopt
     def test_amp_fixed_integer_nlp_retries_with_ipopt(self):


### PR DESCRIPTION
## Summary

- Add certified piecewise tan envelopes across tan inflection points so the nlp_004 tan/abs objective gets a useful relaxation bound instead of a loose lifted bound.
- Fix inactive disaggregated piecewise McCormick rows for negative product intervals by using row-specific Big-M slack and always forcing inactive product auxiliaries to zero.
- Extend AMP square-monomial partition candidates to coupled `<=` square constraints so the mixed-integer nlp_004 sphere constraints refine all coupled square variables.
- Add focused unit coverage and opt-in integration coverage for `nlp_004_010`, `nlp_mi_004_010`, and `nlp_mi_004_011` at the issue's 1e-6 certification tolerance.

## Tests run

- `/home/bernalde/.pixi/bin/pixi exec -s python=3.12 -s ipopt -s pkg-config -s c-compiler -s cxx-compiler -s gfortran -- .venv/bin/python -m pytest python/tests/test_amp.py::test_weymouth_like_squares_extend_builtin_partition_selection python/tests/test_amp.py::test_mixed_curvature_tan_relaxation_respects_fixed_argument python/tests/test_amp.py::test_disaggregated_piecewise_bilinear_big_m_keeps_negative_endpoint_feasible -q`  
  Result: `3 passed in 0.51s`
- `/home/bernalde/.pixi/bin/pixi exec -s python=3.12 -s ipopt -s pkg-config -s c-compiler -s cxx-compiler -s gfortran -- .venv/bin/python -m pytest python/tests/test_amp_integration.py::TestCurrentCodeWeaknesses::test_amp_certifies_tan_abs_nlp_004_010_at_issue_gap -q --durations=0`  
  Result: `1 passed in 33.70s`
- `/home/bernalde/.pixi/bin/pixi exec -s python=3.12 -s ipopt -s pkg-config -s c-compiler -s cxx-compiler -s gfortran -- .venv/bin/python -m pytest 'python/tests/test_amp_integration.py::TestCurrentCodeWeaknesses::test_amp_certifies_tan_abs_integer_nlp_004_cases_at_issue_gap[nlp_mi_004_010]' -q --durations=0`  
  Result: `1 passed in 99.42s`
- `/home/bernalde/.pixi/bin/pixi exec -s python=3.12 -s ipopt -s pkg-config -s c-compiler -s cxx-compiler -s gfortran -- .venv/bin/python -m pytest 'python/tests/test_amp_integration.py::TestCurrentCodeWeaknesses::test_amp_certifies_tan_abs_integer_nlp_004_cases_at_issue_gap[nlp_mi_004_011]' -q --durations=0`  
  Result: `1 passed in 126.95s`
- `/home/bernalde/.pixi/bin/pixi exec -s python=3.12 -s ipopt -s pkg-config -s c-compiler -s cxx-compiler -s gfortran -- make test-amp-fast PYTHON=.venv/bin/python PYTEST='.venv/bin/python -m pytest' PYTEST_MEMORY_LIMIT_MB=0`  
  Result: `89 passed, 15 deselected in 1.81s`
- `/home/bernalde/.pixi/bin/pixi exec -s python=3.12 -s ipopt -s pkg-config -s c-compiler -s cxx-compiler -s gfortran -- .venv/bin/python -m ruff check python/`  
  Result: `All checks passed!`
- `/home/bernalde/.pixi/bin/pixi exec -s python=3.12 -s ipopt -s pkg-config -s c-compiler -s cxx-compiler -s gfortran -- .venv/bin/python -m ruff format --check python/`  
  Result: `278 files already formatted`
- `/home/bernalde/.pixi/bin/pixi exec -s python=3.12 -s ipopt -s pkg-config -s c-compiler -s cxx-compiler -s gfortran -- .venv/bin/python -m mypy python/discopt/`  
  Result: `Success: no issues found in 170 source files`
- `cargo test -p discopt-core`  
  Result: `255 passed`
- `/home/bernalde/.pixi/bin/pixi exec -s python=3.12 -s ipopt -s pkg-config -s c-compiler -s cxx-compiler -s gfortran -- make test PYTHON=.venv/bin/python PYTEST='.venv/bin/python -m pytest' PYTEST_MEMORY_LIMIT_MB=0`  
  Result: `2507 passed, 59 skipped, 740 deselected, 2 xfailed, 11 warnings in 534.56s`

## Notes

- A combined issue-integration pytest invocation was interrupted by a WSL crash; the three issue cases were rerun individually and passed.
- Not run locally: full `make test-all` and full `make test-amp-integration`; the issue-specific opt-in integration nodes and the documented PR-fast suite were run instead.

Closes #79
