### PR TITLE
Fix AMP OA cut coverage diagnostics

### DIFF
--- a/python/discopt/_jax/cutting_planes.py
+++ b/python/discopt/_jax/cutting_planes.py
@@ -47,6 +47,20 @@ class LinearCut(NamedTuple):
     sense: str
 
 
+class OACutSkip(NamedTuple):
+    """Structured reason an evaluator constraint did not receive a direct OA cut."""
+
+    constraint_index: int
+    reason: str
+
+
+class OACutGenerationReport(NamedTuple):
+    """Direct evaluator OA cuts plus per-row skip reasons."""
+
+    cuts: list[LinearCut]
+    skipped: list[OACutSkip]
+
+
 # ---------------------------------------------------------------------------
 # RLT (Reformulation-Linearization Technique) cuts
 #
@@ -277,9 +291,29 @@ def generate_oa_cuts_from_evaluator(
     Returns:
         List of LinearCut objects, one per constraint.
     """
+    return generate_oa_cuts_from_evaluator_report(
+        evaluator,
+        x_sol,
+        constraint_senses=constraint_senses,
+        convex_mask=convex_mask,
+    ).cuts
+
+
+def generate_oa_cuts_from_evaluator_report(
+    evaluator,
+    x_sol: np.ndarray,
+    constraint_senses: Optional[list[str]] = None,
+    convex_mask: Optional[list[bool]] = None,
+) -> OACutGenerationReport:
+    """Generate direct evaluator OA cuts and record intentionally skipped rows.
+
+    A row marked false in ``convex_mask`` is not safe for direct tangent OA, so
+    it is skipped with the ``"not_certified_convex"`` reason. The existing
+    :func:`generate_oa_cuts_from_evaluator` API returns only ``report.cuts``.
+    """
     m = evaluator.n_constraints
     if m == 0:
-        return []
+        return OACutGenerationReport(cuts=[], skipped=[])
 
     cons_vals = evaluator.evaluate_constraints(x_sol)
     jac = evaluator.evaluate_jacobian(x_sol)
@@ -288,8 +322,10 @@ def generate_oa_cuts_from_evaluator(
         constraint_senses = ["<="] * m
 
     cuts = []
+    skipped = []
     for k in range(m):
         if convex_mask is not None and not convex_mask[k]:
+            skipped.append(OACutSkip(constraint_index=k, reason="not_certified_convex"))
             continue
         grad_k = jac[k, :]
         g_k = float(cons_vals[k])
@@ -297,7 +333,7 @@ def generate_oa_cuts_from_evaluator(
         cut = generate_oa_cut(grad_k, g_k, x_sol, sense=sense)
         cuts.append(cut)
 
-    return cuts
+    return OACutGenerationReport(cuts=cuts, skipped=skipped)
 
 
 QuadraticPolynomial = dict[tuple[int, ...], float]

--- a/python/discopt/_jax/cutting_planes.py
+++ b/python/discopt/_jax/cutting_planes.py
@@ -273,6 +273,7 @@ def generate_oa_cuts_from_evaluator(
     x_sol: np.ndarray,
     constraint_senses: Optional[list[str]] = None,
     convex_mask: Optional[list[bool]] = None,
+    skip_reasons: Optional[list[Optional[str]]] = None,
 ) -> list[LinearCut]:
     """Generate OA cuts for all constraints using an NLPEvaluator.
 
@@ -296,6 +297,7 @@ def generate_oa_cuts_from_evaluator(
         x_sol,
         constraint_senses=constraint_senses,
         convex_mask=convex_mask,
+        skip_reasons=skip_reasons,
     ).cuts
 
 
@@ -304,11 +306,13 @@ def generate_oa_cuts_from_evaluator_report(
     x_sol: np.ndarray,
     constraint_senses: Optional[list[str]] = None,
     convex_mask: Optional[list[bool]] = None,
+    skip_reasons: Optional[list[Optional[str]]] = None,
 ) -> OACutGenerationReport:
     """Generate direct evaluator OA cuts and record intentionally skipped rows.
 
     A row marked false in ``convex_mask`` is not safe for direct tangent OA, so
-    it is skipped with the ``"not_certified_convex"`` reason. The existing
+    it is skipped with the corresponding ``skip_reasons[k]`` value, or
+    ``"not_certified_convex"`` when no reason is supplied. The existing
     :func:`generate_oa_cuts_from_evaluator` API returns only ``report.cuts``.
     """
     m = evaluator.n_constraints
@@ -325,7 +329,10 @@ def generate_oa_cuts_from_evaluator_report(
     skipped = []
     for k in range(m):
         if convex_mask is not None and not convex_mask[k]:
-            skipped.append(OACutSkip(constraint_index=k, reason="not_certified_convex"))
+            reason = "not_certified_convex"
+            if skip_reasons is not None and skip_reasons[k] is not None:
+                reason = str(skip_reasons[k])
+            skipped.append(OACutSkip(constraint_index=k, reason=reason))
             continue
         grad_k = jac[k, :]
         g_k = float(cons_vals[k])

--- a/python/discopt/solvers/amp.py
+++ b/python/discopt/solvers/amp.py
@@ -2149,6 +2149,8 @@ def _solve_amp_impl(
             nonlinear_bt_stats.n_tightened,
             ", ".join(nonlinear_bt_stats.applied_rules),
         )
+    if root_changed or nonlinear_bt_stats.n_tightened > 0:
+        _apply_flat_bounds_to_model(model, flat_lb, flat_ub)
     evaluator = NLPEvaluator(model)
     constraint_lb, constraint_ub = _infer_constraint_bounds(model)
     deadline = t_start + time_limit
@@ -2159,10 +2161,19 @@ def _solve_amp_impl(
         constraint_lb,
         constraint_ub,
     )
-    oa_convexity = classify_oa_cut_convexity(model)
-    if evaluator.n_constraints > 0 and not all(oa_convexity.constraint_mask):
+    oa_convexity = classify_oa_cut_convexity(model, use_certificate=True)
+    direct_oa_skipped_rows = [
+        idx for idx, is_convex in enumerate(oa_convexity.constraint_mask) if not is_convex
+    ]
+    if evaluator.n_constraints > 0 and direct_oa_skipped_rows:
         logger.warning(
-            "AMP: generating OA cuts only for %d of %d constraints classified convex",
+            "AMP: direct OA skips %d of %d constraint rows not certified convex: rows=%s",
+            len(direct_oa_skipped_rows),
+            len(oa_convexity.constraint_mask),
+            direct_oa_skipped_rows,
+        )
+        logger.info(
+            "AMP: direct OA enabled for %d of %d constraint rows certified convex",
             sum(1 for is_convex in oa_convexity.constraint_mask if is_convex),
             len(oa_convexity.constraint_mask),
         )
@@ -2419,19 +2430,25 @@ def _solve_amp_impl(
         try:
             from discopt._jax.cutting_planes import (
                 generate_alphabb_quadratic_oa_cuts_from_evaluator,
-                generate_oa_cuts_from_evaluator,
+                generate_oa_cuts_from_evaluator_report,
             )
             from discopt.modeling.core import Constraint
 
             _x_orig = x_incumbent[:n_orig]
             _senses = [c.sense for c in model._constraints if isinstance(c, Constraint)]
-            direct_cuts = generate_oa_cuts_from_evaluator(
+            direct_report = generate_oa_cuts_from_evaluator_report(
                 evaluator,
                 _x_orig,
                 constraint_senses=_senses,
                 convex_mask=oa_convexity.constraint_mask,
             )
-            appended += _append_linearized_cuts(direct_cuts)
+            if direct_report.skipped:
+                logger.debug(
+                    "AMP iter %d: direct OA skipped rows: %s",
+                    iteration_idx,
+                    list(direct_report.skipped),
+                )
+            appended += _append_linearized_cuts(direct_report.cuts)
 
             has_nonconvex_oa_row = not all(oa_convexity.constraint_mask)
             had_effectively_unbounded = any(

--- a/python/discopt/solvers/amp.py
+++ b/python/discopt/solvers/amp.py
@@ -39,6 +39,7 @@ from discopt._jax.nonlinear_bound_tightening import (
 from discopt.modeling.core import (
     BinaryOp,
     Constant,
+    Constraint,
     Expression,
     FunctionCall,
     IndexExpression,
@@ -1134,6 +1135,121 @@ def _square_monomial_vars_in_expr(expr: Expression, model: Model) -> set[int]:
     return square_vars
 
 
+def _expr_variable_indices(expr: Expression, model: Model) -> set[int]:
+    """Collect flat variable indices referenced by an expression."""
+    flat_idx = _flat_var_index(expr, model)
+    if flat_idx is not None:
+        return {flat_idx}
+    if isinstance(expr, Variable):
+        start = _compute_var_offset(expr, model)
+        return set(range(start, start + expr.size))
+    if isinstance(expr, (Constant, IndexExpression)):
+        return set()
+    if isinstance(expr, BinaryOp):
+        left = _expr_variable_indices(expr.left, model)
+        right = _expr_variable_indices(expr.right, model)
+        return left | right
+    if isinstance(expr, UnaryOp):
+        return _expr_variable_indices(expr.operand, model)
+    if isinstance(expr, FunctionCall):
+        indices: set[int] = set()
+        for arg in expr.args:
+            indices.update(_expr_variable_indices(arg, model))
+        return indices
+    if isinstance(expr, MatMulExpression):
+        left = _expr_variable_indices(expr.left, model)
+        right = _expr_variable_indices(expr.right, model)
+        return left | right
+    if isinstance(expr, SumExpression):
+        return _expr_variable_indices(expr.operand, model)
+    if isinstance(expr, SumOverExpression):
+        indices = set()
+        for term in expr.terms:
+            indices.update(_expr_variable_indices(term, model))
+        return indices
+    return set()
+
+
+def _expr_has_function(expr: Expression, names: set[str]) -> bool:
+    """Return true when an expression tree calls any named function."""
+    if isinstance(expr, FunctionCall):
+        return expr.func_name in names or any(_expr_has_function(arg, names) for arg in expr.args)
+    if isinstance(expr, BinaryOp):
+        return _expr_has_function(expr.left, names) or _expr_has_function(expr.right, names)
+    if isinstance(expr, UnaryOp):
+        return _expr_has_function(expr.operand, names)
+    if isinstance(expr, MatMulExpression):
+        return _expr_has_function(expr.left, names) or _expr_has_function(expr.right, names)
+    if isinstance(expr, SumExpression):
+        return _expr_has_function(expr.operand, names)
+    if isinstance(expr, SumOverExpression):
+        return any(_expr_has_function(term, names) for term in expr.terms)
+    if isinstance(expr, IndexExpression) and not isinstance(expr.base, Variable):
+        return _expr_has_function(expr.base, names)
+    return False
+
+
+def _expr_all_vars_fixed(
+    expr: Expression,
+    model: Model,
+    flat_lb: np.ndarray,
+    flat_ub: np.ndarray,
+    tol: float = 1e-9,
+) -> bool:
+    """Return true when all variables used by an expression have fixed bounds."""
+    indices = _expr_variable_indices(expr, model)
+    if not indices:
+        return False
+    return all(float(flat_ub[idx]) - float(flat_lb[idx]) <= tol for idx in indices)
+
+
+def _direct_oa_skip_reasons(
+    model: Model,
+    convex_mask: list[bool],
+    flat_lb: np.ndarray,
+    flat_ub: np.ndarray,
+) -> list[str | None]:
+    """Explain why each constraint row is excluded from direct tangent OA."""
+    from discopt._jax.convexity.rules import Curvature, classify_expr
+    from discopt._jax.cutting_planes import _quadratic_polynomial
+
+    reasons: list[str | None] = []
+    for idx, is_convex in enumerate(convex_mask):
+        if is_convex:
+            reasons.append(None)
+            continue
+
+        constraint = model._constraints[idx]
+        if not isinstance(constraint, Constraint):
+            reasons.append("unsupported_constraint_type")
+            continue
+
+        expr = constraint.body
+        if _expr_all_vars_fixed(expr, model, flat_lb, flat_ub):
+            reasons.append("fixed_nonlinear_row")
+            continue
+        if constraint.sense == "==":
+            reasons.append("nonaffine_equality")
+            continue
+
+        curvature = classify_expr(expr, model)
+        if (constraint.sense == "<=" and curvature == Curvature.CONCAVE) or (
+            constraint.sense == ">=" and curvature == Curvature.CONVEX
+        ):
+            reasons.append("opposite_curvature_for_direct_oa")
+            continue
+
+        if _quadratic_polynomial(expr, model) is not None:
+            reasons.append("nonconvex_quadratic_alpha_bb_candidate")
+            continue
+        if _expr_has_function(expr, {"sin", "cos", "tan"}):
+            reasons.append("trigonometric_not_certified_convex")
+            continue
+
+        reasons.append("not_certified_convex")
+    return reasons
+
+
 def _equality_square_monomial_partition_candidates(model: Model, terms: Any) -> list[int]:
     """Select coupled square monomials that benefit from AMP refinement.
 
@@ -2162,8 +2278,14 @@ def _solve_amp_impl(
         constraint_ub,
     )
     oa_convexity = classify_oa_cut_convexity(model, use_certificate=True)
+    direct_oa_skip_reasons = _direct_oa_skip_reasons(
+        model,
+        oa_convexity.constraint_mask,
+        flat_lb,
+        flat_ub,
+    )
     direct_oa_skipped_rows = [
-        idx for idx, is_convex in enumerate(oa_convexity.constraint_mask) if not is_convex
+        (idx, reason) for idx, reason in enumerate(direct_oa_skip_reasons) if reason is not None
     ]
     if evaluator.n_constraints > 0 and direct_oa_skipped_rows:
         logger.warning(
@@ -2432,7 +2554,6 @@ def _solve_amp_impl(
                 generate_alphabb_quadratic_oa_cuts_from_evaluator,
                 generate_oa_cuts_from_evaluator_report,
             )
-            from discopt.modeling.core import Constraint
 
             _x_orig = x_incumbent[:n_orig]
             _senses = [c.sense for c in model._constraints if isinstance(c, Constraint)]
@@ -2441,6 +2562,7 @@ def _solve_amp_impl(
                 _x_orig,
                 constraint_senses=_senses,
                 convex_mask=oa_convexity.constraint_mask,
+                skip_reasons=direct_oa_skip_reasons,
             )
             if direct_report.skipped:
                 logger.debug(

--- a/python/tests/test_amp.py
+++ b/python/tests/test_amp.py
@@ -2372,6 +2372,7 @@ def test_oa_cut_generation_receives_convex_constraint_mask(monkeypatch):
     from discopt.solvers import amp as amp_mod
 
     recorded_masks = []
+    recorded_reasons = []
     classify_calls = []
 
     def fake_classify(model, **kwargs):
@@ -2405,6 +2406,7 @@ def test_oa_cut_generation_receives_convex_constraint_mask(monkeypatch):
 
     def fake_generate_report(*args, **kwargs):
         recorded_masks.append(list(kwargs["convex_mask"]))
+        recorded_reasons.append(list(kwargs["skip_reasons"]))
         return cutting_planes.OACutGenerationReport(cuts=[], skipped=[])
 
     monkeypatch.setattr(
@@ -2431,6 +2433,7 @@ def test_oa_cut_generation_receives_convex_constraint_mask(monkeypatch):
     assert result.status in ("optimal", "feasible")
     assert classify_calls == [{"use_certificate": True}]
     assert recorded_masks == [[True, False]]
+    assert recorded_reasons == [[None, "opposite_curvature_for_direct_oa"]]
 
 
 def test_amp_oa_classification_uses_tightened_bounds_for_reciprocal_rows(monkeypatch):
@@ -2490,6 +2493,160 @@ def test_amp_oa_classification_uses_tightened_bounds_for_reciprocal_rows(monkeyp
 
     assert result.status in ("optimal", "feasible")
     assert recorded_masks == [[True, True, False]]
+
+
+def _unwrap_minlptests_case(case):
+    return case.values[0] if hasattr(case, "values") else case
+
+
+def _issue91_minlptests_model(group: str, problem_id: str) -> Model:
+    from test_minlptests import MINLPTESTS_CVX_BY_ID, NLP_INSTANCES, NLP_MI_INSTANCES
+
+    if group == "cvx":
+        return MINLPTESTS_CVX_BY_ID[problem_id].build_fn()
+    instances = NLP_MI_INSTANCES if group == "mi" else NLP_INSTANCES
+    by_id = {
+        instance.problem_id: instance
+        for instance in (_unwrap_minlptests_case(case) for case in instances)
+    }
+    return by_id[problem_id].build_fn()
+
+
+def _issue91_oa_mask_and_skip_reasons(model: Model) -> tuple[list[bool], list[str | None]]:
+    from discopt._jax.convexity import classify_oa_cut_convexity
+    from discopt._jax.model_utils import flat_variable_bounds
+    from discopt._jax.nonlinear_bound_tightening import tighten_nonlinear_bounds
+    from discopt.modeling.core import VarType
+    from discopt.solvers import amp as amp_mod
+    from discopt.solvers._root_presolve import tighten_root_bounds_with_fbbt
+
+    flat_lb, flat_ub = flat_variable_bounds(model)
+    int_offsets = []
+    int_sizes = []
+    offset = 0
+    for variable in model._variables:
+        if variable.var_type in (VarType.BINARY, VarType.INTEGER):
+            int_offsets.append(offset)
+            int_sizes.append(variable.size)
+        offset += variable.size
+
+    flat_lb, flat_ub, root_infeasible, _root_changed = tighten_root_bounds_with_fbbt(
+        model,
+        flat_lb,
+        flat_ub,
+        int_offsets,
+        int_sizes,
+    )
+    assert not root_infeasible
+
+    flat_lb, flat_ub, nonlinear_bt_stats = tighten_nonlinear_bounds(model, flat_lb, flat_ub)
+    assert not nonlinear_bt_stats.infeasible
+    amp_mod._apply_flat_bounds_to_model(model, flat_lb, flat_ub)
+
+    oa_convexity = classify_oa_cut_convexity(model, use_certificate=True)
+    reasons = amp_mod._direct_oa_skip_reasons(
+        model,
+        oa_convexity.constraint_mask,
+        flat_lb,
+        flat_ub,
+    )
+    return oa_convexity.constraint_mask, reasons
+
+
+@pytest.mark.parametrize(
+    ("group", "problem_id", "expected_mask", "expected_reasons"),
+    [
+        pytest.param(
+            "cvx",
+            "nlp_cvx_106_010",
+            [False, False],
+            ["trigonometric_not_certified_convex", "trigonometric_not_certified_convex"],
+            id="nlp_cvx_106_010",
+        ),
+        pytest.param(
+            "cvx",
+            "nlp_cvx_106_011",
+            [False, False],
+            ["trigonometric_not_certified_convex", "trigonometric_not_certified_convex"],
+            id="nlp_cvx_106_011",
+        ),
+        pytest.param(
+            "nlp",
+            "nlp_002_010",
+            [False, False],
+            ["nonaffine_equality", "nonaffine_equality"],
+            id="nlp_002_010",
+        ),
+        *[
+            pytest.param(
+                "nlp",
+                f"nlp_003_0{suffix}",
+                [True, False],
+                [None, "trigonometric_not_certified_convex"],
+                id=f"nlp_003_0{suffix}",
+            )
+            for suffix in range(10, 17)
+        ],
+        pytest.param(
+            "nlp",
+            "nlp_005_010",
+            [True, True, False],
+            [None, None, "opposite_curvature_for_direct_oa"],
+            id="nlp_005_010",
+        ),
+        pytest.param(
+            "nlp",
+            "nlp_008_010",
+            [True, False, True],
+            [None, "nonconvex_quadratic_alpha_bb_candidate", None],
+            id="nlp_008_010",
+        ),
+        pytest.param(
+            "nlp",
+            "nlp_008_011",
+            [True, False, True],
+            [None, "nonconvex_quadratic_alpha_bb_candidate", None],
+            id="nlp_008_011",
+        ),
+        pytest.param(
+            "mi",
+            "nlp_mi_002_010",
+            [True, False],
+            [None, "fixed_nonlinear_row"],
+            id="nlp_mi_002_010",
+        ),
+        *[
+            pytest.param(
+                "mi",
+                f"nlp_mi_003_0{suffix}",
+                [True, False],
+                [None, "trigonometric_not_certified_convex"],
+                id=f"nlp_mi_003_0{suffix}",
+            )
+            for suffix in range(10, 17)
+        ],
+        pytest.param(
+            "mi",
+            "nlp_mi_005_010",
+            [True, True, False],
+            [None, None, "opposite_curvature_for_direct_oa"],
+            id="nlp_mi_005_010",
+        ),
+    ],
+)
+def test_issue91_minlptests_oa_rows_are_cut_or_explained(
+    group,
+    problem_id,
+    expected_mask,
+    expected_reasons,
+):
+    """Every issue 91 motivating row should be cut or have a stable direct-OA skip reason."""
+    model = _issue91_minlptests_model(group, problem_id)
+
+    mask, reasons = _issue91_oa_mask_and_skip_reasons(model)
+
+    assert mask == expected_mask
+    assert reasons == expected_reasons
 
 
 def test_alphabb_quadratic_oa_cut_covers_issue_63_row():

--- a/python/tests/test_amp.py
+++ b/python/tests/test_amp.py
@@ -2372,11 +2372,16 @@ def test_oa_cut_generation_receives_convex_constraint_mask(monkeypatch):
     from discopt.solvers import amp as amp_mod
 
     recorded_masks = []
+    classify_calls = []
+
+    def fake_classify(model, **kwargs):
+        classify_calls.append(kwargs)
+        return OACutConvexity(objective_is_convex=True, constraint_mask=[True, False])
 
     monkeypatch.setattr(
         convexity_mod,
         "classify_oa_cut_convexity",
-        lambda model: OACutConvexity(objective_is_convex=True, constraint_mask=[True, False]),
+        fake_classify,
     )
     monkeypatch.setattr(
         amp_mod,
@@ -2398,11 +2403,15 @@ def test_oa_cut_generation_receives_convex_constraint_mask(monkeypatch):
         lambda *args, **kwargs: (np.array([1.0, 1.0], dtype=np.float64), 2.0),
     )
 
-    def fake_generate(*args, **kwargs):
+    def fake_generate_report(*args, **kwargs):
         recorded_masks.append(list(kwargs["convex_mask"]))
-        return []
+        return cutting_planes.OACutGenerationReport(cuts=[], skipped=[])
 
-    monkeypatch.setattr(cutting_planes, "generate_oa_cuts_from_evaluator", fake_generate)
+    monkeypatch.setattr(
+        cutting_planes,
+        "generate_oa_cuts_from_evaluator_report",
+        fake_generate_report,
+    )
 
     m = Model("amp_oa_mask")
     x = m.continuous("x", lb=0, ub=2, shape=(2,))
@@ -2420,7 +2429,67 @@ def test_oa_cut_generation_receives_convex_constraint_mask(monkeypatch):
     )
 
     assert result.status in ("optimal", "feasible")
+    assert classify_calls == [{"use_certificate": True}]
     assert recorded_masks == [[True, False]]
+
+
+def test_amp_oa_classification_uses_tightened_bounds_for_reciprocal_rows(monkeypatch):
+    """Root bound tightening should feed OA convexity classification."""
+    import discopt._jax.cutting_planes as cutting_planes
+    from discopt._jax.milp_relaxation import MilpRelaxationResult
+    from discopt.solvers import amp as amp_mod
+
+    recorded_masks = []
+
+    monkeypatch.setattr(
+        amp_mod,
+        "_solve_milp_with_oa_recovery",
+        lambda **kwargs: (
+            MilpRelaxationResult(
+                status="optimal",
+                objective=0.0,
+                x=np.array([1.0, 1.0], dtype=np.float64),
+            ),
+            {},
+            [],
+            1,
+        ),
+    )
+    monkeypatch.setattr(
+        amp_mod,
+        "_solve_best_nlp_candidate",
+        lambda *args, **kwargs: (np.array([1.0, 1.0], dtype=np.float64), 2.0),
+    )
+
+    def fake_generate_report(*args, **kwargs):
+        recorded_masks.append(list(kwargs["convex_mask"]))
+        return cutting_planes.OACutGenerationReport(cuts=[], skipped=[])
+
+    monkeypatch.setattr(
+        cutting_planes,
+        "generate_oa_cuts_from_evaluator_report",
+        fake_generate_report,
+    )
+
+    m = Model("amp_reciprocal_oa_bounds")
+    x = m.continuous("x", lb=0.0)
+    y = m.continuous("y", lb=0.0)
+    m.minimize(x + y)
+    m.subject_to(y >= 1 / (x + 0.1) - 0.5)
+    m.subject_to(x >= y ** (-2) - 0.5)
+    m.subject_to(4 / (x + y + 0.1) >= 1)
+
+    result = m.solve(
+        solver="amp",
+        apply_partitioning=False,
+        skip_convex_check=True,
+        presolve_bt=False,
+        max_iter=1,
+        time_limit=5,
+    )
+
+    assert result.status in ("optimal", "feasible")
+    assert recorded_masks == [[True, True, False]]
 
 
 def test_alphabb_quadratic_oa_cut_covers_issue_63_row():

--- a/python/tests/test_cutting_planes.py
+++ b/python/tests/test_cutting_planes.py
@@ -29,11 +29,14 @@ from discopt._jax.cutting_planes import (
     BilinearTerm,
     CutPool,
     LinearCut,
+    OACutGenerationReport,
+    OACutSkip,
     detect_bilinear_terms,
     generate_cuts_at_node,
     generate_lift_and_project_cut,
     generate_oa_cut,
     generate_oa_cuts_from_evaluator,
+    generate_oa_cuts_from_evaluator_report,
     generate_objective_oa_cut,
     generate_rlt_cuts,
     is_cut_violated,
@@ -331,6 +334,29 @@ class TestOACutsFromEvaluator:
         assert len(cuts) == 1
         np.testing.assert_allclose(cuts[0].coeffs, [1.0, 1.0], atol=1e-6)
         assert cuts[0].sense == "<="
+
+    def test_report_records_nonconvex_mask_skip_reason(self):
+        """The report exposes why direct evaluator OA skipped a row."""
+        from discopt._jax.nlp_evaluator import NLPEvaluator
+        from discopt.modeling.core import Model
+
+        m = Model("test_oa_report")
+        x = m.continuous("x", shape=(2,), lb=-2.0, ub=2.0)
+        m.minimize(x[0] + x[1])
+        m.subject_to(x[0] + x[1] <= 1.0, name="linear")
+        m.subject_to(x[0] * x[1] <= 0.25, name="bilinear")
+        evaluator = NLPEvaluator(m)
+
+        report = generate_oa_cuts_from_evaluator_report(
+            evaluator,
+            np.array([0.5, 0.5]),
+            constraint_senses=["<=", "<="],
+            convex_mask=[True, False],
+        )
+
+        assert isinstance(report, OACutGenerationReport)
+        assert len(report.cuts) == 1
+        assert report.skipped == [OACutSkip(constraint_index=1, reason="not_certified_convex")]
 
 
 class TestOASeparation:

--- a/python/tests/test_cutting_planes.py
+++ b/python/tests/test_cutting_planes.py
@@ -352,11 +352,12 @@ class TestOACutsFromEvaluator:
             np.array([0.5, 0.5]),
             constraint_senses=["<=", "<="],
             convex_mask=[True, False],
+            skip_reasons=[None, "bilinear_not_direct_oa"],
         )
 
         assert isinstance(report, OACutGenerationReport)
         assert len(report.cuts) == 1
-        assert report.skipped == [OACutSkip(constraint_index=1, reason="not_certified_convex")]
+        assert report.skipped == [OACutSkip(constraint_index=1, reason="bilinear_not_direct_oa")]
 
 
 class TestOASeparation:


### PR DESCRIPTION
Summary:
- Apply tightened root/nonlinear bounds back to the AMP model before direct-OA convexity classification, so bound-sensitive reciprocal rows can be certified for OA cuts.
- Use the existing convexity certificate for AMP direct-OA masks.
- Add structured direct-OA skip reasons and pass them through the evaluator OA report, so intentionally skipped rows are distinguishable from missing cut generation.
- Add a full regression over the MINLPTests instances listed in issue #91; every listed row is now either direct-OA enabled or has a stable skip reason.

Tests run:
- `/home/bernalde/.pixi/bin/pixi exec -s python .venv/bin/python -m pytest python/tests/test_amp.py::test_oa_cut_generation_receives_convex_constraint_mask python/tests/test_amp.py::test_issue91_minlptests_oa_rows_are_cut_or_explained python/tests/test_cutting_planes.py::TestOACutsFromEvaluator::test_report_records_nonconvex_mask_skip_reason -q --tb=short` -> 24 passed.
- `/home/bernalde/.pixi/bin/pixi exec -s python make test-amp-fast PYTHON=.venv/bin/python PYTEST='.venv/bin/python -m pytest'` -> 116 passed, 15 deselected.
- `/home/bernalde/.pixi/bin/pixi exec -s python .venv/bin/python -m pytest python/tests/test_cutting_planes.py -q --tb=short` -> 72 passed.
- `/home/bernalde/.pixi/bin/pixi exec -s python make lint RUFF=.venv/bin/ruff` -> passed.
- `/home/bernalde/.pixi/bin/pixi exec -s python .venv/bin/python -m mypy python/discopt/` -> success, no issues found in 170 source files.
- `/home/bernalde/.pixi/bin/pixi exec -s python .venv/bin/python -m pytest python/tests/test_alphabb.py::TestEigenvalueMethods::test_gershgorin_diagonal -q --tb=short` -> 1 passed.

Notes about tests not run:
- `/home/bernalde/.pixi/bin/pixi exec -s python make test PYTHON=.venv/bin/python PYTEST='.venv/bin/python -m pytest'` aborted early in unrelated `python/tests/test_alphabb.py::TestEigenvalueMethods::test_gershgorin_diagonal` inside JAX lowering. Re-running that exact test in isolation passed.
- `make test-all` was not run after the PR-fast suite abort.

Closes #91
