### PR TITLE
Tighten gas square-difference bounds

### DIFF
--- a/python/discopt/_jax/nonlinear_bound_tightening.py
+++ b/python/discopt/_jax/nonlinear_bound_tightening.py
@@ -1465,6 +1465,151 @@ class QuadraticEqualityBoundsRule(NonlinearBoundTighteningRule):
         return tightened_lb, tightened_ub
 
 
+class SquareDifferenceLowerBoundRule(NonlinearBoundTighteningRule):
+    """Tighten the leading square in equalities like ``a*x^2 = b*y^2 + c*z^2``."""
+
+    name = "square_difference_lower_bound"
+
+    def _collect_square_sum(
+        self,
+        expr,
+        scale: float,
+        metadata: FlatVariableMetadata,
+        square_coeffs: dict[int, float],
+    ) -> Optional[float]:
+        const_val = _constant_value(expr)
+        if const_val is not None:
+            return scale * const_val
+
+        match = _match_scaled_square_var(expr, scale, metadata)
+        if match is not None:
+            flat_idx, coeff = match
+            square_coeffs[flat_idx] = square_coeffs.get(flat_idx, 0.0) + coeff
+            return 0.0
+
+        if isinstance(expr, UnaryOp) and expr.op == "neg":
+            return self._collect_square_sum(expr.operand, -scale, metadata, square_coeffs)
+
+        if isinstance(expr, BinaryOp):
+            if expr.op == "+":
+                left = self._collect_square_sum(expr.left, scale, metadata, square_coeffs)
+                right = self._collect_square_sum(expr.right, scale, metadata, square_coeffs)
+                if left is None or right is None:
+                    return None
+                return left + right
+            if expr.op == "-":
+                left = self._collect_square_sum(expr.left, scale, metadata, square_coeffs)
+                right = self._collect_square_sum(expr.right, -scale, metadata, square_coeffs)
+                if left is None or right is None:
+                    return None
+                return left + right
+            if expr.op == "*":
+                left_const = _constant_value(expr.left)
+                if left_const is not None:
+                    return self._collect_square_sum(
+                        expr.right, scale * left_const, metadata, square_coeffs
+                    )
+                right_const = _constant_value(expr.right)
+                if right_const is not None:
+                    return self._collect_square_sum(
+                        expr.left, scale * right_const, metadata, square_coeffs
+                    )
+            if expr.op == "/":
+                right_const = _constant_value(expr.right)
+                if right_const is not None:
+                    return self._collect_square_sum(
+                        expr.left, scale / right_const, metadata, square_coeffs
+                    )
+
+        return None
+
+    def tighten(
+        self,
+        model: Model,
+        flat_lb: np.ndarray,
+        flat_ub: np.ndarray,
+        metadata: FlatVariableMetadata,
+    ) -> tuple[np.ndarray, np.ndarray]:
+        tightened_lb = flat_lb.copy()
+        tightened_ub = flat_ub.copy()
+
+        for constraint in model._constraints:
+            if getattr(constraint, "sense", None) != "==":
+                continue
+
+            square_coeffs: dict[int, float] = {}
+            constant = self._collect_square_sum(constraint.body, 1.0, metadata, square_coeffs)
+            if constant is None:
+                continue
+            constant_term = float(constant)
+
+            square_coeffs = {
+                idx: coeff for idx, coeff in square_coeffs.items() if abs(coeff) > 1e-12
+            }
+            negative = [(idx, coeff) for idx, coeff in square_coeffs.items() if coeff < -1e-12]
+            positive = [(idx, coeff) for idx, coeff in square_coeffs.items() if coeff > 1e-12]
+            if len(negative) != 1 or not positive:
+                continue
+
+            target_idx, target_coeff = negative[0]
+            target_scale = -target_coeff
+            rhs_lb = constant_term
+            rhs_ub = constant_term
+            for flat_idx, coeff in positive:
+                sq_lb, sq_ub = QuadraticEqualityBoundsRule._square_interval(
+                    float(tightened_lb[flat_idx]),
+                    float(tightened_ub[flat_idx]),
+                )
+                rhs_lb += coeff * sq_lb
+                rhs_ub += coeff * sq_ub
+
+            if rhs_ub < -1e-12:
+                _prove_infeasible(
+                    self.name,
+                    constraint,
+                    "positive square activity cannot balance the negative square",
+                )
+
+            feasible_square_lb = max(0.0, rhs_lb / target_scale)
+            feasible_square_ub = max(0.0, rhs_ub / target_scale)
+            if feasible_square_lb > feasible_square_ub + 1e-12:
+                _prove_infeasible(
+                    self.name,
+                    constraint,
+                    "required square interval is empty",
+                )
+
+            interval = QuadraticEqualityBoundsRule._intersect_square_preimage(
+                float(tightened_lb[target_idx]),
+                float(tightened_ub[target_idx]),
+                feasible_square_lb,
+                feasible_square_ub,
+            )
+            if interval is None:
+                _prove_infeasible(
+                    self.name,
+                    constraint,
+                    f"required interval for flat variable {target_idx} is empty",
+                )
+
+            new_lb, new_ub = _apply_integrality(
+                interval[0],
+                interval[1],
+                metadata.flat_var_types[target_idx],
+            )
+            if new_lb <= new_ub:
+                tightened_lb[target_idx] = new_lb
+                tightened_ub[target_idx] = new_ub
+            else:
+                _prove_infeasible(
+                    self.name,
+                    constraint,
+                    f"required interval for flat variable {target_idx} is empty",
+                )
+
+        return tightened_lb, tightened_ub
+
+
 def _match_scaled_constant_division(expr, scale: float) -> Optional[tuple[float, object]]:
     if isinstance(expr, UnaryOp) and expr.op == "neg":
         return _match_scaled_constant_division(expr.operand, -scale)
