### PR TITLE
Fix nlp_008_010 square monomial lift

### DIFF
--- a/python/discopt/_jax/milp_relaxation.py
+++ b/python/discopt/_jax/milp_relaxation.py
@@ -2255,6 +2255,34 @@ def build_milp_relaxation(
             points.append(0.0)
         return _sorted_unique_points(points)
 
+    def _monomial_aux_bounds(lb_i: float, ub_i: float, n: int) -> tuple[float, float]:
+        """Return safe auxiliary bounds for ``s = x**n``.
+
+        Effectively infinite original bounds cannot support numerically useful
+        tangent/secant rows, but the auxiliary still lets constraints and
+        objectives reference the lifted monomial instead of dropping the whole
+        expression from the MILP relaxation.
+        """
+        lb_finite = _is_effectively_finite(lb_i)
+        ub_finite = _is_effectively_finite(ub_i)
+        if lb_finite and ub_finite:
+            vals = [lb_i**n, ub_i**n]
+            if n % 2 == 0 and lb_i < 0 < ub_i:
+                vals.append(0.0)
+            return min(vals), max(vals)
+
+        if n % 2 == 0:
+            lower = 0.0
+            if lb_finite and lb_i > 0.0:
+                lower = lb_i**n
+            elif ub_finite and ub_i < 0.0:
+                lower = ub_i**n
+            return float(lower), np.inf
+
+        lower = lb_i**n if lb_finite else -np.inf
+        upper = ub_i**n if ub_finite else np.inf
+        return float(lower), float(upper)
+
     # ── Assign MILP column indices ──────────────────────────────────────────
     # Original variables keep columns 0..n_orig-1. Additional columns are created
     # for lifted bilinear, trilinear, and monomial terms plus any piecewise binaries.
@@ -2349,13 +2377,8 @@ def build_milp_relaxation(
     for var_idx, n in monomial_terms:
         lb_i = float(flat_lb[var_idx])
         ub_i = float(flat_ub[var_idx])
-        if not (_is_effectively_finite(lb_i) and _is_effectively_finite(ub_i)):
-            continue
-        vals = [lb_i**n, ub_i**n]
-        if n % 2 == 0 and lb_i < 0 < ub_i:
-            vals.append(0.0)
         monomial_var_map[(var_idx, n)] = col_idx
-        all_bounds.append((min(vals), max(vals)))
+        all_bounds.append(_monomial_aux_bounds(lb_i, ub_i, n))
         integrality_flags.append(0)
         col_idx += 1
 
@@ -2368,8 +2391,8 @@ def build_milp_relaxation(
         if (
             var_idx not in disc_state.partitions
             or not _power_is_convex_on_box(n, lb_i)
-            or not np.isfinite(lb_i)
-            or not np.isfinite(ub_i)
+            or not _is_effectively_finite(lb_i)
+            or not _is_effectively_finite(ub_i)
         ):
             continue
 
@@ -3200,6 +3223,8 @@ def build_milp_relaxation(
             continue
         lb_i = float(flat_lb[var_idx])
         ub_i = float(flat_ub[var_idx])
+        if not (_is_effectively_finite(lb_i) and _is_effectively_finite(ub_i)):
+            continue
         s_col = monomial_var_map[(var_idx, n)]
         breakpoints = _guarded_partition_points(
             "monomial tangent",

--- a/python/tests/test_amp.py
+++ b/python/tests/test_amp.py
@@ -297,6 +297,27 @@ def test_shifted_square_constraint_linearizes_and_proves_infeasible(caplog):
     assert "omitting constraint" not in caplog.text
 
 
+def test_issue90_unbounded_square_constraint_linearizes_with_lifted_aux(caplog):
+    """The nlp_008_010 square constraint should get aux columns even on wide boxes."""
+    m = Model("nlp_008_010_square_core")
+    x = m.continuous("x")
+    y = m.continuous("y")
+    z = m.continuous("z", lb=0.0, ub=1.0)
+    m.minimize(y**2 + z**3)
+    m.subject_to(x**2 <= y**2 + z**2)
+
+    with caplog.at_level("WARNING", logger="discopt._jax.milp_relaxation"):
+        milp_model, varmap = _build_relaxation_for_test(m)
+        result = milp_model.solve()
+
+    assert {(0, 2), (1, 2), (2, 2), (2, 3)} <= set(varmap["monomial"])
+    assert milp_model._objective_bound_valid is True
+    assert result.status == "optimal"
+    assert result.objective == pytest.approx(0.0, abs=1e-8)
+    assert "Monomial (0, 2)" not in caplog.text
+    assert "omitting constraint" not in caplog.text
+
+
 @pytest.mark.memory_heavy
 def test_amp_reports_shifted_square_minlptests_case_infeasible():
     """Regression for MINLPTests nlp_mi_007_020."""


### PR DESCRIPTION
## Summary

- Keep monomial auxiliary columns available even when the original variable has effectively unbounded/wide bounds, so constraints can still be linearized instead of omitted.
- Skip tangent/secant monomial envelope rows for those effectively unbounded domains, where the rows are not numerically meaningful.
- Add a focused AMP regression for the `nlp_008_010` square-constraint core so `Monomial (0, 2) not in map` does not reappear.

## Tests run

- `pixi exec -s python=3.12 -s ipopt -s pkg-config -s c-compiler -s cxx-compiler -s gfortran -- uv venv --python 3.12 --allow-existing .venv` - passed
- `pixi exec -s python=3.12 -s ipopt -s pkg-config -s c-compiler -s cxx-compiler -s gfortran -- uv pip install --python .venv/bin/python maturin pytest pytest-timeout numpy scipy jax jaxlib highspy cyipopt` - passed
- `pixi exec -s python=3.12 -s ipopt -s pkg-config -s c-compiler -s cxx-compiler -s gfortran -- uv pip install --python .venv/bin/python -e ".[dev,ipopt,highs]"` - passed
- `pixi exec -s python=3.12 -s ipopt -s pkg-config -s c-compiler -s cxx-compiler -s gfortran -- .venv/bin/python -m pytest python/tests/test_amp.py::test_issue90_unbounded_square_constraint_linearizes_with_lifted_aux -q` - passed, 1 passed
- `pixi exec -s python=3.12 -s ipopt -s pkg-config -s c-compiler -s cxx-compiler -s gfortran -- .venv/bin/python -m pytest python/tests/test_amp.py::test_shifted_square_constraint_linearizes_and_proves_infeasible python/tests/test_amp.py::test_issue90_unbounded_square_constraint_linearizes_with_lifted_aux python/tests/test_amp.py::test_partitioned_square_secants_tighten_circle_superlevel_bound -q` - passed, 3 passed
- `pixi exec -s python=3.12 -s ipopt -s pkg-config -s c-compiler -s cxx-compiler -s gfortran -- make test-amp-fast PYTHON=.venv/bin/python PYTEST=.venv/bin/python\ -m\ pytest MATURIN=.venv/bin/python\ -m\ maturin RUFF=.venv/bin/python\ -m\ ruff` - passed, 93 passed, 15 deselected
- `pixi exec -s python=3.12 -s ipopt -s pkg-config -s c-compiler -s cxx-compiler -s gfortran -- make lint PYTHON=.venv/bin/python PYTEST=.venv/bin/python\ -m\ pytest MATURIN=.venv/bin/python\ -m\ maturin RUFF=.venv/bin/python\ -m\ ruff` - passed
- `pixi exec -s python=3.12 -s ipopt -s pkg-config -s c-compiler -s cxx-compiler -s gfortran -- .venv/bin/python -m pytest 'python/tests/test_amp_integration.py::TestCurrentCodeWeaknesses::test_amp_recovers_remaining_pure_continuous_minlptests_cases[nlp_008_010]' -q --tb=short --timeout=120` - passed, 1 passed
- `pixi exec -s python=3.12 -s ipopt -s pkg-config -s c-compiler -s cxx-compiler -s gfortran -- .venv/bin/python -m pytest 'python/tests/test_amp_integration.py::TestCurrentCodeWeaknesses::test_amp_recovers_remaining_pure_continuous_minlptests_cases[nlp_008_010]' -q --tb=short --timeout=120 --log-cli-level=WARNING` - passed, 1 passed; warning output did not include `omitting constraint` or `Monomial (0, 2)`
- `pixi exec -s python=3.12 -s ipopt -s pkg-config -s c-compiler -s cxx-compiler -s gfortran -- .venv/bin/python -m mypy python/discopt/_jax/milp_relaxation.py` - passed
- Pre-commit on commit: ruff, ruff format, mypy passed; cargo fmt skipped with no files to check

## Notes

- `make test` was attempted twice in the same fresh `.venv`; both runs aborted before reaching the changed AMP tests, in `python/tests/test_alphabb.py::TestEigenvalueMethods::test_gershgorin_diagonal` while JAX was lowering `jnp.diag`. The exact test passes when run alone, so this appears to be a local JAX process abort outside this PR.

Closes #90