@@ -1813,6 +1958,7 @@ class ReciprocalBoundsRule(NonlinearBoundTighteningRule):
 DEFAULT_NONLINEAR_BOUND_RULES: tuple[NonlinearBoundTighteningRule, ...] = (
     MonotoneFunctionEqualityRule(),
     QuadraticEqualityBoundsRule(),
+    SquareDifferenceLowerBoundRule(),
     MonotoneFunctionBoundsRule(),
     PositiveAffineReciprocalBoundsRule(),
     NegativePowerBoundsRule(),

--- a/python/tests/test_amp.py
+++ b/python/tests/test_amp.py
@@ -2217,6 +2217,72 @@ def test_nonlinear_tightening_counts_infinite_bounds_without_warning():
     np.testing.assert_allclose(tightened_ub, np.array([2.0, 2.0]))
 
 
+def test_square_difference_tightens_weymouth_like_upstream_pressure():
+    """Rows like f^2 = C*(p_from^2 - p_to^2) imply a lower bound on p_from."""
+    from discopt._jax.model_utils import flat_variable_bounds
+    from discopt._jax.nonlinear_bound_tightening import tighten_nonlinear_bounds
+
+    m = Model("weymouth_bound_tightening")
+    f = m.continuous("f", lb=6.0, ub=20.0)
+    p_to = m.continuous("p_to", lb=5.0, ub=10.0)
+    p_from = m.continuous("p_from", lb=0.0, ub=20.0)
+    m.subject_to(f**2 == 4.0 * (p_from**2 - p_to**2))
+    m.minimize(p_from)
+
+    flat_lb, flat_ub = flat_variable_bounds(m)
+    tightened_lb, _tightened_ub, stats = tighten_nonlinear_bounds(m, flat_lb, flat_ub)
+
+    assert "square_difference_lower_bound" in stats.applied_rules
+    assert tightened_lb[2] == pytest.approx(np.sqrt(5.0**2 + 6.0**2 / 4.0))
+
+
+def test_gas_square_difference_tightening_strengthens_root_relaxation():
+    """The gas benchmark should start AMP from a tighter Weymouth pressure box."""
+    from discopt._jax.discretization import initialize_partitions
+    from discopt._jax.milp_relaxation import build_milp_relaxation
+    from discopt._jax.model_utils import flat_variable_bounds
+    from discopt._jax.nonlinear_bound_tightening import tighten_nonlinear_bounds
+    from discopt._jax.term_classifier import classify_nonlinear_terms
+    from discopt.benchmarks.problems.gas_network_minlp import build_gas_network_minlp
+    from discopt.solvers import amp as amp_mod
+
+    m = build_gas_network_minlp()
+    terms = classify_nonlinear_terms(m)
+    raw_lb, raw_ub = flat_variable_bounds(m)
+    tightened_lb, tightened_ub, stats = tighten_nonlinear_bounds(m, raw_lb, raw_ub)
+
+    assert "square_difference_lower_bound" in stats.applied_rules
+    assert tightened_lb[4] >= 45.0
+
+    part_vars = sorted(
+        set(terms.partition_candidates)
+        | set(amp_mod._equality_square_monomial_partition_candidates(m, terms))
+    )
+
+    def root_bound(lb, ub):
+        state = initialize_partitions(
+            part_vars,
+            lb=[float(lb[i]) for i in part_vars],
+            ub=[float(ub[i]) for i in part_vars],
+            n_init=4,
+        )
+        milp_model, _varmap = build_milp_relaxation(
+            m,
+            terms,
+            state,
+            bound_override=(lb, ub),
+        )
+        result = milp_model.solve()
+        assert result.objective is not None
+        return float(result.objective)
+
+    raw_bound = root_bound(raw_lb, raw_ub)
+    tightened_bound = root_bound(tightened_lb, tightened_ub)
+
+    assert tightened_bound >= raw_bound + 0.1
+    assert tightened_bound > 2.3
+
+
 def test_oa_cut_recovery_drops_oldest_half(monkeypatch):
     """OA recovery should retry with the oldest half of cuts removed."""
     from discopt._jax.milp_relaxation import MilpRelaxationResult


### PR DESCRIPTION
Summary
- Add a nonlinear bound-tightening rule for square-difference equalities of the form `a*x^2 = b*y^2 + c*z^2`.
- This tightens Weymouth-like upstream pressure lower bounds before AMP initializes partitions.
- Add regressions for a small Weymouth-like row and for the gas-network root MILP relaxation.

Tests run
- `/home/bernalde/.pixi/bin/pixi exec -s python=3.12 -s ipopt -s pkg-config -s highspy -- /home/bernalde/.local/bin/uv run --no-sync --python .venv/bin/python -- python -m pytest python/tests/test_amp.py::test_square_difference_tightens_weymouth_like_upstream_pressure python/tests/test_amp.py::test_gas_square_difference_tightening_strengthens_root_relaxation -q`
  - Result: `2 passed in 0.99s`
- `/home/bernalde/.pixi/bin/pixi exec -s python=3.12 -s ipopt -s pkg-config -s highspy -- /home/bernalde/.local/bin/uv run --no-sync --python .venv/bin/python -- python -m pytest python/tests/test_amp.py -q`
  - Result: `107 passed in 20.85s`
- `/home/bernalde/.pixi/bin/pixi exec -s python=3.12 -s ipopt -s pkg-config -s highspy -- /home/bernalde/.local/bin/uv run --no-sync --python .venv/bin/python -- python -m pytest python/tests/test_amp_integration.py -k "nonlinear_bound_tightening or tightens_separable_quadratic or tighten_sum_of_squares or quadratic_equality_bounds" -q`
  - Result: `5 passed, 185 deselected in 0.66s`
- `/home/bernalde/.pixi/bin/pixi exec -s python=3.12 -s ruff -- /home/bernalde/.local/bin/uv run --no-sync --python .venv/bin/python -- python -m ruff check python/discopt/_jax/nonlinear_bound_tightening.py python/tests/test_amp.py`
  - Result: `All checks passed!`
- `/home/bernalde/.pixi/bin/pixi exec -s python=3.12 -s ruff -- /home/bernalde/.local/bin/uv run --no-sync --python .venv/bin/python -- python -m ruff format --check python/discopt/_jax/nonlinear_bound_tightening.py python/tests/test_amp.py`
  - Result: `2 files already formatted`
- Commit hook: `git commit -m "Fix gas square-difference tightening (#24)"`
  - Result: `ruff`, `ruff format`, and `mypy` passed; `cargo fmt` skipped with no Rust files.
- Local gas benchmark:
  - Command: `/home/bernalde/.pixi/bin/pixi exec -s python=3.12 -s ipopt -s pkg-config -s highspy -- /home/bernalde/.local/bin/uv run --no-sync --python .venv/bin/python -- python -c "... build_gas_network_minlp(); m.solve(solver='amp', nlp_solver='ipopt', time_limit=120, gap_tolerance=1e-3) ..."`
  - Result: `status=feasible`, `objective=3.0025942013493583`, `bound=2.8318019773559975`, `gap=0.05688155392980084`, `wall_time=120.01802463600325`.

Notes
- The full Python suite was not run locally; the most relevant AMP file, nearby nonlinear-bound-tightening integration subset, lint, format, and the local gas benchmark were run.
- The 120s gas benchmark still did not certify optimality locally, but this change gives AMP a stronger Weymouth pressure box and improves the tested root relaxation lower bound.
- This PR intentionally references, but does not close, #24 because additional relaxation work is still needed to certify the gas benchmark within the documented run budget.

Refs #24
