### PR TITLE
Merge upstream/main into amp

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,9 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  schedule:
+    # Nightly coverage refresh (07:30 UTC ≈ 03:30 ET).
+    - cron: "30 7 * * *"
 
 # Cancel superseded runs on the same PR/branch — saves CI minutes when
 # pushes land in quick succession.
@@ -109,11 +112,12 @@ jobs:
 
   python-coverage:
     name: Python coverage (3.12, ubuntu)
-    # Run coverage on main pushes and on PRs explicitly opted in via the
-    # `coverage` label.  Keeping it off the default PR path is what gets
-    # the per-PR turnaround under 2 minutes (issue #68).
+    # Run coverage nightly (scheduled), or on PRs explicitly opted in via the
+    # `coverage` label. Skipped on plain main pushes so the post-merge wall
+    # clock isn't gated on the coverage instrumentation tax (~100s vs the
+    # fast job). See issue #68 for the per-PR/main turnaround target.
     if: >-
-      github.event_name == 'push' ||
+      github.event_name == 'schedule' ||
       contains(github.event.pull_request.labels.*.name, 'coverage')
     runs-on: ubuntu-latest
     steps:

--- a/Makefile
+++ b/Makefile
@@ -171,8 +171,11 @@ lint:
 # Common flags for the PR-fast tier (kept in sync with .github/workflows/ci.yml).
 # `not slow` excludes the heavy backend matrix; the curated PR correctness
 # subset (test_pr_correctness.py) is *not* slow-marked so it still runs.
+# `-n auto --dist loadgroup` parallelizes across CPUs while keeping
+# class-shared fixtures pinned to one worker (matches CI).
 PYTEST_FAST_FLAGS := --timeout=120 -m "not slow" \
-    --ignore=python/tests/test_correctness.py
+    --ignore=python/tests/test_correctness.py \
+    -n auto --dist loadgroup
 
 # File groups for slice targets. A test file may appear in more than one group.
 TEST_MODELING := \

--- a/discopt_benchmarks/benchmarks/runner.py
+++ b/discopt_benchmarks/benchmarks/runner.py
@@ -24,9 +24,10 @@ from benchmarks.metrics import (
 @dataclass
 class SolverConfig:
     """Configuration for a solver executable."""
+
     name: str
     command: str
-    solver_type: str          # "internal" (discopt) or "external"
+    solver_type: str  # "internal" (discopt) or "external"
     nl_interface: bool = False
     options: dict = None
 
@@ -38,6 +39,7 @@ class SolverConfig:
 @dataclass
 class BenchmarkConfig:
     """Configuration for a benchmark run."""
+
     suite_name: str
     time_limit: int = 3600
     memory_limit_mb: int = 32768
@@ -104,12 +106,14 @@ class BenchmarkRunner:
         total = len(instances) * len(self.config.solvers) * self.config.num_runs
         completed = 0
 
-        print(f"\n{'='*70}")
+        print(f"\n{'=' * 70}")
         print(f"discopt Benchmark: {self.config.suite_name}")
-        print(f"Instances: {len(instances)} | Solvers: {len(self.config.solvers)} "
-              f"| Runs: {self.config.num_runs} | Total: {total}")
+        print(
+            f"Instances: {len(instances)} | Solvers: {len(self.config.solvers)} "
+            f"| Runs: {self.config.num_runs} | Total: {total}"
+        )
         print(f"Time limit: {self.config.time_limit}s | Memory: {self.config.memory_limit_mb}MB")
-        print(f"{'='*70}\n")
+        print(f"{'=' * 70}\n")
 
         for solver_config in self.config.solvers:
             print(f"\n--- Solver: {solver_config.name} ---")
@@ -118,17 +122,18 @@ class BenchmarkRunner:
                 best_result = None
 
                 for run_idx in range(self.config.num_runs):
-                    result = self._run_single(
-                        solver_config, instance_name, run_idx
-                    )
+                    result = self._run_single(solver_config, instance_name, run_idx)
                     run_times.append(result.wall_time)
 
                     # Keep the result from the median-time run
-                    if best_result is None or (
-                        result.is_solved and not best_result.is_solved
-                    ) or (
-                        result.is_solved and best_result.is_solved
-                        and result.wall_time < best_result.wall_time
+                    if (
+                        best_result is None
+                        or (result.is_solved and not best_result.is_solved)
+                        or (
+                            result.is_solved
+                            and best_result.is_solved
+                            and result.wall_time < best_result.wall_time
+                        )
                     ):
                         best_result = result
 
@@ -147,9 +152,7 @@ class BenchmarkRunner:
                             )
 
                 # Check determinism
-                if self.config.num_runs > 1 and all(
-                    t < float("inf") for t in run_times
-                ):
+                if self.config.num_runs > 1 and all(t < float("inf") for t in run_times):
                     cv = _coefficient_of_variation(run_times)
                     if cv > 0.1:
                         print(
@@ -217,7 +220,15 @@ class BenchmarkRunner:
         Run discopt solver on a .nl instance.
 
         Uses the Python API directly, capturing layer profiling data.
+
+        A daemon-thread watchdog joins with ``time_limit + grace`` so a
+        single hung instance (e.g. a JAX while_loop that ignored the
+        wall clock, see issue #80) cannot hold the whole sweep hostage.
+        The aborted thread is left to drain in the background; the
+        returned result reflects the time-limit verdict.
         """
+        import threading
+
         start_time = time.monotonic()
         try:
             import discopt.modeling as dm
@@ -241,12 +252,41 @@ class BenchmarkRunner:
             max_nodes = opts.pop("max_nodes", 100_000)
             opts.pop("gpu", None)  # legacy option, ignored
 
-            result = model.solve(
-                time_limit=time_limit,
-                gap_tolerance=gap_tol,
-                max_nodes=max_nodes,
-                **opts,
-            )
+            box: dict = {}
+
+            def _do_solve() -> None:
+                try:
+                    box["result"] = model.solve(
+                        time_limit=time_limit,
+                        gap_tolerance=gap_tol,
+                        max_nodes=max_nodes,
+                        **opts,
+                    )
+                except BaseException as e:  # propagate to caller
+                    box["error"] = e
+
+            grace = 30.0  # mirrors the external-solver path
+            worker = threading.Thread(target=_do_solve, daemon=True)
+            worker.start()
+            worker.join(timeout=float(time_limit) + grace)
+            if worker.is_alive():
+                # Watchdog tripped: a JAX-compiled loop or other in-process
+                # call ignored time_limit. Surface a TIME_LIMIT result and
+                # let the daemon thread drain in the background.
+                elapsed = time.monotonic() - start_time
+                print(
+                    f"  WATCHDOG {instance}: in-process solve exceeded "
+                    f"time_limit+{int(grace)}s, abandoning thread"
+                )
+                return SolveResult(
+                    instance=instance,
+                    solver=solver.name,
+                    status=SolveStatus.TIME_LIMIT,
+                    wall_time=elapsed,
+                )
+            if "error" in box:
+                raise box["error"]
+            result = box["result"]
 
             # Map discopt status to benchmark status
             status_map = {
@@ -398,6 +438,7 @@ def _coefficient_of_variation(values: list[float]) -> float:
     if len(values) < 2:
         return 0.0
     import numpy as np
+
     arr = np.array(values)
     mean = np.mean(arr)
     if mean < 1e-6:

--- a/docs/references.bib
+++ b/docs/references.bib
@@ -1384,3 +1384,269 @@
   archivePrefix = {arXiv},
   primaryClass = {math.OC},
 }
+
+% ============================================================
+% Course-specific entries (added by the discopt course build)
+% ============================================================
+
+@book{Williams2013,
+  author    = {Williams, H. Paul},
+  title     = {Model Building in Mathematical Programming},
+  edition   = {5},
+  publisher = {Wiley},
+  year      = {2013},
+  isbn      = {978-1-118-44333-0},
+}
+
+@book{Conforti2014,
+  author    = {Conforti, Michele and Cornu{\'e}jols, G{\'e}rard and Zambelli, Giacomo},
+  title     = {Integer Programming},
+  series    = {Graduate Texts in Mathematics},
+  volume    = {271},
+  publisher = {Springer},
+  year      = {2014},
+  doi       = {10.1007/978-3-319-11008-0},
+}
+
+@article{Bland1977,
+  author  = {Bland, Robert G.},
+  title   = {New finite pivoting rules for the simplex method},
+  journal = {Mathematics of Operations Research},
+  volume  = {2},
+  number  = {2},
+  pages   = {103--107},
+  year    = {1977},
+  doi     = {10.1287/moor.2.2.103},
+}
+
+@article{Karmarkar1984,
+  author  = {Karmarkar, Narendra},
+  title   = {A new polynomial-time algorithm for linear programming},
+  journal = {Combinatorica},
+  volume  = {4},
+  number  = {4},
+  pages   = {373--395},
+  year    = {1984},
+  doi     = {10.1007/BF02579150},
+}
+
+@article{Gomory1958,
+  author  = {Gomory, Ralph E.},
+  title   = {Outline of an algorithm for integer solutions to linear programs},
+  journal = {Bulletin of the American Mathematical Society},
+  volume  = {64},
+  number  = {5},
+  pages   = {275--278},
+  year    = {1958},
+  doi     = {10.1090/S0002-9904-1958-10224-4},
+}
+
+@article{Balas1993,
+  author  = {Balas, Egon and Ceria, Sebasti{\'a}n and Cornu{\'e}jols, G{\'e}rard},
+  title   = {A lift-and-project cutting plane algorithm for mixed 0-1 programs},
+  journal = {Mathematical Programming},
+  volume  = {58},
+  pages   = {295--324},
+  year    = {1993},
+  doi     = {10.1007/BF01581273},
+}
+
+@article{Cornuejols2008,
+  author  = {Cornu{\'e}jols, G{\'e}rard},
+  title   = {Valid inequalities for mixed integer linear programs},
+  journal = {Mathematical Programming},
+  volume  = {112},
+  number  = {1},
+  pages   = {3--44},
+  year    = {2008},
+  doi     = {10.1007/s10107-006-0086-0},
+}
+
+@phdthesis{Achterberg2007,
+  author = {Achterberg, Tobias},
+  title  = {Constraint Integer Programming},
+  school = {Technische Universit{\"a}t Berlin},
+  year   = {2007},
+  url    = {https://depositonce.tu-berlin.de/handle/11303/1747},
+}
+
+@book{BenTal2001,
+  author    = {Ben-Tal, Aharon and Nemirovski, Arkadi},
+  title     = {Lectures on Modern Convex Optimization: Analysis, Algorithms, and Engineering Applications},
+  series    = {MPS-SIAM Series on Optimization},
+  publisher = {SIAM},
+  year      = {2001},
+  doi       = {10.1137/1.9780898718829},
+}
+
+@article{Benders1962,
+  author  = {Benders, Jacques F.},
+  title   = {Partitioning procedures for solving mixed-variables programming problems},
+  journal = {Numerische Mathematik},
+  volume  = {4},
+  number  = {1},
+  pages   = {238--252},
+  year    = {1962},
+  doi     = {10.1007/BF01386316},
+}
+
+@article{DantzigWolfe1960,
+  author  = {Dantzig, George B. and Wolfe, Philip},
+  title   = {Decomposition principle for linear programs},
+  journal = {Operations Research},
+  volume  = {8},
+  number  = {1},
+  pages   = {101--111},
+  year    = {1960},
+  doi     = {10.1287/opre.8.1.101},
+}
+
+@book{Birge2011,
+  author    = {Birge, John R. and Louveaux, Fran{\c{c}}ois},
+  title     = {Introduction to Stochastic Programming},
+  edition   = {2},
+  publisher = {Springer},
+  year      = {2011},
+  doi       = {10.1007/978-1-4614-0237-4},
+}
+
+@book{Shapiro2009,
+  author    = {Shapiro, Alexander and Dentcheva, Darinka and Ruszczy{\'n}ski, Andrzej},
+  title     = {Lectures on Stochastic Programming: Modeling and Theory},
+  series    = {MPS-SIAM Series on Optimization},
+  publisher = {SIAM},
+  year      = {2009},
+}
+
+@book{Floudas1999,
+  author    = {Floudas, Christodoulos A.},
+  title     = {Deterministic Global Optimization: Theory, Methods and Applications},
+  publisher = {Kluwer Academic},
+  year      = {1999},
+  doi       = {10.1007/978-1-4757-4949-6},
+}
+
+@book{HorstTuy1996,
+  author    = {Horst, Reiner and Tuy, Hoang},
+  title     = {Global Optimization: Deterministic Approaches},
+  edition   = {3},
+  publisher = {Springer},
+  year      = {1996},
+  doi       = {10.1007/978-3-662-03199-5},
+}
+
+@article{Grossmann2013,
+  author  = {Grossmann, Ignacio E. and Trespalacios, Francisco},
+  title   = {Systematic modeling of discrete-continuous optimization models through generalized disjunctive programming},
+  journal = {AIChE Journal},
+  volume  = {59},
+  number  = {9},
+  pages   = {3276--3295},
+  year    = {2013},
+  doi     = {10.1002/aic.14088},
+}
+
+@article{Fischetti2018,
+  author  = {Fischetti, Matteo and Jo, Jason},
+  title   = {Deep neural networks and mixed integer linear optimization},
+  journal = {Constraints},
+  volume  = {23},
+  pages   = {296--309},
+  year    = {2018},
+  doi     = {10.1007/s10601-018-9285-6},
+}
+
+@article{Bengio2021,
+  author  = {Bengio, Yoshua and Lodi, Andrea and Prouvost, Antoine},
+  title   = {Machine learning for combinatorial optimization: A methodological tour d'horizon},
+  journal = {European Journal of Operational Research},
+  volume  = {290},
+  number  = {2},
+  pages   = {405--421},
+  year    = {2021},
+  doi     = {10.1016/j.ejor.2020.07.063},
+}
+
+@book{Dempe2002,
+  author    = {Dempe, Stephan},
+  title     = {Foundations of Bilevel Programming},
+  publisher = {Kluwer Academic},
+  year      = {2002},
+  doi       = {10.1007/b101970},
+}
+
+@book{LuoPangRalph1996,
+  author    = {Luo, Zhi-Quan and Pang, Jong-Shi and Ralph, Daniel},
+  title     = {Mathematical Programs with Equilibrium Constraints},
+  publisher = {Cambridge University Press},
+  year      = {1996},
+  doi       = {10.1017/CBO9780511983658},
+}
+
+@article{Liberti2009,
+  author  = {Liberti, Leo},
+  title   = {Reformulations in mathematical programming: Definitions and systematics},
+  journal = {RAIRO-Operations Research},
+  volume  = {43},
+  number  = {1},
+  pages   = {55--85},
+  year    = {2009},
+  doi     = {10.1051/ro/2009005},
+}
+
+@book{Rockafellar1970,
+  author    = {Rockafellar, R. Tyrrell},
+  title     = {Convex Analysis},
+  publisher = {Princeton University Press},
+  year      = {1970},
+  isbn      = {978-0-691-01586-6},
+}
+
+@article{Khachiyan1979,
+  author  = {Khachiyan, Leonid G.},
+  title   = {A polynomial algorithm in linear programming},
+  journal = {Soviet Mathematics Doklady},
+  volume  = {20},
+  pages   = {191--194},
+  year    = {1979},
+}
+
+@article{KleeMinty1972,
+  author    = {Klee, Victor and Minty, George J.},
+  title     = {How good is the simplex algorithm?},
+  booktitle = {Inequalities III},
+  editor    = {Shisha, O.},
+  publisher = {Academic Press},
+  pages     = {159--175},
+  year      = {1972},
+}
+
+@book{Dorfman1958,
+  author    = {Dorfman, Robert and Samuelson, Paul A. and Solow, Robert M.},
+  title     = {Linear Programming and Economic Analysis},
+  publisher = {McGraw-Hill},
+  year      = {1958},
+}
+
+@article{Stigler1945,
+  author  = {Stigler, George J.},
+  title   = {The cost of subsistence},
+  journal = {Journal of Farm Economics},
+  volume  = {27},
+  number  = {2},
+  pages   = {303--314},
+  year    = {1945},
+  doi     = {10.2307/1231810},
+}
+
+@article{Kantorovich1960,
+  author  = {Kantorovich, Leonid V.},
+  title   = {Mathematical methods of organizing and planning production},
+  journal = {Management Science},
+  volume  = {6},
+  number  = {4},
+  pages   = {366--422},
+  year    = {1960},
+  note    = {English translation of 1939 Russian original},
+  doi     = {10.1287/mnsc.6.4.366},
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ xgboost = ["xgboost>=1.7"]
 lightgbm = ["lightgbm>=4.0"]
 gnn = ["equinox>=0.13.8", "optax>=0.1"]
 learned = ["equinox>=0.13.8", "optax>=0.1"]
-dev = ["pytest", "pytest-timeout", "pytest-cov", "ruff", "mypy", "highspy"]
+dev = ["pytest", "pytest-timeout", "pytest-cov", "pytest-xdist", "ruff", "mypy", "highspy"]
 all = ["discopt[ipopt,highs,cutest,llm,gnn,nn,ml]"]
 
 [project.scripts]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,7 +70,7 @@ include = [
 [tool.ruff]
 line-length = 100
 target-version = "py310"
-extend-exclude = ["adversary/"]
+extend-exclude = ["adversary/", "python/discopt/course/"]
 
 [tool.ruff.lint]
 select = ["E", "F", "I", "W"]

--- a/python/discopt/_jax/deadline.py
+++ b/python/discopt/_jax/deadline.py
@@ -1,0 +1,100 @@
+"""Wall-clock deadline plumbing for JAX-compiled solver loops.
+
+Python orchestration enforces ``time_limit`` between B&B nodes and between
+sub-solver calls, but once a ``jax.lax.while_loop`` (e.g. IPM iteration) is
+running the XLA runtime spins until ``cond_fn`` returns false. There is no
+path for Python to interrupt it mid-execution.
+
+This module exposes a process-global deadline that a ``cond_fn`` can poll via
+a host callback (``jax.experimental.io_callback``). One callback per outer
+iteration is cheap compared to the iteration body (matrix factor / KKT solve),
+so the predicate short-circuits the loop within ``time_limit + ε``.
+
+Usage::
+
+    from discopt._jax.deadline import deadline_scope, deadline_exceeded_jax
+
+    with deadline_scope(time_limit_seconds):
+        ...  # any JAX call whose cond_fn uses deadline_exceeded_jax()
+
+The deadline is cleared on scope exit; if no deadline is set,
+``deadline_exceeded_jax()`` returns ``False`` unconditionally.
+"""
+
+from __future__ import annotations
+
+import time
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+from jax.experimental import io_callback
+
+_deadline_monotonic: float | None = None
+
+
+def set_deadline(seconds_from_now: float | None) -> None:
+    """Set a process-global wall-clock deadline ``seconds_from_now`` ahead.
+
+    ``None`` clears any existing deadline.
+    """
+    global _deadline_monotonic
+    if seconds_from_now is None:
+        _deadline_monotonic = None
+        return
+    _deadline_monotonic = time.monotonic() + max(0.0, float(seconds_from_now))
+
+
+def clear_deadline() -> None:
+    """Clear the process-global deadline."""
+    global _deadline_monotonic
+    _deadline_monotonic = None
+
+
+def get_deadline() -> float | None:
+    """Return the monotonic deadline timestamp, or None if unset."""
+    return _deadline_monotonic
+
+
+def deadline_exceeded() -> bool:
+    """True iff a deadline is set and the wall clock has reached it."""
+    d = _deadline_monotonic
+    return d is not None and time.monotonic() >= d
+
+
+class deadline_scope:
+    """Context manager that installs (and on exit restores) the global deadline."""
+
+    def __init__(self, seconds_from_now: float | None):
+        self._seconds = seconds_from_now
+        self._prev: float | None = None
+
+    def __enter__(self) -> "deadline_scope":
+        self._prev = _deadline_monotonic
+        set_deadline(self._seconds)
+        return self
+
+    def __exit__(self, *_exc: object) -> None:
+        global _deadline_monotonic
+        _deadline_monotonic = self._prev
+
+
+def _host_check() -> np.ndarray:
+    return np.asarray(deadline_exceeded(), dtype=np.bool_)
+
+
+def deadline_exceeded_jax() -> jnp.ndarray:
+    """JAX-side predicate: 0-d bool array, True iff the deadline has passed.
+
+    Safe to call inside ``jax.lax.while_loop`` ``cond_fn``. Uses
+    ``ordered=True`` so the host callback fires once per iteration in
+    order, which is what we want for a self-terminating loop. Note this
+    means the predicate cannot be used under ``jax.vmap`` — call sites
+    that vmap must compile the cond_fn without the deadline check.
+    """
+    result: jnp.ndarray = io_callback(
+        _host_check,
+        jax.ShapeDtypeStruct((), jnp.bool_),
+        ordered=True,
+    )
+    return result

--- a/python/discopt/_jax/ipm.py
+++ b/python/discopt/_jax/ipm.py
@@ -21,6 +21,8 @@ from typing import Callable, NamedTuple, Optional
 import jax
 import jax.numpy as jnp
 
+from discopt._jax.deadline import deadline_exceeded_jax
+
 # ---------------------------------------------------------------------------
 # Data structures (NamedTuples for JAX pytree compatibility)
 # ---------------------------------------------------------------------------
@@ -1186,6 +1188,8 @@ def ipm_solve(
     g_l: Optional[jnp.ndarray] = None,
     g_u: Optional[jnp.ndarray] = None,
     options: Optional[IPMOptions] = None,
+    *,
+    check_deadline: bool = True,
 ) -> IPMState:
     """
     Solve an NLP using a pure-JAX interior point method.
@@ -1199,6 +1203,11 @@ def ipm_solve(
         g_l: Lower constraint bounds (m,).
         g_u: Upper constraint bounds (m,).
         options: IPMOptions.
+        check_deadline: When True (default), the cond_fn polls the process-
+            global wall-clock deadline via host callback so the while_loop
+            self-terminates on time-out (issue #80). Must be set to False
+            when this function is wrapped in ``jax.vmap``; the host callback
+            does not survive a batched predicate.
 
     Returns:
         Final IPMState with solution in state.x.
@@ -1226,8 +1235,20 @@ def ipm_solve(
     state = _initialize_state(obj_fn, con_fn_safe, x0, pd, opts)
     body = _make_iteration_body(obj_fn, con_fn_safe, pd, opts)
 
-    def cond(st):
-        return st.converged == 0
+    if check_deadline:
+
+        def cond(st):
+            # Self-terminate on a process-global wall-clock deadline (#80).
+            # solve_nlp_ipm's post-hoc check maps elapsed > max_wall_time to
+            # ITERATION_LIMIT, so partial state on early exit is handled.
+            return jnp.logical_and(
+                st.converged == 0,
+                jnp.logical_not(deadline_exceeded_jax()),
+            )
+    else:
+
+        def cond(st):
+            return st.converged == 0
 
     return jax.lax.while_loop(cond, body, state)  # type: ignore[no-any-return]
 
@@ -1349,9 +1370,11 @@ def solve_nlp_ipm(
         if fields:
             ipm_opts = ipm_opts._replace(**fields)
 
-    # Enforce max_wall_time by capping max_iter. The JIT-compiled
-    # jax.lax.while_loop cannot check wall clock, so we limit iterations
-    # upfront and verify after the solve (issue #5).
+    # max_wall_time backstop: the in-loop deadline check (issue #80)
+    # interrupts the JAX while_loop within ~1 host callback, but we still
+    # cross-check post-hoc so callers that pass max_wall_time without
+    # entering a deadline_scope still see the correct ITERATION_LIMIT
+    # status (issue #5).
     max_wall_time = options.get("max_wall_time") if options else None
 
     obj_fn = evaluator._obj_fn
@@ -1497,6 +1520,7 @@ def solve_nlp_batch(
             g_l,
             g_u,
             options,
+            check_deadline=False,  # host callback unsupported under vmap (#80)
         )
 
     return jax.vmap(_solve_single)(x0_batch, xl_batch, xu_batch)  # type: ignore[no-any-return]

--- a/python/discopt/_jax/ipm_iterative.py
+++ b/python/discopt/_jax/ipm_iterative.py
@@ -481,6 +481,7 @@ def solve_nlp_iterative_batch(
             g_l,
             g_u,
             options,
+            check_deadline=False,  # host callback unsupported under vmap (#80)
         )
 
     return jax.vmap(_solve_single)(  # type: ignore[no-any-return]

--- a/python/discopt/_jax/lp_ipm.py
+++ b/python/discopt/_jax/lp_ipm.py
@@ -30,6 +30,8 @@ import jax
 import jax.numpy as jnp
 import jax.scipy.linalg as jsla
 
+from discopt._jax.deadline import deadline_exceeded_jax
+
 # ---------------------------------------------------------------------------
 # Constants
 # ---------------------------------------------------------------------------
@@ -544,8 +546,8 @@ def _iteration_body(carry: LPCarry, tol: float, max_iter: int, tau_min: float) -
 # ---------------------------------------------------------------------------
 
 
-@functools.partial(jax.jit, static_argnums=(5, 6, 7, 8))
-def _lp_ipm_solve_jit(c, A, b, x_l, x_u, tol, max_iter, tau_min, bound_push):
+@functools.partial(jax.jit, static_argnums=(5, 6, 7, 8, 9))
+def _lp_ipm_solve_jit(c, A, b, x_l, x_u, tol, max_iter, tau_min, bound_push, check_deadline):
     """JIT-compiled LP IPM core (m > 0 path).
 
     By wrapping the entire solve (init + while_loop) in @jax.jit, all JAX
@@ -556,14 +558,30 @@ def _lp_ipm_solve_jit(c, A, b, x_l, x_u, tol, max_iter, tau_min, bound_push):
     Options (tol, max_iter, tau_min, bound_push) are static_argnums so they
     become compile-time constants.  Different option values cause recompilation,
     but benchmarks typically use the same options for all runs.
+
+    ``check_deadline`` is also static so the cond_fn is compiled with or
+    without the host-callback predicate. The vmap'd batch path passes
+    False because ``io_callback`` does not survive a batched while_loop
+    predicate (issue #80).
     """
     pd = _make_problem_data(c, A, b, x_l, x_u)
     opts = LPIPMOptions(tol=tol, max_iter=max_iter, tau_min=tau_min, bound_push=bound_push)
     state = _initialize_state(pd, opts)
     carry = LPCarry(state=state, pd=pd)
 
-    def cond(carry):
-        return carry.state.converged == 0
+    if check_deadline:
+
+        def cond(carry):
+            # Self-terminate if the process-global wall-clock deadline
+            # trips mid-solve (issue #80).
+            return jnp.logical_and(
+                carry.state.converged == 0,
+                jnp.logical_not(deadline_exceeded_jax()),
+            )
+    else:
+
+        def cond(carry):
+            return carry.state.converged == 0
 
     def body(carry):
         return _iteration_body(carry, tol, max_iter, tau_min)
@@ -579,6 +597,8 @@ def lp_ipm_solve(
     x_l: jnp.ndarray,
     x_u: jnp.ndarray,
     options: LPIPMOptions | None = None,
+    *,
+    check_deadline: bool = True,
 ) -> LPIPMState:
     """Solve an LP using a pure-JAX Mehrotra predictor-corrector IPM.
 
@@ -630,7 +650,16 @@ def lp_ipm_solve(
         return state  # type: ignore[no-any-return]
 
     state = _lp_ipm_solve_jit(
-        c, A, b, x_l, x_u, opts.tol, opts.max_iter, opts.tau_min, opts.bound_push
+        c,
+        A,
+        b,
+        x_l,
+        x_u,
+        opts.tol,
+        opts.max_iter,
+        opts.tau_min,
+        opts.bound_push,
+        check_deadline,
     )
     if factors.applied:
         x_us, y_us, zl_us, zu_us = unscale_lp_solution(
@@ -667,7 +696,10 @@ def lp_ipm_solve_batch(
     """
 
     def _solve_single(xl_single, xu_single):
-        return lp_ipm_solve(c, A, b, xl_single, xu_single, options)
+        # Host-callback deadline check doesn't survive a batched while_loop
+        # predicate; the Python orchestration layer caps the batch call
+        # externally (issue #80).
+        return lp_ipm_solve(c, A, b, xl_single, xu_single, options, check_deadline=False)
 
     result: LPIPMState = jax.vmap(_solve_single)(xl_batch, xu_batch)
     return result

--- a/python/discopt/_jax/qp_ipm.py
+++ b/python/discopt/_jax/qp_ipm.py
@@ -30,6 +30,8 @@ import jax
 import jax.numpy as jnp
 import jax.scipy.linalg as jsla
 
+from discopt._jax.deadline import deadline_exceeded_jax
+
 # ---------------------------------------------------------------------------
 # Constants
 # ---------------------------------------------------------------------------
@@ -524,21 +526,36 @@ def _iteration_body(carry: QPCarry, tol: float, max_iter: int, tau_min: float) -
 # ---------------------------------------------------------------------------
 
 
-@functools.partial(jax.jit, static_argnums=(6, 7, 8, 9))
-def _qp_ipm_solve_jit(Q, c, A, b, x_l, x_u, tol, max_iter, tau_min, bound_push):
+@functools.partial(jax.jit, static_argnums=(6, 7, 8, 9, 10))
+def _qp_ipm_solve_jit(Q, c, A, b, x_l, x_u, tol, max_iter, tau_min, bound_push, check_deadline):
     """JIT-compiled QP IPM core.
 
     Wraps the entire solve (init + while_loop) in @jax.jit so all JAX
     operations compile into a single XLA program, eliminating Python
     dispatch overhead (~75x speedup on warm calls).
+
+    ``check_deadline`` is static so the cond_fn is compiled with or
+    without the host-callback predicate. The vmap'd batch path passes
+    False because ``io_callback`` doesn't survive a batched while_loop
+    predicate (issue #80).
     """
     pd = _make_problem_data(Q, c, A, b, x_l, x_u)
     opts = QPIPMOptions(tol=tol, max_iter=max_iter, tau_min=tau_min, bound_push=bound_push)
     state = _initialize_state(pd, opts)
     carry = QPCarry(state=state, pd=pd)
 
-    def cond(carry):
-        return carry.state.converged == 0
+    if check_deadline:
+
+        def cond(carry):
+            # Self-terminate on a process-global wall-clock deadline (#80).
+            return jnp.logical_and(
+                carry.state.converged == 0,
+                jnp.logical_not(deadline_exceeded_jax()),
+            )
+    else:
+
+        def cond(carry):
+            return carry.state.converged == 0
 
     def body(carry):
         return _iteration_body(carry, tol, max_iter, tau_min)
@@ -555,6 +572,8 @@ def qp_ipm_solve(
     x_l: jnp.ndarray,
     x_u: jnp.ndarray,
     options: QPIPMOptions | None = None,
+    *,
+    check_deadline: bool = True,
 ) -> QPIPMState:
     """Solve a QP using a pure-JAX Mehrotra predictor-corrector IPM.
 
@@ -593,7 +612,17 @@ def qp_ipm_solve(
     x_u = jnp.asarray(x_u, dtype=jnp.float64)
 
     return _qp_ipm_solve_jit(  # type: ignore[no-any-return]
-        Q, c, A, b, x_l, x_u, opts.tol, opts.max_iter, opts.tau_min, opts.bound_push
+        Q,
+        c,
+        A,
+        b,
+        x_l,
+        x_u,
+        opts.tol,
+        opts.max_iter,
+        opts.tau_min,
+        opts.bound_push,
+        check_deadline,
     )
 
 
@@ -624,6 +653,9 @@ def qp_ipm_solve_batch(
     """
 
     def _solve_single(xl_single, xu_single):
-        return qp_ipm_solve(Q, c, A, b, xl_single, xu_single, options)
+        # Host-callback deadline check doesn't survive a batched while_loop
+        # predicate; the Python orchestration layer caps the batch call
+        # externally (issue #80).
+        return qp_ipm_solve(Q, c, A, b, xl_single, xu_single, options, check_deadline=False)
 
     return jax.vmap(_solve_single)(xl_batch, xu_batch)  # type: ignore[no-any-return]

--- a/python/discopt/_jax/taylor_model.py
+++ b/python/discopt/_jax/taylor_model.py
@@ -40,10 +40,10 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 
-import jax
 import jax.numpy as jnp
 import numpy as np
 import numpy.polynomial.polynomial as np_poly
+from jax.experimental.jet import jet
 
 # ---------------------------------------------------------------------------
 # Helpers (interval arithmetic + polynomial range)
@@ -253,27 +253,27 @@ def _taylor_coefficients(f_callable, x0: float, half_width: float, degree: int) 
     so ``sum_k coeffs[k] * s^k`` approximates ``f(x0 + half_width * s)`` for
     ``s ∈ [-1, 1]``.
 
-    Derivatives are computed via repeated ``jax.grad`` on a JAX-traceable
-    wrapper. ``f_callable`` must accept and return JAX-compatible scalars
-    (the standard NumPy unary functions ``np.exp``, ``np.log``, etc. work
-    because JAX's ``jnp`` versions have the same API and ``jax.grad`` traces
-    through the chosen elementary operations of the wrapper).
+    Uses ``jax.experimental.jet.jet`` to evaluate the entire Taylor tower in a
+    single tracing pass. That replaces the older chained ``jax.grad`` approach,
+    which retraced + recompiled at every order (the dominant cost for
+    high-degree univariate compositions).
     """
-
-    def _f(u):
-        # Wrap to ensure jax can trace; rely on caller passing jax-compatible f.
-        return f_callable(u)
-
+    x0_jax = jnp.asarray(x0, dtype=jnp.float64)
+    if degree == 0:
+        return np.array([float(f_callable(x0_jax))])
+    # For x(t) = x0 + t, the input series is (1, 0, 0, ...). ``jet`` returns
+    # ``y_terms[k-1] = f^(k)(x0)`` (raw higher derivatives, not divided by k!)
+    # and ``y0 = f(x0)``.
+    series = ((1.0,) + (0.0,) * (degree - 1),)
+    y0, y_terms = jet(f_callable, (x0_jax,), series)
     coeffs = np.zeros(degree + 1)
-    deriv = _f
+    coeffs[0] = float(y0)
+    hw_pow = half_width
     factorial = 1.0
-    hw_pow = 1.0
-    for k in range(degree + 1):
-        val = float(deriv(jnp.asarray(x0, dtype=jnp.float64)))
-        coeffs[k] = val * hw_pow / factorial
-        deriv = jax.grad(deriv)
+    for k in range(1, degree + 1):
+        factorial *= k
+        coeffs[k] = float(y_terms[k - 1]) * hw_pow / factorial
         hw_pow *= half_width
-        factorial *= k + 1
     return coeffs
 
 
@@ -323,7 +323,7 @@ def compose_unary(f_callable, g: TaylorModel) -> TaylorModel:
     M = _COMPOSE_VALIDATE_GRID
     fine_s = np.linspace(-1.0, 1.0, M)
     fine_u = x0 + half_width * fine_s
-    f_fine = np.array([float(f_callable(jnp.asarray(float(u)))) for u in fine_u])
+    f_fine = np.asarray(f_callable(jnp.asarray(fine_u, dtype=jnp.float64)))
     p_fine = np_poly.polyval(fine_s, f_coeffs)
     resid = np.abs(f_fine - p_fine)
     resid_max = float(resid.max())

--- a/python/discopt/cli.py
+++ b/python/discopt/cli.py
@@ -5,6 +5,7 @@ Usage:
     discopt test
     discopt convert input.gms output.nl
     discopt install-skills [--project-scope] [--dev] [--force]
+    discopt tutor [list|start|resume|next|reset|install] ...
 
 Developer-only commands (``lit-scan``, ``adversary``, ``search-arxiv``,
 ``search-openalex``, ``write-report``) live under ``discopt-dev`` in
@@ -292,7 +293,15 @@ def main():
     )
     p_skills.set_defaults(func=_cmd_install_skills)
 
+    from discopt.tutor import add_subparser as _add_tutor_subparser
+
+    _add_tutor_subparser(subparsers)
+
     args = parser.parse_args()
+    if args.command == "tutor":
+        from discopt.tutor import run as _run_tutor
+
+        sys.exit(_run_tutor(args) or 0)
     args.func(args)
 
 

--- a/python/discopt/course/.gitignore
+++ b/python/discopt/course/.gitignore
@@ -1,0 +1,12 @@
+# Personal progress file (the template is checked in)
+progress.yaml
+
+# Notebook execution artifacts
+**/.ipynb_checkpoints/
+
+# Student-submitted writing drafts (uncomment if you want privacy)
+# **/writing_response.md
+__pycache__/
+
+# Reference solutions — instructors only; do not ship to student clones.
+solutions/

--- a/python/discopt/course/README.md
+++ b/python/discopt/course/README.md
@@ -1,0 +1,113 @@
+# discopt: An Optimization Course
+
+A self-paced, Claude-Code-assisted course in mathematical optimization, taught
+through the `discopt` solver. Three tracks (basic, intermediate, advanced)
+totalling **30 lessons**, each pairing a reading notebook with an exercise
+notebook, a writing prompt, and a rubric. Claude Code acts as your TA: it
+delivers material, answers questions, hints when you're stuck, and grades your
+work against the rubric.
+
+## How the course works
+
+Each lesson lives in `course/<track>/<id>/` and contains:
+
+| File             | Purpose                                                       |
+| ---------------- | ------------------------------------------------------------- |
+| `reading.ipynb`  | The lesson — math, examples, runnable code with `discopt`.    |
+| `exercises.ipynb`| 3-6 exercises with `# TODO` cells you fill in.                |
+| `writing.md`     | A short essay or analysis prompt (≈ 1 page).                  |
+| `rubric.md`      | The criteria Claude uses to assess your work.                 |
+
+Reference solutions live under `course/solutions/<track>/<id>/`. Try the
+exercise yourself before peeking — Claude can give hints without revealing
+the answer.
+
+## Quick start
+
+```bash
+# 1. Install discopt with the optional notebook deps
+pip install -e ".[dev,nn,llm]"
+jupyter lab
+
+# 2. Install the course slash commands and assessor skill into .claude/
+bash course/install_skills.sh             # project-scope (./.claude/)
+# or
+bash course/install_skills.sh --user      # global (~/.claude/)
+
+# 3. Open the syllabus
+open course/SYLLABUS.md
+
+# 4. In Claude Code, start lesson 1
+/course:lesson basic/01_intro_to_optimization
+
+# 5. When you finish the exercises, ask Claude to assess
+/course:assess basic/01_intro_to_optimization
+```
+
+The slash commands and assessor skill ship as source files under
+`course/_claude_assets/`. The install script copies them into `.claude/`
+where Claude Code will pick them up. Source-of-truth lives under
+`_claude_assets/` so they're version-controlled with the rest of the course.
+
+## Slash commands
+
+The course ships with these Claude Code commands:
+
+- `/course:lesson <id>` — load a lesson, get a guided tour of the reading.
+- `/course:hint <id> <ex#>` — get a graduated hint for a specific exercise.
+- `/course:assess <id>` — Claude grades your exercises against the rubric.
+- `/course:grade-writing <id>` — Claude grades your `writing.md` response.
+- `/course:progress` — show what you've completed and what's next.
+- `/course:cite-check` — verify all `{cite:p}` keys resolve in `references.bib`.
+
+The grading behaviour is implemented by the `course-assessor` skill in
+`.claude/skills/course-assessor/`, so it is consistent across sessions.
+
+## Tracks
+
+- **Basic (1–10)**: modeling, LP, duality, IP, B&B, convexity, NLP. Aimed at
+  someone who has had calculus and linear algebra and wants a working
+  knowledge of optimization plus the `discopt` API.
+- **Intermediate (11–20)**: simplex internals, IPM, cuts, branching rules,
+  presolve, relaxations, conic optimization, decomposition, stochastic
+  programming. Algorithms-first; you'll implement small pieces and benchmark
+  against `discopt`'s defaults.
+- **Advanced (21–30)**: spatial B&B, global optimization theory, GDP,
+  NN-embedded MINLP, robust optimization, ML-for-OR, differentiable
+  optimization, bilevel, reformulations. Capstone is a paper-style writeup
+  with computational results.
+
+## Progress tracking
+
+Your state is recorded in `course/progress.yaml` (created on first
+`/course:progress` call from `progress.template.yaml`). Lessons unlock in
+order within a track, but tracks can be done in parallel.
+
+## Citations
+
+Every reading cites the literature with `{cite:p}` / `{cite:t}` keys
+resolving to entries in `docs/references.bib`. New course-specific entries
+were added when this course was built. Run `/course:cite-check` to verify.
+
+## Building / regenerating notebooks
+
+The notebooks are generated from Python content modules in
+`course/_build/lessons/`:
+
+```bash
+python course/_build/nbgen.py
+```
+
+This rewrites every `reading.ipynb` and `exercises.ipynb`. Edit the `.py`
+modules — not the JSON — and rebuild.
+
+## Course-API shim
+
+The lesson code cells use a slightly-friendlier façade
+(`m.add_variable / .add_variables / .add_constraint / .is_convex / .solve`
+with kwargs like `mode`, `verbose`, `x0`) that maps onto the real `discopt`
+API (`m.continuous / .binary / .integer / .subject_to / .solve`). The shim
+lives in `course/_compat.py`; `nbgen.py` auto-injects a loader cell at the
+top of every notebook so the shim is installed before the lesson code runs.
+You can remove the shim when comfortable working directly with the real
+`discopt.modeling.core.Model` API.

--- a/python/discopt/course/SYLLABUS.md
+++ b/python/discopt/course/SYLLABUS.md
@@ -1,0 +1,72 @@
+# Syllabus
+
+Thirty lessons in three tracks. Each row links the lesson directory and the
+primary literature backing it (full BibTeX entries in `docs/references.bib`).
+
+## Basic track — modeling and solving
+
+| #  | Title                              | Primary references                        |
+| -- | ---------------------------------- | ----------------------------------------- |
+| 01 | Introduction to optimization       | Bertsimas1997, Williams2013, Wolsey1998   |
+| 02 | Linear programming fundamentals    | Bertsimas1997, Dantzig1963                |
+| 03 | Modeling in `discopt`              | Williams2013                              |
+| 04 | Sensitivity, duality, shadow prices| Bertsimas1997, Boyd2004                   |
+| 05 | Integer programming basics         | Wolsey1998, Williams2013, Conforti2014    |
+| 06 | Branch-and-bound, conceptually     | Land1960, Dakin1965, Wolsey1998           |
+| 07 | Convexity and why it matters       | Boyd2004, Rockafellar1970                 |
+| 08 | Unconstrained nonlinear optimization | Nocedal2006                             |
+| 09 | Constrained NLP — KKT and IPOPT    | Nocedal2006, Wachter2006, KKT references  |
+| 10 | Capstone (basic): a real model     | Williams2013                              |
+
+## Intermediate track — algorithms and structure
+
+| #  | Title                              | Primary references                        |
+| -- | ---------------------------------- | ----------------------------------------- |
+| 11 | Simplex revealed                   | Dantzig1963, Bland1977, Bertsimas1997     |
+| 12 | Interior-point methods             | Karmarkar1984, Mehrotra1992, Wright1997   |
+| 13 | Cutting planes                     | Gomory1958, Balas1993, Cornuejols2008     |
+| 14 | Branching rules                    | Achterberg2005, Achterberg2007            |
+| 15 | Presolve and FBBT                  | Belotti2009, Savelsbergh1994              |
+| 16 | Convex relaxations                 | McCormick1976, Adjiman1998, Tawarmalani2005 |
+| 17 | Conic optimization (SOCP/SDP)      | BenTal2001, Boyd2004                      |
+| 18 | Decomposition methods              | Benders1962, DantzigWolfe1960             |
+| 19 | Stochastic programming             | Birge2011, Shapiro2009                    |
+| 20 | Capstone (intermediate)            | mixed                                     |
+
+## Advanced track — frontiers
+
+| #  | Title                              | Primary references                        |
+| -- | ---------------------------------- | ----------------------------------------- |
+| 21 | Spatial branch-and-bound           | Tawarmalani2005, Smith1999, Belotti2009   |
+| 22 | Global optimization theory         | Floudas1999, HorstTuy1996                 |
+| 23 | Generalized disjunctive programming| Raman1994, Grossmann2013, Trespalacios2015|
+| 24 | Neural-net-embedded MINLP          | Fischetti2018, Anderson2020, Ceccon2022   |
+| 25 | Robust optimization                | BenTal2009, BertsimasSim2004              |
+| 26 | Differentiable optimization        | Amos2017, Agrawal2019                     |
+| 27 | Machine learning for optimization  | Bengio2021, Gasse2019                     |
+| 28 | Bilevel and complementarity        | Dempe2002, LuoPangRalph1996               |
+| 29 | Reformulations and symmetry        | Liberti2012, Margot2010                   |
+| 30 | Capstone (advanced)                | mixed                                     |
+
+## Pacing
+
+The course is self-paced. A reasonable target is **one lesson per week** for
+basic, **one every 1-2 weeks** for intermediate, and **one every 2-3 weeks**
+for advanced. The total course is roughly equivalent to a one-year graduate
+sequence in optimization.
+
+## Prerequisites
+
+- **Basic**: calculus, linear algebra, comfort with Python.
+- **Intermediate**: completion of basic track or equivalent (an undergraduate
+  OR or convex optimization course).
+- **Advanced**: completion of intermediate track and at least one of: a
+  graduate optimization course, research experience, or significant industrial
+  experience formulating MINLPs.
+
+## Assessment
+
+Each lesson awards up to 100 points distributed across exercise correctness,
+writing quality, and (on capstones) experimental rigor. The `course-assessor`
+skill normalizes grading across sessions. Track completion requires ≥ 70 / 100
+on every lesson.

--- a/python/discopt/course/__init__.py
+++ b/python/discopt/course/__init__.py
@@ -1,0 +1,26 @@
+"""Packaged ``discopt`` course content.
+
+The course tree (lesson notebooks, syllabus, rubrics, progress template,
+and the ``/course:`` Claude-Code slash commands under
+``_claude_assets/``) ships as package data so ``discopt tutor`` works
+out-of-the-box for pip-installed users.
+
+For mutable state (a student's own ``progress.yaml``) the tutor
+materializes a writable copy of this tree into the user's working
+directory via ``discopt tutor install`` — the packaged copy stays
+read-only.
+"""
+
+from __future__ import annotations
+
+from importlib.resources import files
+from pathlib import Path
+
+
+def package_root() -> Path:
+    """Return the on-disk path to the packaged ``course/`` tree.
+
+    Resolves through :mod:`importlib.resources` so it works whether
+    ``discopt`` is installed in editable mode, as a wheel, or from sdist.
+    """
+    return Path(str(files("discopt.course")))

--- a/python/discopt/course/_claude_assets/commands/course/assess.md
+++ b/python/discopt/course/_claude_assets/commands/course/assess.md
@@ -1,0 +1,43 @@
+---
+description: Grade the student's exercises (and writing if present) for a lesson
+argument-hint: <track>/<id> [--milestone N]
+---
+
+The student has asked for assessment of `$ARGUMENTS`.
+
+**Argument parsing.** `$ARGUMENTS` is `<track>/<id>` plus optional flags:
+
+- `--milestone <N>` — for the advanced capstone (`advanced/30_capstone_advanced`),
+  grade only milestone N (1, 2, or 3): M1 = proposal, M2 = method + initial
+  results, M3 = final paper. Look for `course/<track>/<id>/milestone_<N>.md`
+  and grade against the milestone-specific subset of the rubric. Reject
+  with a clear message if `--milestone` is passed for a non-capstone lesson.
+
+**Default flow.** Invoke the `course-assessor` skill. The skill knows the
+procedure:
+
+- Read `course/<track>/<id>/rubric.md`.
+- Read the student's `course/<track>/<id>/exercises.ipynb`.
+- Read the optional `course/<track>/<id>/writing_response.md`.
+- Use the reference solution at `course/solutions/<track>/<id>/exercises.ipynb`
+  (instructor-only path; the `solutions/` tree is gitignored on student
+  distributions, so this read may fail in a student clone — degrade
+  gracefully and grade only against the rubric in that case).
+
+**Workspace safety.** The student's `exercises.ipynb` is the live file they
+edit. Do NOT overwrite it during grading. Do NOT regenerate it via
+`python course/_build/nbgen.py`; nbgen has overwrite-safety that detects
+student edits, but the assessor must never touch the file regardless.
+
+**Progress write.** After grading, atomically update
+`course/progress.yaml` under `scores.<track>/<id>`:
+
+- preserve any pre-existing `exercises`, `writing`, `attempts`, `hints_used`
+  fields you don't overwrite;
+- recompute `total = exercises + writing` only when both subscores exist;
+- append `last_assessed: <ISO date>`.
+
+If `course/progress.yaml` doesn't yet exist, copy
+`course/progress.template.yaml` first.
+
+Produce the structured feedback report and update `progress.yaml`.

--- a/python/discopt/course/_claude_assets/commands/course/cite-check.md
+++ b/python/discopt/course/_claude_assets/commands/course/cite-check.md
@@ -1,0 +1,31 @@
+---
+description: Verify that all citations in course readings resolve in docs/references.bib
+---
+
+Verify that every `{cite:p}` and `{cite:t}` key used anywhere under
+`course/` exists in `docs/references.bib`.
+
+Procedure:
+
+1. Use Bash + grep to extract every citation key from
+   `course/**/*.ipynb`, `course/**/*.md`, and
+   `course/_build/lessons/*.py`. Pattern: `{cite:[pt]}` followed by
+   `<key>` or `<key1>, <key2>`.
+2. Use Bash + grep to extract every `@type{key,` from
+   `docs/references.bib`.
+3. Diff the two sets. Report any keys cited but not defined.
+4. (Optional) For each course-cited key, fetch its DOI/URL via WebFetch to
+   verify the citation refers to a real published work — highlight any keys
+   that look fabricated.
+
+Print a summary table:
+
+```
+Cited keys: 47
+Defined in references.bib: 47
+Missing: 0
+Suspicious (no DOI/URL on file): 2  (Foo2099, Bar1900)
+```
+
+Exit with a non-zero status (in the conceptual sense — say "FAIL") if any
+keys are cited but undefined.

--- a/python/discopt/course/_claude_assets/commands/course/grade-writing.md
+++ b/python/discopt/course/_claude_assets/commands/course/grade-writing.md
@@ -1,0 +1,31 @@
+---
+description: Grade only the writing assignment for a lesson
+argument-hint: <track>/<id>
+---
+
+Grade only the writing assignment for lesson `$ARGUMENTS`.
+
+Invoke the `course-assessor` skill. Read:
+
+- `course/$ARGUMENTS/writing.md` — the prompt.
+- `course/$ARGUMENTS/rubric.md` — the writing-specific criteria (typically the
+  bottom 30 points).
+- `course/$ARGUMENTS/writing_response.md` — the student's response.
+
+If `writing_response.md` does not exist, ask the student to create it (you may
+suggest a starter outline based on the prompt) and stop.
+
+Otherwise, score it on:
+- clarity
+- technical correctness
+- use of citations (verify every `{cite:p}` key resolves in
+  `docs/references.bib`; flag invented or unverifiable keys explicitly)
+- engagement with the prompt
+
+**Preserve the exercises score.** Read the existing
+`scores.<lesson>` block first. Update only the `writing` field. Recompute
+`total = exercises + writing` ONLY if `exercises` is already set; if
+`exercises` is unset, write `total: null` and leave a note that the student
+should run `/course:assess <lesson>` before the writing total is meaningful.
+
+Append `last_assessed_writing: <ISO date>`.

--- a/python/discopt/course/_claude_assets/commands/course/hint.md
+++ b/python/discopt/course/_claude_assets/commands/course/hint.md
@@ -1,0 +1,21 @@
+---
+description: Get a graduated hint for a course exercise (does not reveal the answer)
+argument-hint: <track>/<id> <exercise-number>
+---
+
+The student is stuck on an exercise. Arguments: `$ARGUMENTS` (lesson id and
+exercise number).
+
+Use the `course-assessor` skill in **hint mode** (per its SKILL.md). The
+protocol is graduated:
+
+1. First time asked → give a general nudge ("re-read section X").
+2. Second time asked → give a specific pointer ("count your dual variables").
+3. Third time asked → give pseudocode/structure but never the literal answer.
+
+Look up the previous hint level in `course/progress.yaml` under
+`scores.<lesson>.hints_used` (it may not yet exist; treat absence as 0).
+Increment after giving the hint.
+
+If the student asks for the answer outright, decline politely and explain
+that struggling productively with the exercise is the point.

--- a/python/discopt/course/_claude_assets/commands/course/lesson.md
+++ b/python/discopt/course/_claude_assets/commands/course/lesson.md
@@ -1,0 +1,26 @@
+---
+description: Load a discopt-course lesson and walk the student through the reading
+argument-hint: <track>/<id>   (e.g. basic/02_lp_fundamentals)
+---
+
+You are guiding a student through a discopt-course lesson. The lesson id is
+`$ARGUMENTS`. Steps:
+
+1. Read `course/$ARGUMENTS/reading.ipynb`. (Use Read; for notebooks the tool
+   returns cell contents.)
+2. Give a 5-bullet preview: the lesson's learning objectives.
+3. Ask the student which they'd like to do first:
+   (a) work through the reading interactively here in the chat,
+   (b) open the notebook in JupyterLab and read it themselves and ask Claude
+       questions as they go,
+   (c) skip straight to the exercises.
+4. If (a), step through the markdown sections in order, pausing for questions.
+5. If the student finishes the reading, suggest they run
+   `/course:hint $ARGUMENTS <ex#>` if they get stuck on any exercise, and
+   `/course:assess $ARGUMENTS` when done.
+
+**Do NOT update `current_lesson` on a bare preview.** Update
+`course/progress.yaml`'s `current_lesson` to `$ARGUMENTS` only if the
+student picks option (a) (work through interactively now) or explicitly
+confirms they're switching to this lesson. A student peeking at a future
+lesson must not clobber their actual position.

--- a/python/discopt/course/_claude_assets/commands/course/progress.md
+++ b/python/discopt/course/_claude_assets/commands/course/progress.md
@@ -1,0 +1,26 @@
+---
+description: Show the student's discopt-course progress
+---
+
+Show the student's progress through the course.
+
+1. If `course/progress.yaml` does not exist, copy
+   `course/progress.template.yaml` to `course/progress.yaml` (using the
+   `cp` command via Bash) and tell the student you've initialized it.
+2. Read `course/progress.yaml`.
+3. Render a table:
+
+   ```
+   Track          Lessons completed     Avg score    Next
+   --------------------------------------------------------
+   basic          7 / 10                82           basic/08_unconstrained_nlp
+   intermediate   0 / 10                -            (locked - finish basic first)
+   advanced       0 / 10                -            (locked)
+   ```
+
+4. Highlight any lessons below the 70-point threshold and recommend
+   revising those first.
+5. Show the lesson the student should attempt next.
+
+A track is "unlocked" if the student has completed (≥70 on every lesson) the
+prior track. Lessons within a track unlock in order.

--- a/python/discopt/course/_claude_assets/skills/course-assessor/SKILL.md
+++ b/python/discopt/course/_claude_assets/skills/course-assessor/SKILL.md
@@ -1,0 +1,98 @@
+---
+name: course-assessor
+description: Assess a discopt-course lesson - load the rubric, read the student's exercise notebook and (optional) writing response, then produce structured feedback and update progress.yaml. Trigger when the user runs /course:assess or /course:grade-writing, or otherwise asks Claude to grade a lesson.
+---
+
+# discopt course assessor
+
+You are grading a lesson in the discopt optimization course. Be **rigorous**,
+**specific**, and **fair**. The student has worked hard; cite exactly what is
+correct, what is missing, and what to fix. Avoid generic praise.
+
+## Inputs
+
+When invoked, you will be given a lesson id of the form `<track>/<id>` (e.g.
+`basic/02_lp_fundamentals`). You should locate:
+
+- `course/<track>/<id>/rubric.md` — the criteria you grade against.
+- `course/<track>/<id>/exercises.ipynb` — the student's filled-in exercises.
+- `course/<track>/<id>/writing_response.md` — the student's essay (optional;
+  may not exist if they haven't written it yet).
+- `course/solutions/<track>/<id>/exercises.ipynb` — reference solution (do not
+  show contents to the student verbatim; use it only to check correctness).
+
+## Procedure
+
+1. Read the rubric. Note the criteria, weights, and pass thresholds.
+2. Read the student's exercise notebook. For each exercise:
+   - Determine whether their code runs (mentally or via a small check).
+   - Determine whether their answer is correct against the reference solution.
+   - Note partial credit cases explicitly.
+3. If the lesson includes writing and the response file exists, read it.
+   Score it on the writing rubric criteria.
+4. Score each criterion. Sum to a total out of 100.
+5. Produce a markdown feedback report (template below).
+6. Append/update `course/progress.yaml` under `scores.<track>/<id>`.
+
+## Feedback template
+
+```markdown
+# Assessment: <track>/<id>
+
+**Total: XX / 100**   (exercises XX/70, writing XX/30)
+
+## Per-criterion
+
+### Exercise 1 — <criterion> (X / Y)
+What was correct: ...
+What was missing or wrong: ...
+Specific fix: ...
+
+### Exercise 2 — ...
+
+## Writing (if graded)
+
+### Clarity (X / Y)
+...
+
+### Technical correctness (X / Y)
+...
+
+### Use of citations (X / Y)
+...
+
+## Recommended next steps
+
+- [ ] Concrete action 1
+- [ ] Concrete action 2
+```
+
+## Hard rules
+
+- **Do not show the reference solution code.** You may quote a single line of
+  it to clarify a fix, but never paste a working solution wholesale.
+- **Do not inflate scores.** A criterion is met or it is not.
+- **Cite exact cell numbers / line numbers** when noting issues.
+- **Update `progress.yaml`** with the score, attempt count, and ISO date
+  using a YAML edit (preserve existing keys; do not rewrite the file).
+- If the student score is below 70, add a `recommended_revisions` block to
+  the feedback rather than marking the lesson complete.
+- If `writing_response.md` does not exist, score writing as 0 / 30 and note
+  that they should run `/course:grade-writing` after submitting.
+- Verify any `{cite:p}` keys the student uses in `writing_response.md`
+  resolve in `docs/references.bib`. Flag unverified keys.
+
+## Hint mode
+
+When invoked via `/course:hint`, do NOT grade. Instead:
+
+1. Identify which exercise the student is asking about.
+2. Use a graduated-hint protocol:
+   - First hint: a general nudge ("re-read section X of the reading").
+   - Second hint: a more specific pointer ("the LP dual has a constraint
+     for each primal variable — count yours").
+   - Third hint: pseudocode or a partial solution structure, but never the
+     final answer.
+3. Track which hint level you've given in a brief note in
+   `course/progress.yaml` under `scores.<track>/<id>.hints_used` so we can
+   weight assessment accordingly.

--- a/python/discopt/course/advanced/21_spatial_branch_and_bound/exercises.ipynb
+++ b/python/discopt/course/advanced/21_spatial_branch_and_bound/exercises.ipynb
@@ -1,0 +1,87 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "# Lesson 21 \u2014 Exercises"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## Exercise 1 \u2014 Trace a spatial-B&B node (15 pts)\n\nFor $\\min x y$ s.t. $x + y \\ge 1, x, y \\in [0, 2]$, solve the McCormick relaxation by hand at the root box. Then branch $x$ at $1$ and resolve both children. Record bounds at each step; verify the global optimum."
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "# Standard discopt course imports. The lessons target the real\n# `discopt.modeling.core.Model` API: `m.continuous(name, shape=..., lb=..., ub=...)`,\n# `m.binary(name, shape=...)`, `m.integer(name, shape=..., lb=..., ub=...)`,\n# `m.subject_to(...)`, `m.minimize(...) / .maximize(...)`, `m.solve(...)`.\n# Result attributes: `r.status`, `r.objective`, `r.gap`, `r.bound`,\n# `r.wall_time`, `r.node_count`, and `r.value(var)` for variable arrays.\nimport numpy as np\nimport discopt as do\nimport discopt.modeling as dm\n"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "# TODO\n"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## Exercise 2 \u2014 OBBT vs no-BBT (15 pts)\n\nFor a 3-bilinear MINLP of your choice, solve `mode='global'` (i) with OBBT enabled, (ii) disabled. Compare nodes and time."
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "# TODO\n"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## Exercise 3 \u2014 Branching rule comparison (15 pts)\n\nSwap between `branching='most_violated'` and `branching='longest_edge'` on the same problem. Compare nodes."
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "# TODO\n"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## Exercise 4 \u2014 Build your own (20 pts)\n\nImplement a *minimal* spatial B&B in ~150 lines: McCormick at each node, depth-first node selection, midpoint branching. Test on 3 small bilinear NLPs."
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "# TODO\n"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## Exercise 5 \u2014 Diagnose stalled gap (5 pts)\n\nPick a MINLP whose gap doesn't close after 5,000 nodes. Diagnose: is it bounds, symmetry, or convex-envelope tightness?"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "**Your diagnosis:** ..."
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/python/discopt/course/advanced/21_spatial_branch_and_bound/reading.ipynb
+++ b/python/discopt/course/advanced/21_spatial_branch_and_bound/reading.ipynb
@@ -1,0 +1,67 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "# Lesson 21 \u2014 Spatial Branch-and-Bound\n\n## Learning objectives\n\n1. State the spatial-B&B algorithm for nonconvex MINLP.\n2. Recognize the role of FBBT, OBBT, and convex relaxations inside the tree.\n3. Read a `discopt` global-mode log: bounds, gap, node count.\n4. Diagnose when spatial B&B is failing (gap not closing)."
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## 1. Algorithm\n\n```\nStack = {root box B}\nLB = -inf, UB = +inf, incumbent = None\nwhile gap > tol and Stack non-empty:\n    pick node N (with box B_N)\n    LB_N = solve convex relaxation over B_N\n    if relaxation infeasible:        continue   # prune (infeasibility)\n    if LB_N >= UB - tol:              continue   # prune (bound)\n    if relaxation looks \"tight\" \u2014 auxiliaries near McCormick-tight,\n       integer variables near-integer:\n        x_local = local_NLP(N)                  # try to recover a primal point\n        if x_local feasible: UB <- min(UB, f(x_local))\n    if (UB - LB_N) / max(1, |UB|) < tol: continue   # gap closed at this node\n    pick branching variable j (most violated, longest edge, etc.)\n    split B_N along j -> two children, push\nupdate LB <- min LB_N over open nodes\n```\n\nThis is the spatial B&B of {cite:p}`Smith1999,Tawarmalani2005,Belotti2009`. The key differences from MILP B&B (Lesson 6) are **branching on continuous variables** (typically the auxiliaries $w_{ij} = x_i x_j$ that linearise nonconvex terms) to refine the convex relaxation, and the `relaxation looks tight` cue for the local-NLP recovery \u2014 bare integer feasibility isn't enough since continuous nonconvexities remain."
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## 2. Convex relaxation at a node\n\nFor each nonconvex term, build the McCormick (Lesson 16) or \u03b1BB underestimator over the *current* box. The relaxation is an LP (if all relaxations are linear) or convex NLP, solved cheaply at each node.\n\nThis is why **bound tightening** (Lesson 15) is so critical in MINLP \u2014 each tightening *retroactively* tightens every relaxation in the tree."
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## 3. Branching\n\nContinuous branching variables are picked by:\n\n- **Most violated** \u2014 branch on the variable whose envelope inequality is most violated by the LP solution.\n- **Longest edge** \u2014 bisect the longest box edge.\n- **Pseudocost-style** (recent literature).\n\nWhere to split (golden ratio? mid-point?): typically at the LP solution value or midpoint, with safeguards."
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## 4. Convergence and termination\n\nSpatial B&B is **finite for \u03b5-optimality** but not finite in exact arithmetic for general nonconvex MINLPs. Convergence is by gap squeezing: every infinite branching sequence must shrink some box dimension to zero, eventually making the relaxation exact at the limit point {cite:p}`HorstTuy1996,Floudas1999`.\n\nPractical termination: gap < \u03b5 (relative or absolute), or node/time limit."
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "# Standard discopt course imports. The lessons target the real\n# `discopt.modeling.core.Model` API: `m.continuous(name, shape=..., lb=..., ub=...)`,\n# `m.binary(name, shape=...)`, `m.integer(name, shape=..., lb=..., ub=...)`,\n# `m.subject_to(...)`, `m.minimize(...) / .maximize(...)`, `m.solve(...)`.\n# Result attributes: `r.status`, `r.objective`, `r.gap`, `r.bound`,\n# `r.wall_time`, `r.node_count`, and `r.value(var)` for variable arrays.\nimport numpy as np\nimport discopt as do\nimport discopt.modeling as dm\n"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "import numpy as np, discopt as do\nfrom discopt.modeling import Model, sin, cos\n\n# Nonconvex MINLP: pump network design (toy)\nm = Model(\"pump_net\")\nx = m.continuous(\"x\", lb=0, ub=10)     # flow\ny = m.continuous(\"y\", lb=0, ub=10)     # pressure\nm.subject_to(x * y >= 6)                  # work\nm.subject_to(0.5 * x**2 + y <= 12)        # head loss\nm.minimize(0.1 * x**3 + y)                    # power cost\n\nr = m.solve()\nprint(f\"global: f* = {r.objective:.6f} at x = {r.x}\")\nprint(f\"closed gap to: {r.gap:.2e}, nodes = {r.node_count}\")\n"
+  },
+  {
+   "cell_type": "markdown",
+   "id": "levers-45087",
+   "metadata": {},
+   "source": "## 5. Levers in `discopt`'s spatial B&B\n\nThe Python API for `m.solve()` exposes the knobs you actually reach for\nwhen a spatial B&B run is not closing:\n\n| Argument | Effect |\n|---|---|\n| `time_limit=<sec>` | Wall-clock deadline, honored even inside the JIT-compiled JAX IPM (no waiting for the current node to finish). |\n| `gap_tolerance=<eps>` | Relative optimality gap for termination. |\n| `initial_solution={var: value, ...}` | Warm-start: validated, clamped/rounded if needed, and *injected as the initial incumbent* so the bound has something to prune against from node zero. |\n| `partitions=k` | Use $k$ piecewise McCormick partitions per nonconvex term instead of the single-piece envelope. Tighter relaxation at $O(k)$ size cost. |\n| `nlp_bb=True/False` | Force NLP-BB (convex MINLP) or spatial B&B. Default `None` auto-detects. |\n| `skip_convex_check=False` | Default behavior runs the convexity certificate (Lesson 16 \u00a76); a convex-fast-path skip means `r.convex_fast_path == True` and no spatial branching at all. |\n| `incumbent_callback`, `lazy_constraints`, `node_callback` | Extension hooks for custom acceptance, lazy cuts, or per-batch monitoring. |\n| `validate=True` | Re-validate the returned primal independently (Lesson 4: this also surfaces `r.constraint_duals` for the relaxation at the root). |\n\nInternally, `discopt` also runs **fractional-power lifts** and piecewise\nsecant relaxations on monomials like $x^{1/p}$ at the root, which is what\nlets it close gas-network-style MINLPs in finite time\n{cite:p}`Belotti2009`."
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## 6. When spatial B&B fails\n\n- **Loose bounds** \u2192 loose envelopes \u2192 loose relaxations \u2192 no pruning. Fix: bound tightening, OBBT, branching on bounds.\n- **Symmetry** \u2192 many equivalent nodes. Fix: lex breaking (Lesson 29).\n- **High dimension** \u2192 curse of dimensionality on box partitioning. Fix: structure (Benders, Lagrangian) when applicable.\n\n## References\n{cite:p}`Smith1999,Tawarmalani2005,Belotti2009,Belotti2013,Floudas1999,HorstTuy1996`."
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/python/discopt/course/advanced/21_spatial_branch_and_bound/rubric.md
+++ b/python/discopt/course/advanced/21_spatial_branch_and_bound/rubric.md
@@ -1,0 +1,25 @@
+# Rubric — Lesson 21
+
+## Exercises (70)
+- E1 (15): trace correct; bounds tight at termination.
+- E2 (15): OBBT impact measured.
+- E3 (15): branching rules compared.
+- E4 (20): toy spatial B&B works on 3 problems.
+- E5 (5): diagnostic plausible.
+
+## Writing (30)
+
+- **Concept coverage (10):** the response names ≥ 3 specific concepts from
+  this lesson with a one-line definition or formula each, AND references at
+  least one numerical result the student produced in the exercise notebook
+  (objective value, runtime, gap, plot point).
+- **Technical correctness (10):** every claim about complexity, an algorithm,
+  or a solver's behaviour is either a citation or a derivation; nothing
+  factually wrong per the assessor's checklist for this lesson.
+- **Citations (5):** ≥ 2 `{cite:p}` keys resolve in `docs/references.bib`,
+  at least one of which is a recommended reference for this lesson; no
+  invented or unverifiable keys.
+- **Engagement (5):** the response cites a specific surprise, equation,
+  measurement, or solver-log line the student personally observed — not a
+  generic platitude.
+

--- a/python/discopt/course/advanced/21_spatial_branch_and_bound/writing.md
+++ b/python/discopt/course/advanced/21_spatial_branch_and_bound/writing.md
@@ -1,0 +1,7 @@
+# Writing assignment — Lesson 21
+
+In ~700 words, explain why spatial B&B for nonconvex MINLP is *fundamentally
+harder* than MILP B&B. Use {cite:p}`Tawarmalani2005,Belotti2009`. Address:
+(i) the LP-vs-convex-relaxation distinction; (ii) why bound tightening
+matters more than branching rules in the MINLP setting; (iii) when one would
+choose a global solver over a local NLP solver with multistart.

--- a/python/discopt/course/advanced/22_global_optimization_theory/exercises.ipynb
+++ b/python/discopt/course/advanced/22_global_optimization_theory/exercises.ipynb
@@ -1,0 +1,87 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "# Lesson 22 \u2014 Exercises"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## Exercise 1 \u2014 Test functions (20 pts)\n\nSolve to global optimality (or report gap after 5 minutes) the following:\n\n- Goldstein-Price ($f^\\star = 3$ at $(0, -1)$)\n- Branin ($f^\\star \\approx 0.398$ at three points)\n- Hartmann-6 (6D, $f^\\star \\approx -3.32$)\n\nReport bounds at termination."
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "# Standard discopt course imports. The lessons target the real\n# `discopt.modeling.core.Model` API: `m.continuous(name, shape=..., lb=..., ub=...)`,\n# `m.binary(name, shape=...)`, `m.integer(name, shape=..., lb=..., ub=...)`,\n# `m.subject_to(...)`, `m.minimize(...) / .maximize(...)`, `m.solve(...)`.\n# Result attributes: `r.status`, `r.objective`, `r.gap`, `r.bound`,\n# `r.wall_time`, `r.node_count`, and `r.value(var)` for variable arrays.\nimport numpy as np\nimport discopt as do\nimport discopt.modeling as dm\n"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "# TODO\n"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## Exercise 2 \u2014 Multi-start vs global (15 pts)\n\nFor each test function, run a *local* solver from 100 random starts. Compare the best multi-start objective to the certified global optimum. How often does multi-start succeed? Time both."
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "# TODO\n"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## Exercise 3 \u2014 Lasserre on a small QCQP (15 pts)\n\nFor $\\min x_1^2 - x_2^2$ s.t. $x_1^2 + x_2^2 \\le 1$, solve with degree-2 and degree-4 Lasserre relaxations (use `cvxpy` or any SDP solver). Compare bounds."
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "# TODO\n"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## Exercise 4 \u2014 Curse of dimensionality (10 pts)\n\nFor a separable nonconvex objective $f(x) = \\sum_i (x_i^2 - 1)^2$ on $[-2, 2]^n$, solve with `mode='global'` for $n = 2, 4, 6, 8, 10$. Plot solve time vs $n$."
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "# TODO\n"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## Exercise 5 \u2014 When global fails (10 pts)\n\nDescribe (in words) two situations where deterministic global optimization is the wrong tool (e.g., black-box objective, very high dimension, very tight time budget)."
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "**Your answer:** ..."
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/python/discopt/course/advanced/22_global_optimization_theory/reading.ipynb
+++ b/python/discopt/course/advanced/22_global_optimization_theory/reading.ipynb
@@ -1,0 +1,66 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "# Lesson 22 \u2014 Global Optimization Theory\n\n## Learning objectives\n\n1. Distinguish deterministic vs heuristic global optimization.\n2. State convergence guarantees of spatial B&B and their hypotheses.\n3. Recognize the role of factorable functions and convex envelopes.\n4. Understand the Lasserre / SDP hierarchy for polynomial optimization."
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## 1. Deterministic vs heuristic\n\n- **Deterministic** (spatial B&B, \u03b1BB, BARON, Couenne, ANTIGONE): finite \u03b5-convergence; certified optimum.\n- **Heuristic** (DIRECT, GA, simulated annealing, basin hopping): no certified optimum; in practice often fast first incumbent but no termination criterion.\n\nThis course is about *deterministic* global optimization {cite:p}`Floudas1999,HorstTuy1996`. Heuristics have their place but cannot certify optimality."
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## 2. Factorable functions\n\nMost practical NLPs use **factorable** functions: built up from elementary operators (+, \u00d7, \u00f7, exp, log, sin, ...) on continuous variables. The convex-envelope construction in Lesson 16 applies term-by-term.\n\nFor non-factorable functions (oracle-only, black-box), Bayesian optimization or trust-region surrogate methods are alternatives \u2014 but no global certificate."
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## 3. Convergence\n\n**Theorem (informal, {cite:p}`HorstTuy1996,Floudas1999`):** spatial B&B with consistent bounding (relaxation gap \u2192 0 as box \u2192 point) and exhaustive partitioning ($\\sup_N \\text{diam}(B_N) \\to 0$) converges to the global optimum.\n\nThe hypotheses are mild \u2014 McCormick + bisection satisfies them. So convergence isn't the question; *speed* is."
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## 4. Worst-case complexity\n\n**Unbounded-integer** polynomial MINLP is undecidable (Hilbert's 10th problem: deciding whether a polynomial Diophantine equation has an integer solution is undecidable, and it embeds into the feasibility question for an unbounded-integer NLP). For **bounded-box** problems with rational coefficients and bounded integer variables, the problem is decidable; the existential theory of the reals on bounded boxes is in PSPACE, and bounded MINLP is at least NP-hard already in the quadratic case. Finite-precision algorithms (including spatial B&B) are exponential in the worst case.\n\n**Practical lesson:** in the worst case, spatial B&B is exponential in the number of nonconvex variables. Reformulate to convexify when possible (e.g., GDP, Lesson 23)."
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## 5. Lasserre / SDP hierarchy\n\nFor polynomial optimization\n\n$$\\min p(x) \\;\\;\\text{s.t.}\\;\\; g_i(x) \\ge 0,$$\n\na sequence of SDPs of increasing degree provides monotonically improving lower bounds, converging to the global optimum (Lasserre 2001). Practical for low-degree problems with few variables; doesn't scale to high-dimensional industrial problems.\n\nSum-of-squares (SOS) certificates are the dual viewpoint."
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "# Standard discopt course imports. The lessons target the real\n# `discopt.modeling.core.Model` API: `m.continuous(name, shape=..., lb=..., ub=...)`,\n# `m.binary(name, shape=...)`, `m.integer(name, shape=..., lb=..., ub=...)`,\n# `m.subject_to(...)`, `m.minimize(...) / .maximize(...)`, `m.solve(...)`.\n# Result attributes: `r.status`, `r.objective`, `r.gap`, `r.bound`,\n# `r.wall_time`, `r.node_count`, and `r.value(var)` for variable arrays.\nimport numpy as np\nimport discopt as do\nimport discopt.modeling as dm\n"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "import numpy as np, discopt as do\nfrom discopt.modeling import Model\n\n# Box-constrained polynomial; classical Goldstein-Price test function\nm = Model(\"gp\")\nx = m.continuous(\"x\", lb=-2, ub=2)\ny = m.continuous(\"y\", lb=-2, ub=2)\nf = ((1 + (x + y + 1)**2 * (19 - 14*x + 3*x**2 - 14*y + 6*x*y + 3*y**2)) *\n     (30 + (2*x - 3*y)**2 * (18 - 32*x + 12*x**2 + 48*y - 36*x*y + 27*y**2)))\nm.minimize(f)\n\nr = m.solve(time_limit=120)\n# Known global min: f* = 3 at (0, -1)\nprint(f\"global: f* = {r.objective:.6f} at x = {r.x}\")\n"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## References\n{cite:p}`Floudas1999,HorstTuy1996,Tawarmalani2005,Belotti2013`."
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/python/discopt/course/advanced/22_global_optimization_theory/rubric.md
+++ b/python/discopt/course/advanced/22_global_optimization_theory/rubric.md
@@ -1,0 +1,25 @@
+# Rubric — Lesson 22
+
+## Exercises (70)
+- E1 (20) Three test functions; bounds reported.
+- E2 (15) Multi-start success rates measured.
+- E3 (15) Lasserre bounds increase with degree.
+- E4 (10) Time vs $n$ curve produced.
+- E5 (10) Two limitations articulated.
+
+## Writing (30)
+
+- **Concept coverage (10):** the response names ≥ 3 specific concepts from
+  this lesson with a one-line definition or formula each, AND references at
+  least one numerical result the student produced in the exercise notebook
+  (objective value, runtime, gap, plot point).
+- **Technical correctness (10):** every claim about complexity, an algorithm,
+  or a solver's behaviour is either a citation or a derivation; nothing
+  factually wrong per the assessor's checklist for this lesson.
+- **Citations (5):** ≥ 2 `{cite:p}` keys resolve in `docs/references.bib`,
+  at least one of which is a recommended reference for this lesson; no
+  invented or unverifiable keys.
+- **Engagement (5):** the response cites a specific surprise, equation,
+  measurement, or solver-log line the student personally observed — not a
+  generic platitude.
+

--- a/python/discopt/course/advanced/22_global_optimization_theory/writing.md
+++ b/python/discopt/course/advanced/22_global_optimization_theory/writing.md
@@ -1,0 +1,7 @@
+# Writing assignment — Lesson 22
+
+In ~700 words, defend the claim that "global optimization without certificate
+isn't optimization." Address: (i) what a certificate buys (proof of
+optimality, repeatability); (ii) when heuristics are nonetheless the right
+choice; (iii) the role of convex relaxations as the *engine* of
+certification. Cite {cite:p}`Floudas1999,HorstTuy1996,Tawarmalani2005`.

--- a/python/discopt/course/advanced/23_generalized_disjunctive_programming/exercises.ipynb
+++ b/python/discopt/course/advanced/23_generalized_disjunctive_programming/exercises.ipynb
@@ -1,0 +1,87 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "# Lesson 23 \u2014 Exercises"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## Exercise 1 \u2014 Big-M vs hull (20 pts)\n\nFor a 4-disjunction GDP of your choice, solve with big-M and with convex-hull reformulation. Compare LP relaxation gap, nodes, and time."
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "# Standard discopt course imports. The lessons target the real\n# `discopt.modeling.core.Model` API: `m.continuous(name, shape=..., lb=..., ub=...)`,\n# `m.binary(name, shape=...)`, `m.integer(name, shape=..., lb=..., ub=...)`,\n# `m.subject_to(...)`, `m.minimize(...) / .maximize(...)`, `m.solve(...)`.\n# Result attributes: `r.status`, `r.objective`, `r.gap`, `r.bound`,\n# `r.wall_time`, `r.node_count`, and `r.value(var)` for variable arrays.\nimport numpy as np\nimport discopt as do\nimport discopt.modeling as dm\n"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "# TODO\n"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## Exercise 2 \u2014 Reactor network (20 pts)\n\nThree-stage reactor network, each stage choosing among {CSTR, PFR, plug-flow with recycle}. Find the cheapest configuration meeting a yield target. Use convex-hull reformulation throughout."
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "# TODO\n"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## Exercise 3 \u2014 Logical constraints (10 pts)\n\nEncode the implication 'if reactor A and reactor B both chosen, then separator X is required' as linear constraints on the binary indicators. Verify it works on a 3-disjunction toy model."
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "# TODO\n"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## Exercise 4 \u2014 Nested disjunction (10 pts)\n\nWrite a 2-level nested disjunction (outer: technology family; inner: vendor within family). Reformulate to flat MINLP. How many binaries?"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "# TODO\n"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## Exercise 5 \u2014 When big-M is fine (10 pts)\n\nGive an example where big-M is *naturally tight* (because variable bounds are intrinsic) and convex hull would be wasteful. Justify."
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "**Your answer:** ..."
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/python/discopt/course/advanced/23_generalized_disjunctive_programming/reading.ipynb
+++ b/python/discopt/course/advanced/23_generalized_disjunctive_programming/reading.ipynb
@@ -1,0 +1,61 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "# Lesson 23 \u2014 Generalized Disjunctive Programming\n\n## Learning objectives\n\n1. Write a GDP with disjunctions over algebraic constraints.\n2. Convert GDP to MINLP via big-M and convex-hull reformulations.\n3. Recognize when convex hull is worth the extra variables.\n4. Use `discopt`'s GDP frontend (or build one)."
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## 1. Disjunctive programming\n\nA *disjunction* is an \"or\": at least one branch must hold. Standard form {cite:p}`Raman1994,Grossmann2013`:\n\n$$\n\\bigvee_{k \\in K} \\begin{bmatrix} Y_k \\\\ A_k x \\le b_k \\\\ f_k(x) \\le 0 \\end{bmatrix}\n$$\n\nwith $Y_k$ a Boolean variable. Exactly one $Y_k$ is True. The constraints in branch $k$ are active iff $Y_k$ is True.\n\nLogical constraints between $Y_k$'s can be expressed (e.g., $Y_1 \\lor Y_2 \\Rightarrow \\neg Y_3$).\n\nGDP is *the* natural framework for process synthesis problems with discrete unit-selection decisions {cite:p}`Grossmann2013,Trespalacios2015`."
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## 2. Big-M reformulation\n\nConvert each disjunctive constraint $A_k x \\le b_k$ to\n\n$$A_k x \\le b_k + M_k (1 - y_k)$$\n\nwith binary $y_k$ corresponding to $Y_k$, and $\\sum_k y_k = 1$. Plus indicators on $f_k(x) \\le 0$.\n\n**Pros:** simple, smaller model.\n**Cons:** weak relaxation; tightness depends on $M_k$ {cite:p}`Sawaya2005`."
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## 3. Convex-hull reformulation\n\nFor each $k$, introduce a copy $x_k$ of the variables. Let $x = \\sum_k x_k$. Constrain $A_k x_k \\le b_k y_k$ and $\\sum_k y_k = 1$, $y_k \\in [0, 1]$. The shorthand $x_k \\in y_k X_k$ unfolds into the explicit **bound-scaling** constraints $\\underline x \\, y_k \\le x_k \\le \\overline x \\, y_k$, which force $x_k = 0$ whenever $y_k = 0$. The convex hull of the disjunction is then:\n\n$$x = \\sum_k x_k, \\quad A_k x_k \\le b_k y_k, \\quad \\underline x \\, y_k \\le x_k \\le \\overline x \\, y_k, \\quad \\sum_k y_k = 1, \\; y \\ge 0.$$\n\nFor nonlinear convex $f_k$, the natural extension uses the **perspective function**: for a convex $f$ on a domain $D$, the perspective $\\tilde f(x, y) = y f(x / y)$ for $y > 0$ (with $\\tilde f(0, 0) = 0$ and $\\tilde f(x, 0) = +\\infty$ otherwise) is jointly convex in $(x, y)$ and provides the tightest convex underestimator of \"$y = 1 \\Rightarrow f(x) \\le t$, $y = 0 \\Rightarrow x = 0$\" {cite:p}`Trespalacios2015`. We meet it again systematically in Lesson 29.\n\n**Pros:** tightest possible LP relaxation.\n**Cons:** $|K|$ copies of variables (model size grows). Worth it when big-M is loose."
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## 4. Practical recipe\n\nDefault: big-M with carefully derived $M$. Switch to convex hull when:\n\n- big-M values are \"large\" (no natural physical bound),\n- the problem is solving slowly with much branching on indicators,\n- the disjunction has a small number of branches ($|K| \\le 3$).\n\nIn `discopt`, the GDP-style frontend (`Disjunct` / `add_disjunction`) is still maturing; today most users build the chosen reformulation **manually** (see the reactor cell below for big-M, and Exercises 1 and 2 for hull). {cite:p}`Sawaya2005`."
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "# Standard discopt course imports. The lessons target the real\n# `discopt.modeling.core.Model` API: `m.continuous(name, shape=..., lb=..., ub=...)`,\n# `m.binary(name, shape=...)`, `m.integer(name, shape=..., lb=..., ub=...)`,\n# `m.subject_to(...)`, `m.minimize(...) / .maximize(...)`, `m.solve(...)`.\n# Result attributes: `r.status`, `r.objective`, `r.gap`, `r.bound`,\n# `r.wall_time`, `r.node_count`, and `r.value(var)` for variable arrays.\nimport numpy as np\nimport discopt as do\nimport discopt.modeling as dm\n"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "# Process synthesis: pick reactor type (CSTR or PFR) for one stage.\n# CSTR: cost 100 + 5*F   (F flow)\n# PFR : cost 60  + 8*F + 0.5*F^2\n# Production target F = 4. Minimize cost.\n#\n# discopt's high-level GDP API takes Disjunct objects (see discopt.modeling.Disjunct).\n# Below we implement the same problem manually with the big-M reformulation \u2014\n# this works against the stable real API today and is what the GDP frontend\n# emits internally.\nimport numpy as np, discopt as do\nfrom discopt.modeling import Model\n\nm = Model(\"reactor\")\nF = m.continuous(\"F\", lb=0, ub=10)\ny_cstr = m.binary(\"y_cstr\"); y_pfr = m.binary(\"y_pfr\")\ncost = m.continuous(\"cost\", lb=0, ub=1000)\nM = 1000\n\nm.subject_to(F == 4)\nm.subject_to(y_cstr + y_pfr == 1)                              # exactly one\n# CSTR active: cost \u2265 100 + 5F  (and \u2264 same, when active)\nm.subject_to(cost >= 100 + 5 * F - M * (1 - y_cstr))\nm.subject_to(cost <= 100 + 5 * F + M * (1 - y_cstr))\n# PFR active\nm.subject_to(cost >= 60 + 8 * F + 0.5 * F**2 - M * (1 - y_pfr))\nm.subject_to(cost <= 60 + 8 * F + 0.5 * F**2 + M * (1 - y_pfr))\nm.minimize(cost)\nr = m.solve()\nprint(\"chosen reactor:\", \"CSTR\" if r.value(y_cstr) > 0.5 else \"PFR\")\nprint(\"cost          :\", r.objective)\n"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## 5. Beyond two-branch disjunctions\n\nMulti-branch disjunctions (3 or more options) and *nested* disjunctions are common in process synthesis. The convex-hull reformulation generalizes; big-M does too but loses tightness.\n\nLogical constraints between disjunctions (e.g., \"if reactor type A is chosen at stage 1 then separator type X cannot be chosen at stage 2\") are easy to express as Boolean implications and reformulate to linear constraints on $y$.\n\n## References\n{cite:p}`Raman1994,Grossmann2013,Trespalacios2015,Sawaya2005`."
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/python/discopt/course/advanced/23_generalized_disjunctive_programming/rubric.md
+++ b/python/discopt/course/advanced/23_generalized_disjunctive_programming/rubric.md
@@ -1,0 +1,25 @@
+# Rubric — Lesson 23
+
+## Exercises (70)
+- E1 (20): big-M vs hull comparison; numbers reported.
+- E2 (20): reactor network solved; cheapest config returned.
+- E3 (10): logical implication encoded; verified.
+- E4 (10): nested disjunction flat-reformulated.
+- E5 (10): tight-bigM example given.
+
+## Writing (30)
+
+- **Concept coverage (10):** the response names ≥ 3 specific concepts from
+  this lesson with a one-line definition or formula each, AND references at
+  least one numerical result the student produced in the exercise notebook
+  (objective value, runtime, gap, plot point).
+- **Technical correctness (10):** every claim about complexity, an algorithm,
+  or a solver's behaviour is either a citation or a derivation; nothing
+  factually wrong per the assessor's checklist for this lesson.
+- **Citations (5):** ≥ 2 `{cite:p}` keys resolve in `docs/references.bib`,
+  at least one of which is a recommended reference for this lesson; no
+  invented or unverifiable keys.
+- **Engagement (5):** the response cites a specific surprise, equation,
+  measurement, or solver-log line the student personally observed — not a
+  generic platitude.
+

--- a/python/discopt/course/advanced/23_generalized_disjunctive_programming/writing.md
+++ b/python/discopt/course/advanced/23_generalized_disjunctive_programming/writing.md
@@ -1,0 +1,7 @@
+# Writing assignment — Lesson 23
+
+In ~600 words, explain why **GDP is the natural language for discrete-continuous
+optimization** in chemical engineering. Use {cite:p}`Grossmann2013`. Address:
+(i) why writing the disjunction directly is more honest than encoding it as
+big-M; (ii) the convex-hull vs big-M trade-off; (iii) how nested disjunctions
+arise. Cite {cite:p}`Trespalacios2015,Raman1994`.

--- a/python/discopt/course/advanced/24_nn_embedded_minlp/exercises.ipynb
+++ b/python/discopt/course/advanced/24_nn_embedded_minlp/exercises.ipynb
@@ -1,0 +1,89 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "# Lesson 24 \u2014 Exercises"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## Exercise 1 \u2014 Train + embed (15 pts)\n\nTrain a 2-hidden-layer ReLU MLP on a 2D function (your choice; say the Branin function). Embed in `discopt.nn` and find its global maximum. Compare to the true Branin maximum. What's the surrogate error?"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "# Standard discopt course imports. The lessons target the real\n# `discopt.modeling.core.Model` API: `m.continuous(name, shape=..., lb=..., ub=...)`,\n# `m.binary(name, shape=...)`, `m.integer(name, shape=..., lb=..., ub=...)`,\n# `m.subject_to(...)`, `m.minimize(...) / .maximize(...)`, `m.solve(...)`.\n# Result attributes: `r.status`, `r.objective`, `r.gap`, `r.bound`,\n# `r.wall_time`, `r.node_count`, and `r.value(var)` for variable arrays.\nimport numpy as np\nimport discopt as do\nimport discopt.modeling as dm\n"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "# TODO\n"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## Exercise 2 \u2014 ReLU big-M from scratch (20 pts)\n\nWrite the ReLU big-M constraints by hand (no `discopt.nn`). Verify by solving for a 2-2-1 network and checking against the embedded version."
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "# TODO\n"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## Exercise 3 \u2014 Bounds matter (15 pts)\n\nFor the same network, compare solve times when (i) using interval propagation (IBP), (ii) using OBBT layer-by-layer. What's the speedup?"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "# TODO\n"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## Exercise 4 \u2014 Smooth activation (10 pts)\n\nReplace ReLU with tanh and re-solve as a (nonconvex) MINLP. Use `mode='global'`. How does runtime compare?"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "# TODO\n"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## Exercise 5 \u2014 Surrogate loop (10 pts)\n\nImplement one iteration of a surrogate loop: train, embed-and-optimize, evaluate at candidate, record true objective. Does the candidate improve over random sampling?"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "# TODO\n"
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/python/discopt/course/advanced/24_nn_embedded_minlp/reading.ipynb
+++ b/python/discopt/course/advanced/24_nn_embedded_minlp/reading.ipynb
@@ -1,0 +1,61 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "# Lesson 24 \u2014 Neural-Network-Embedded MINLP\n\n## Learning objectives\n\n1. Encode a trained feedforward NN as algebraic constraints in an MINLP.\n2. Distinguish ReLU big-M, full-space, and reduced-space formulations.\n3. Use `discopt.nn` to embed a Keras / ONNX model.\n4. Apply NN-MINLP to surrogate-based optimization."
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## 1. Why embed a NN?\n\nYou have a trained NN that approximates an expensive physics simulation. You want to *optimize* over its inputs subject to other (algebraic) constraints. Three approaches:\n\n- **Black-box** (Bayesian / surrogate-based): cheap iterations, no certificate.\n- **Embed as constraint**: solver sees the NN as algebraic equations; with MINLP, you can certify global optimality of the surrogate.\n- **Differentiable layer** (Lesson 26): NN is a step inside a larger optimization-aware pipeline.\n\nNN-MINLP took off after {cite:p}`Fischetti2018` showed ReLU networks reduce to MILP, and {cite:p}`Anderson2020` introduced strong formulations. {cite:p}`Ceccon2022` (OMLT) is the modern toolkit; `discopt.nn` follows the same patterns."
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## 2. ReLU big-M\n\nLet $a = w^\\top x + b$ be the pre-activation, with bounds $\\underline a \\le a \\le \\overline a$. The activation $z = \\max(0, a)$ is encoded as:\n\n$$\n\\begin{aligned}\nz &\\ge a \\\\\nz &\\ge 0 \\\\\nz &\\le a - \\underline a (1 - y) \\\\\nz &\\le \\overline a \\, y \\\\\ny &\\in \\{0, 1\\}\n\\end{aligned}\n$$\n\nThis formulation is meaningful **only when the bounds straddle zero**, $\\underline a \\le 0 \\le \\overline a$ \u2014 then $y$ encodes which side ($a \\le 0$ vs $a \\ge 0$) is active. If $\\underline a \\ge 0$ the unit is in its linear regime ($z = a$, no binary needed); if $\\overline a \\le 0$ it is fixed off ($z = 0$). A practical ReLU embedder *checks each unit* and emits the cheapest valid form. Tight $\\underline a, \\overline a$ via bound propagation are critical to the LP-relaxation gap {cite:p}`Anderson2020,Fischetti2018`."
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## 3. Smooth activations (sigmoid, tanh)\n\nFor sigmoid $z = \\sigma(a)$, the constraint is genuinely nonlinear. Two options:\n\n- **Full-space**: keep $z = \\sigma(a)$ as a constraint; solve as MINLP.\n- **Reduced-space**: substitute the NN equations through, leaving a single nested expression. Smaller variable count but worse for spatial B&B.\n\n{cite:p}`Fischetti2018,Ceccon2022`."
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## 4. Bound propagation\n\nPropagate input bounds layer by layer. Split $w$ into non-negative and non-positive parts $w^+ = \\max(w, 0) \\ge 0$ and $w^- = \\max(-w, 0) \\ge 0$ (so $w = w^+ - w^-$). Then for each pre-activation $a = w^\\top x + b$ with $x \\in [\\underline x, \\overline x]$:\n\n$$\\underline a = (w^+)^\\top \\underline x \\;-\\; (w^-)^\\top \\overline x + b, \\quad \\overline a = (w^+)^\\top \\overline x \\;-\\; (w^-)^\\top \\underline x + b.$$\n\nFor deep networks, FBBT alone gives loose bounds; OBBT layer-by-layer is tighter. CROWN, IBP, and SymBP are NN-specific bound-propagation methods {cite:p}`Anderson2020`."
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "# Standard discopt course imports. The lessons target the real\n# `discopt.modeling.core.Model` API: `m.continuous(name, shape=..., lb=..., ub=...)`,\n# `m.binary(name, shape=...)`, `m.integer(name, shape=..., lb=..., ub=...)`,\n# `m.subject_to(...)`, `m.minimize(...) / .maximize(...)`, `m.solve(...)`.\n# Result attributes: `r.status`, `r.objective`, `r.gap`, `r.bound`,\n# `r.wall_time`, `r.node_count`, and `r.value(var)` for variable arrays.\nimport numpy as np\nimport discopt as do\nimport discopt.modeling as dm\n"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "# Hand-coded ReLU big-M for a tiny 2-input, 2-hidden, 1-output network.\n# (`discopt.nn` ships `NetworkDefinition` + `ReluBigMFormulation` /\n# `FullSpaceFormulation` etc.; we build the constraints manually below so\n# you can see the formulation, then Exercise 1 has you use the higher-level\n# `discopt.nn` API.)\nimport numpy as np, discopt as do\n\nnp.random.seed(0)\nW1 = np.random.normal(size=(2, 2)); b1 = np.zeros(2)\nW2 = np.random.normal(size=(2, 1)); b2 = np.zeros(1)\n\n# Pre-activation bound (straddles zero for x \u2208 [-1, 1]).\nm = do.Model(\"nn_opt\")\nx = m.continuous(\"x\", shape=(2,), lb=-1, ub=1)\na1 = W1 @ x + b1                                   # pre-activation, layer 1\nub1 = float(np.abs(W1).sum(axis=1).max() + np.abs(b1).max())\nz1 = m.continuous(\"z1\", shape=(2,), lb=0, ub=ub1)  # ReLU output, layer 1\ny1_int = m.binary(\"y1_int\", shape=(2,))\nfor i in range(2):\n    m.subject_to(z1[i] >= a1[i])\n    m.subject_to(z1[i] <= a1[i] + ub1 * (1 - y1_int[i]))\n    m.subject_to(z1[i] <= ub1 * y1_int[i])\ny_out = (W2 @ z1 + b2)[0]\nm.maximize(y_out)\nr = m.solve()\nprint(\"status:\", r.status, \" input:\", r.value(x), \" output \u2248\", r.objective)\n"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## 5. Surrogate-based optimization\n\nIf your NN approximates an expensive simulation, then:\n\n1. Sample inputs, evaluate simulation, train NN.\n2. Optimize via NN-MINLP to find a candidate input.\n3. Evaluate the simulation at that candidate.\n4. Add to training set, retrain (or fine-tune); iterate.\n\nThis is **Bayesian-flavoured but with MINLP** instead of Gaussian processes. Useful when the simulation is structured (e.g., reactor design where physics gives you a known input domain).\n\n## References\n{cite:p}`Fischetti2018,Anderson2020,Ceccon2022,Wang2022`."
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/python/discopt/course/advanced/24_nn_embedded_minlp/rubric.md
+++ b/python/discopt/course/advanced/24_nn_embedded_minlp/rubric.md
@@ -1,0 +1,25 @@
+# Rubric — Lesson 24
+
+## Exercises (70)
+- E1 (15) NN trained, embedded, optimum found; surrogate error reported.
+- E2 (20) Hand-coded ReLU big-M matches.
+- E3 (15) IBP vs OBBT speedup measured.
+- E4 (10) tanh global solve runs.
+- E5 (10) surrogate loop iteration; improvement vs random.
+
+## Writing (30)
+
+- **Concept coverage (10):** the response names ≥ 3 specific concepts from
+  this lesson with a one-line definition or formula each, AND references at
+  least one numerical result the student produced in the exercise notebook
+  (objective value, runtime, gap, plot point).
+- **Technical correctness (10):** every claim about complexity, an algorithm,
+  or a solver's behaviour is either a citation or a derivation; nothing
+  factually wrong per the assessor's checklist for this lesson.
+- **Citations (5):** ≥ 2 `{cite:p}` keys resolve in `docs/references.bib`,
+  at least one of which is a recommended reference for this lesson; no
+  invented or unverifiable keys.
+- **Engagement (5):** the response cites a specific surprise, equation,
+  measurement, or solver-log line the student personally observed — not a
+  generic platitude.
+

--- a/python/discopt/course/advanced/24_nn_embedded_minlp/writing.md
+++ b/python/discopt/course/advanced/24_nn_embedded_minlp/writing.md
@@ -1,0 +1,7 @@
+# Writing assignment — Lesson 24
+
+In ~700 words, explain why embedding a trained NN as an MINLP constraint is
+*qualitatively* different from black-box surrogate optimization. Address:
+(i) the move from optimization-of-NN to optimization-with-NN-as-constraint;
+(ii) what big-M tightness buys you; (iii) limitations: what stops us from
+embedding arbitrarily large networks? Cite {cite:p}`Fischetti2018,Anderson2020,Ceccon2022`.

--- a/python/discopt/course/advanced/25_robust_optimization/exercises.ipynb
+++ b/python/discopt/course/advanced/25_robust_optimization/exercises.ipynb
@@ -1,0 +1,89 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "# Lesson 25 \u2014 Exercises"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## Exercise 1 \u2014 Box vs ellipsoid (15 pts)\n\nFor a 5-variable random LP with uncertain $a$, solve robust counterparts under (i) box uncertainty $\\delta = 0.1 \\hat a$, (ii) ellipsoid of equivalent volume. Compare optimal objectives and solution sparsity."
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "# Standard discopt course imports. The lessons target the real\n# `discopt.modeling.core.Model` API: `m.continuous(name, shape=..., lb=..., ub=...)`,\n# `m.binary(name, shape=...)`, `m.integer(name, shape=..., lb=..., ub=...)`,\n# `m.subject_to(...)`, `m.minimize(...) / .maximize(...)`, `m.solve(...)`.\n# Result attributes: `r.status`, `r.objective`, `r.gap`, `r.bound`,\n# `r.wall_time`, `r.node_count`, and `r.value(var)` for variable arrays.\nimport numpy as np\nimport discopt as do\nimport discopt.modeling as dm\n"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "# TODO\n"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## Exercise 2 \u2014 Budget tuning (15 pts)\n\nFor a portfolio (uncertain returns), sweep $\\Gamma \\in \\{0, 1, 3, 5, n\\}$ in the budget formulation. Plot expected return vs worst-case return. The classic 'price of robustness' curve {cite:p}`BertsimasSim2004`."
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "# TODO\n"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## Exercise 3 \u2014 Adjustable LDR (15 pts)\n\nMulti-period inventory: 4 periods, demand uncertain in $[\\hat d - \\delta, \\hat d + \\delta]$. Order quantity in period $t$ is affine in *observed* demand history. Solve the LDR-RO and compare to static RO."
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "# TODO\n"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## Exercise 4 \u2014 Compare RO vs SP (15 pts)\n\nFor the same 5-variable LP, formulate (i) RO with budget $\\Gamma = 3$, (ii) SP with 100 sampled scenarios. Compare the optimal $x$. Discuss the trade-off."
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "# TODO\n"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## Exercise 5 \u2014 Robust scheduling (10 pts)\n\nScheduling with uncertain processing times: design a 5-task / 2-machine schedule robust to \u00b110% processing-time uncertainty using budget formulation."
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "# TODO\n"
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/python/discopt/course/advanced/25_robust_optimization/reading.ipynb
+++ b/python/discopt/course/advanced/25_robust_optimization/reading.ipynb
@@ -1,0 +1,61 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "# Lesson 25 \u2014 Robust Optimization\n\n## Learning objectives\n\n1. State the robust-counterpart paradigm.\n2. Recognize box, ellipsoidal, and budget uncertainty sets.\n3. Reformulate robust LPs as deterministic problems.\n4. Distinguish static from adjustable RO."
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## 1. Robust counterparts\n\nFor an LP $\\min c^\\top x$ s.t. $a_i^\\top x \\le b_i$ where $a_i \\in \\mathcal{U}_i$ (uncertainty set centred on the *nominal* $\\hat a_i$), the **robust counterpart** is\n\n$$\\min c^\\top x \\;\\;\\text{s.t.}\\;\\; a_i^\\top x \\le b_i \\;\\; \\forall a_i \\in \\mathcal{U}_i.$$\n\nEquivalent: $\\sup_{a \\in \\mathcal U_i} a^\\top x \\le b_i$, a *semi-infinite* constraint. Tractability hinges on reformulating this supremum {cite:p}`BenTal2009,BertsimasSim2004`.\n\n> **Notation note.** This lesson uses $\\hat a$ for the *nominal* (centre) value of an uncertain coefficient \u2014 distinct from $\\overline a / \\underline a$ which the rest of the course reserves for upper / lower *bounds*."
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## 2. Common uncertainty sets\n\n- **Box** $\\{a : |a_i - \\hat a_i| \\le \\delta_i\\}$ \u2192 reformulates to LP. Conservative.\n- **Ellipsoid** $\\{\\hat a + Pu : \\|u\\| \\le 1\\}$ \u2192 SOCP {cite:p}`BenTal1999`.\n- **Budget** {cite:p}`BertsimasSim2004` $\\{a : \\sum_i |a_i - \\hat a_i|/\\delta_i \\le \\Gamma\\}$ \u2192 LP. Adjustable conservatism via $\\Gamma$."
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## 3. Robust reformulations\n\n**Box uncertainty:**\n\n$$\\sup_{|\\Delta_i| \\le \\delta_i} (\\hat a + \\Delta)^\\top x = \\hat a^\\top x + \\sum_i \\delta_i |x_i| \\le b.$$\n\nLinearize $|x_i|$ with $x = x^+ - x^-, x^\\pm \\ge 0$.\n\n**Ellipsoidal:**\n\n$$\\hat a^\\top x + \\|P^\\top x\\|_2 \\le b.$$\n\nSOCP.\n\n**Budget {cite:p}`BertsimasSim2004`:**\n\n$$\\hat a^\\top x + \\max_{S \\subseteq [n], |S| \\le \\Gamma} \\sum_{i \\in S} \\delta_i |x_i| \\le b.$$\n\nReformulates to an LP with $O(n)$ extra variables."
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## 4. Adjustable RO\n\n**Static RO:** $x$ chosen before $\\xi$ realized.\n**Adjustable RO:** $y(\\xi)$ chosen after $\\xi$, can depend on it. Affine decision rules $y(\\xi) = y_0 + Y\\xi$ keep tractability {cite:p}`BenTalGoryashko2004`.\n\nMulti-stage RO is harder but surfaces in inventory, energy, and scheduling problems."
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "# Standard discopt course imports. The lessons target the real\n# `discopt.modeling.core.Model` API: `m.continuous(name, shape=..., lb=..., ub=...)`,\n# `m.binary(name, shape=...)`, `m.integer(name, shape=..., lb=..., ub=...)`,\n# `m.subject_to(...)`, `m.minimize(...) / .maximize(...)`, `m.solve(...)`.\n# Result attributes: `r.status`, `r.objective`, `r.gap`, `r.bound`,\n# `r.wall_time`, `r.node_count`, and `r.value(var)` for variable arrays.\nimport numpy as np\nimport discopt as do\nimport discopt.modeling as dm\n"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "# Robust LP: min c'x s.t. a'x >= b for all a in box around the nominal hat_a.\n# Since x is free in sign here, we keep the |x| linearisation x = x+ - x-.\n# (If you constrain x >= 0, |x_i| = x_i and you can drop x+/x-.)\nimport numpy as np, discopt as do\n\nn = 5\nnp.random.seed(0)\nhat_a = np.random.uniform(1, 5, size=n)            # nominal coefficients\ndelta = 0.2 * hat_a                                 # 20 % uncertainty\nb = 30.0\nc = np.random.uniform(1, 3, size=n)\n\nm = do.Model(\"robust_lp\")\nxp = m.continuous(\"xp\", shape=(n,), lb=0, ub=10)    # x = xp - xm, |x_i| = xp+xm\nxm = m.continuous(\"xm\", shape=(n,), lb=0, ub=10)\nx = xp - xm\nm.subject_to(hat_a @ x - delta @ (xp + xm) >= b)\nm.minimize(c @ x)\nr = m.solve()\nprint(\"status:\", r.status, \" robust obj:\", round(r.objective, 4),\n      \" x:\", (r.value(xp) - r.value(xm)).round(2))\n"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## 5. RO vs SP\n\n|  | RO | SP |\n|--|----|----|\n| Uncertainty | Worst case in $\\mathcal U$ | Probability distribution |\n| Solution | Min over $x$, max over $a$ | Min expected cost |\n| Tractability | Often LP/SOCP | LP with many scenarios |\n| Conservatism | Can be high; tunable via $\\Gamma$ | Tunable via risk measure |\n\nA mature robust optimizer reaches for both \u2014 RO when uncertainty is bounded but distributions are unknown, SP when distributions are reliable.\n\n## References\n{cite:p}`BenTal2009,BertsimasSim2004,BenTal1999,BenTalGoryashko2004,Bertsimas2010`."
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/python/discopt/course/advanced/25_robust_optimization/rubric.md
+++ b/python/discopt/course/advanced/25_robust_optimization/rubric.md
@@ -1,0 +1,25 @@
+# Rubric — Lesson 25
+
+## Exercises (70)
+- E1 (15) Box vs ellipsoid — both solved; comparison.
+- E2 (15) Price-of-robustness curve.
+- E3 (15) LDR-adjustable RO works; better than static.
+- E4 (15) RO vs SP compared meaningfully.
+- E5 (10) Scheduling with uncertain times.
+
+## Writing (30)
+
+- **Concept coverage (10):** the response names ≥ 3 specific concepts from
+  this lesson with a one-line definition or formula each, AND references at
+  least one numerical result the student produced in the exercise notebook
+  (objective value, runtime, gap, plot point).
+- **Technical correctness (10):** every claim about complexity, an algorithm,
+  or a solver's behaviour is either a citation or a derivation; nothing
+  factually wrong per the assessor's checklist for this lesson.
+- **Citations (5):** ≥ 2 `{cite:p}` keys resolve in `docs/references.bib`,
+  at least one of which is a recommended reference for this lesson; no
+  invented or unverifiable keys.
+- **Engagement (5):** the response cites a specific surprise, equation,
+  measurement, or solver-log line the student personally observed — not a
+  generic platitude.
+

--- a/python/discopt/course/advanced/25_robust_optimization/writing.md
+++ b/python/discopt/course/advanced/25_robust_optimization/writing.md
@@ -1,0 +1,6 @@
+# Writing assignment — Lesson 25
+
+In ~700 words, explain when an OR practitioner should reach for RO vs SP.
+Use the budget formulation {cite:p}`BertsimasSim2004` to argue that RO need
+not be excessively conservative. Address: (i) data requirements;
+(ii) tractability; (iii) interpretability of the result. Cite {cite:p}`BenTal2009`.

--- a/python/discopt/course/advanced/26_differentiable_optimization/exercises.ipynb
+++ b/python/discopt/course/advanced/26_differentiable_optimization/exercises.ipynb
@@ -1,0 +1,87 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "# Lesson 26 \u2014 Exercises"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## Exercise 1 \u2014 Implicit gradient by hand (15 pts)\n\nFor $x^\\star(\\theta) = \\arg\\min_x (x - \\theta)^2 + 0.1 x^2$, compute $dx^\\star/d\\theta$ analytically and via the implicit-function theorem. Verify they agree."
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "# Standard discopt course imports. The lessons target the real\n# `discopt.modeling.core.Model` API: `m.continuous(name, shape=..., lb=..., ub=...)`,\n# `m.binary(name, shape=...)`, `m.integer(name, shape=..., lb=..., ub=...)`,\n# `m.subject_to(...)`, `m.minimize(...) / .maximize(...)`, `m.solve(...)`.\n# Result attributes: `r.status`, `r.objective`, `r.gap`, `r.bound`,\n# `r.wall_time`, `r.node_count`, and `r.value(var)` for variable arrays.\nimport numpy as np\nimport discopt as do\nimport discopt.modeling as dm\n"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "# TODO\n"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## Exercise 2 \u2014 cvxpylayers QP (15 pts)\n\nSet up a portfolio QP in `cvxpylayers`. Differentiate the optimal weights with respect to expected-return inputs. Verify against finite differences."
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "# TODO\n"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## Exercise 3 \u2014 Decision-focused (20 pts)\n\nGenerate features $\\to$ true returns with structure. Fit a returns-predictor under (a) MSE, (b) decision-focused QP loss. Compare *realized* portfolio profit on held-out data."
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "# TODO\n"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## Exercise 4 \u2014 Differentiable LP (15 pts)\n\nUse the LP relaxation of a small MIP (e.g., assignment problem); differentiate the LP optimum w.r.t. cost coefficients. Where does differentiability break down?"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "# TODO\n"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## Exercise 5 \u2014 When NOT to differentiate (5 pts)\n\nGive an example where treating the constraint as a soft penalty would work better than putting it in a differentiable QP layer. Justify."
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "**Your answer:** ..."
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/python/discopt/course/advanced/26_differentiable_optimization/reading.ipynb
+++ b/python/discopt/course/advanced/26_differentiable_optimization/reading.ipynb
@@ -1,0 +1,59 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "# Lesson 26 \u2014 Differentiable Optimization\n\n## Learning objectives\n\n1. Differentiate an *argmin* with respect to its parameters via the implicit-function theorem.\n2. Use OptNet / cvxpylayers in a neural network {cite:p}`Amos2017,Agrawal2019`.\n3. Recognize the contexts where differentiable optimization wins.\n4. Understand the link to decision-focused learning (Lesson 27)."
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## 1. The implicit-function theorem\n\nFor an optimization problem $x^\\star(\\theta) = \\arg\\min_x f(x, \\theta)$, suppose $\\nabla_x f(x^\\star, \\theta) = 0$. Differentiating implicitly:\n\n$$\\nabla_{xx}^2 f \\cdot \\frac{\\partial x^\\star}{\\partial \\theta} + \\nabla_{x \\theta}^2 f = 0,$$\n\nso\n\n$$\\frac{\\partial x^\\star}{\\partial \\theta} = -[\\nabla_{xx}^2 f]^{-1} \\nabla_{x \\theta}^2 f.$$\n\nSame idea works for KKT systems with active inequality constraints \u2014 differentiate the KKT system implicitly {cite:p}`Amos2017`."
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## 2. OptNet\n\nEmbed a QP layer\n\n$$z(\\theta) = \\arg\\min_z \\tfrac{1}{2} z^\\top Q(\\theta) z + p(\\theta)^\\top z \\;\\;\\text{s.t.}\\;\\; A(\\theta) z = b(\\theta), \\; G(\\theta) z \\le h(\\theta)$$\n\ninside a neural network. The forward pass solves the QP; the backward pass differentiates through the KKT system. {cite:p}`Amos2017`.\n\nFor convex programs in DCP form, `cvxpylayers` {cite:p}`Agrawal2019` automates this \u2014 define your CP, get a PyTorch / JAX layer."
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## 3. When differentiable optimization wins\n\n- **Constraint as inductive bias:** the network output is *guaranteed* to satisfy a physical constraint (e.g., $\\sum_i w_i = 1$, a probability).\n- **Decision-focused learning:** train upstream prediction to minimize downstream decision regret (Lesson 27).\n- **Differentiable physics:** PDEs as optimization layers.\n\nWhen *not* to use it: when the constraint is a soft preference (just penalize), when the QP is large (forward + backward both expensive), or when discrete constraints dominate (differentiating MILP is hard)."
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## 4. Differentiating MIP\n\nStrict integer constraints are non-differentiable; approximations:\n\n- **LP relaxation + STE:** use LP-relaxed gradient on the backward pass.\n- **Smoothed perturbed argmax:** add Gumbel noise, take softmax {cite:p}`Mandi2020`.\n- **Sub-gradient via Fenchel-Young loss** {cite:p}`Elmachtoub2022`.\n\nThese give *useful* but biased gradients."
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "### Working tools for differentiable convex programs\n\n`discopt` does not ship a differentiable-optimization layer. For exercises\n2 and 3 below, install **`cvxpylayers`** (PyTorch / JAX) or **`qpth`**\n(the OptNet QP solver). A typical workflow:\n\n```python\nimport cvxpy as cp\nfrom cvxpylayers.torch import CvxpyLayer\n\nmu_p = cp.Parameter(n_assets)\nw_v  = cp.Variable(n_assets)\nprob = cp.Problem(\n    cp.Minimize(0.5 * cp.quad_form(w_v, Sigma) - mu_p @ w_v),\n    [cp.sum(w_v) == 1, w_v >= 0],\n)\nlayer = CvxpyLayer(prob, parameters=[mu_p], variables=[w_v])\n# layer(torch_mu) is now differentiable w.r.t. torch_mu.\n```\n\nThe decision-focused exercise below (E3) gives you the loss-function pattern;\nthe convex layer is what makes the gradient meaningful."
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## 5. Caveats\n\n- Forward pass: solver call per example per batch.\n- Backward pass: extra solve / KKT linear system.\n- Numerical conditioning: differentiating near the boundary of the feasible region or near degeneracy is unstable.\n\n## References\n{cite:p}`Amos2017,Agrawal2019,Mandi2020,Elmachtoub2022`."
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "# Standard discopt course imports. The lessons target the real\n# `discopt.modeling.core.Model` API: `m.continuous(name, shape=..., lb=..., ub=...)`,\n# `m.binary(name, shape=...)`, `m.integer(name, shape=..., lb=..., ub=...)`,\n# `m.subject_to(...)`, `m.minimize(...) / .maximize(...)`, `m.solve(...)`.\n# Result attributes: `r.status`, `r.objective`, `r.gap`, `r.bound`,\n# `r.wall_time`, `r.node_count`, and `r.value(var)` for variable arrays.\nimport numpy as np\nimport discopt as do\nimport discopt.modeling as dm\n"
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/python/discopt/course/advanced/26_differentiable_optimization/rubric.md
+++ b/python/discopt/course/advanced/26_differentiable_optimization/rubric.md
@@ -1,0 +1,25 @@
+# Rubric — Lesson 26
+
+## Exercises (70)
+- E1 (15) implicit gradient matches analytical.
+- E2 (15) cvxpylayers + finite-diff verification.
+- E3 (20) DF beats MSE on held-out regret.
+- E4 (15) LP differentiation; degeneracy noted.
+- E5 (5) sensible counter-example.
+
+## Writing (30)
+
+- **Concept coverage (10):** the response names ≥ 3 specific concepts from
+  this lesson with a one-line definition or formula each, AND references at
+  least one numerical result the student produced in the exercise notebook
+  (objective value, runtime, gap, plot point).
+- **Technical correctness (10):** every claim about complexity, an algorithm,
+  or a solver's behaviour is either a citation or a derivation; nothing
+  factually wrong per the assessor's checklist for this lesson.
+- **Citations (5):** ≥ 2 `{cite:p}` keys resolve in `docs/references.bib`,
+  at least one of which is a recommended reference for this lesson; no
+  invented or unverifiable keys.
+- **Engagement (5):** the response cites a specific surprise, equation,
+  measurement, or solver-log line the student personally observed — not a
+  generic platitude.
+

--- a/python/discopt/course/advanced/26_differentiable_optimization/writing.md
+++ b/python/discopt/course/advanced/26_differentiable_optimization/writing.md
@@ -1,0 +1,6 @@
+# Writing assignment — Lesson 26
+
+In ~700 words, explain to a deep-learning practitioner why differentiable
+optimization is more than "another fancy layer". Use {cite:p}`Amos2017,Agrawal2019`.
+Address: (i) the inductive-bias argument; (ii) the decision-focused learning
+argument; (iii) limitations — when LP/QP is too small a hammer.

--- a/python/discopt/course/advanced/27_ml_for_optimization/exercises.ipynb
+++ b/python/discopt/course/advanced/27_ml_for_optimization/exercises.ipynb
@@ -1,0 +1,87 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "# Lesson 27 \u2014 Exercises"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## Exercise 1 \u2014 Imitate strong branching (20 pts)\n\nGenerate a dataset of (node, strong-branching-decision) pairs by running 20 small MILPs with strong branching. Train a logistic regression on hand-crafted features. Evaluate top-1 accuracy on held-out nodes."
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "# Standard discopt course imports. The lessons target the real\n# `discopt.modeling.core.Model` API: `m.continuous(name, shape=..., lb=..., ub=...)`,\n# `m.binary(name, shape=...)`, `m.integer(name, shape=..., lb=..., ub=...)`,\n# `m.subject_to(...)`, `m.minimize(...) / .maximize(...)`, `m.solve(...)`.\n# Result attributes: `r.status`, `r.objective`, `r.gap`, `r.bound`,\n# `r.wall_time`, `r.node_count`, and `r.value(var)` for variable arrays.\nimport numpy as np\nimport discopt as do\nimport discopt.modeling as dm\n"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "# TODO\n"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## Exercise 2 \u2014 Plug into discopt (15 pts)\n\nUse your trained model in a `discopt` branching callback. On 5 unseen MILPs, compare nodes vs strong branching."
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "# TODO\n"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## Exercise 3 \u2014 Decision-focused training (20 pts)\n\nFor a small portfolio problem with predicted expected returns, train a returns-predictor twice: (i) MSE on returns; (ii) decision-focused (minimize regret of resulting portfolio). Compare regret on held-out data."
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "# TODO\n"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## Exercise 4 \u2014 GNN feature exploration (10 pts)\n\nFor a single MILP instance, compute features that a GNN over the variable-constraint graph would have access to. Confirm at least one is predictive of strong-branching decisions."
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "# TODO\n"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## Exercise 5 \u2014 Critical reading (5 pts)\n\nRead one of the recent papers in {cite:p}`Bengio2021,Gasse2019`. Note one claim you find weak and explain why."
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "**Your answer:** ..."
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/python/discopt/course/advanced/27_ml_for_optimization/reading.ipynb
+++ b/python/discopt/course/advanced/27_ml_for_optimization/reading.ipynb
@@ -1,0 +1,56 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "# Lesson 27 \u2014 Machine Learning for Optimization\n\n## Learning objectives\n\n1. Distinguish *learning to branch*, *learning to cut*, *learning primal heuristics*.\n2. Recognize the role of GNNs for instance representation {cite:p}`Gasse2019`.\n3. Understand decision-focused vs predict-then-optimize learning {cite:p}`Elmachtoub2022,Wilder2019`.\n4. Critically read a \"ML beats Gurobi\" paper."
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## 1. The taxonomy\n\n{cite:p}`Bengio2021` organize ML-for-optimization into:\n\n- **End-to-end learning**: predict the solution from instance features. Limited to easy problems.\n- **Configuring** combinatorial algorithms: choose hyperparameters per instance.\n- **Interleaved with B&B**: learn branching, cuts, heuristics inside the tree."
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## 2. Learning to branch\n\nReplace strong branching (Lesson 14) with a fast classifier trained to imitate it. {cite:p}`Gasse2019` use a GNN over the variable-constraint bipartite graph.\n\n**Training:** supervised \u2014 at each B&B node, log strong-branching scores, train classifier to predict argmax. **Inference:** use the classifier instead of strong branching, getting strong-branching quality at fraction of the cost.\n\nReported speedups: 2\u20135x on benchmark MILPs."
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## 3. Learning primal heuristics\n\nTrain a model to *propose* good integer-feasible incumbents from the LP relaxation. Often used early in B&B. {cite:p}`Bengio2021` survey several approaches.\n\n## 4. Decision-focused learning\n\nWhen the *output* of a predictive model is fed into an optimizer, training the predictor to minimize prediction error is suboptimal \u2014 what matters is the *decision quality*. {cite:p}`Wilder2019,Mandi2020,Elmachtoub2022` develop *decision-focused* training: differentiate the optimizer (Lesson 26) and propagate gradients."
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## 5. Reading the literature critically\n\nML-for-optimization papers vary widely in claim quality. Checklist:\n\n- **Compared to what?** \"Beats Gurobi default\" without solver tuning is weak.\n- **Generalization?** Trained and tested on the same instance distribution? Or transfers?\n- **Compute cost?** Often the ML method's training cost is omitted.\n- **Statistical reporting?** Confidence intervals on benchmarks are rare in ML papers.\n\nFor a sober view, see {cite:p}`Lu2024,Sandrin2025`. The field is rapidly evolving; today's \"breakthrough\" is often tomorrow's \"moderate improvement\".\n\n## References\n{cite:p}`Bengio2021,Gasse2019,Elmachtoub2022,Wilder2019,Mandi2020`."
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "# Standard discopt course imports. The lessons target the real\n# `discopt.modeling.core.Model` API: `m.continuous(name, shape=..., lb=..., ub=...)`,\n# `m.binary(name, shape=...)`, `m.integer(name, shape=..., lb=..., ub=...)`,\n# `m.subject_to(...)`, `m.minimize(...) / .maximize(...)`, `m.solve(...)`.\n# Result attributes: `r.status`, `r.objective`, `r.gap`, `r.bound`,\n# `r.wall_time`, `r.node_count`, and `r.value(var)` for variable arrays.\nimport numpy as np\nimport discopt as do\nimport discopt.modeling as dm\n"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "# A real knapsack solve to anchor the discussion. discopt's stable\n# branching_policy currently exposes \"fractional\" only; \"gnn\" is a future\n# hook intended for ML-driven rules. Custom branching callbacks are not\n# yet a stable public API \u2014 the exercises below treat them as a research\n# extension.\nimport numpy as np, discopt as do\n\nm = do.Model(\"knapsack20\")\nn = 20\nrng = np.random.default_rng(0)\nv = rng.integers(1, 30, n); w = rng.integers(1, 20, n); W = int(0.4 * w.sum())\nx = m.binary(\"x\", shape=(n,))\nm.subject_to(w @ x <= W); m.maximize(v @ x)\nr = m.solve(branching_policy=\"fractional\")\nprint(\"nodes:\", r.node_count, \"  z*:\", r.objective)\n"
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/python/discopt/course/advanced/27_ml_for_optimization/rubric.md
+++ b/python/discopt/course/advanced/27_ml_for_optimization/rubric.md
@@ -1,0 +1,25 @@
+# Rubric — Lesson 27
+
+## Exercises (70)
+- E1 (20) imitation dataset + classifier + accuracy.
+- E2 (15) plugged in; nodes compared.
+- E3 (20) DF vs MSE training; regret comparison.
+- E4 (10) GNN features computed; one shown predictive.
+- E5 (5) thoughtful critique.
+
+## Writing (30)
+
+- **Concept coverage (10):** the response names ≥ 3 specific concepts from
+  this lesson with a one-line definition or formula each, AND references at
+  least one numerical result the student produced in the exercise notebook
+  (objective value, runtime, gap, plot point).
+- **Technical correctness (10):** every claim about complexity, an algorithm,
+  or a solver's behaviour is either a citation or a derivation; nothing
+  factually wrong per the assessor's checklist for this lesson.
+- **Citations (5):** ≥ 2 `{cite:p}` keys resolve in `docs/references.bib`,
+  at least one of which is a recommended reference for this lesson; no
+  invented or unverifiable keys.
+- **Engagement (5):** the response cites a specific surprise, equation,
+  measurement, or solver-log line the student personally observed — not a
+  generic platitude.
+

--- a/python/discopt/course/advanced/27_ml_for_optimization/writing.md
+++ b/python/discopt/course/advanced/27_ml_for_optimization/writing.md
@@ -1,0 +1,7 @@
+# Writing assignment — Lesson 27
+
+In ~700 words, *steelman* and then *critique* the claim "ML will eventually
+replace handcrafted heuristics in MILP solvers." Use {cite:p}`Bengio2021,Gasse2019`.
+Address: (i) the case for — generalization, instance-specific tuning;
+(ii) the case against — out-of-distribution failures, training cost;
+(iii) where you think the field is heading.

--- a/python/discopt/course/advanced/28_bilevel_and_complementarity/exercises.ipynb
+++ b/python/discopt/course/advanced/28_bilevel_and_complementarity/exercises.ipynb
@@ -1,0 +1,89 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "# Lesson 28 \u2014 Exercises"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## Exercise 1 \u2014 Solve the toy by hand (10 pts)\n\nDerive $t^\\star = 4, q^\\star = 2$ analytically. Confirm `discopt`'s answer matches."
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "# Standard discopt course imports. The lessons target the real\n# `discopt.modeling.core.Model` API: `m.continuous(name, shape=..., lb=..., ub=...)`,\n# `m.binary(name, shape=...)`, `m.integer(name, shape=..., lb=..., ub=...)`,\n# `m.subject_to(...)`, `m.minimize(...) / .maximize(...)`, `m.solve(...)`.\n# Result attributes: `r.status`, `r.objective`, `r.gap`, `r.bound`,\n# `r.wall_time`, `r.node_count`, and `r.value(var)` for variable arrays.\nimport numpy as np\nimport discopt as do\nimport discopt.modeling as dm\n"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "# TODO\n"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## Exercise 2 \u2014 Big-M MPCC (15 pts)\n\nReformulate the toy with binary $z$ for the complementarity. Solve as MILP-NLP (MIQP). What $M$ did you use? Try too-large vs too-tight."
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "# TODO\n"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## Exercise 3 \u2014 Stackelberg pricing (20 pts)\n\n3 firms, each producing one good with demand $q_i = (a - p_i)$ where leader sets $p_1, p_2$ and the third firm reacts as Cournot. Solve for leader profit-maximizing prices."
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "# TODO\n"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## Exercise 4 \u2014 Toll setting (15 pts)\n\n5-node network, 6 links, 2 OD pairs. Set tolls on links. Maximize revenue subject to users following shortest-cost paths."
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "# TODO\n"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## Exercise 5 \u2014 Penalty regularization (10 pts)\n\nReplace the complementarity constraint with $\\lambda q \\le \\epsilon$ for $\\epsilon \\in \\{1, 0.1, 0.01, 0.001\\}$. Track the optimum as $\\epsilon \\to 0$. Does it converge to the true bilevel solution?"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "# TODO\n"
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/python/discopt/course/advanced/28_bilevel_and_complementarity/reading.ipynb
+++ b/python/discopt/course/advanced/28_bilevel_and_complementarity/reading.ipynb
@@ -1,0 +1,61 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "# Lesson 28 \u2014 Bilevel and Complementarity Programs\n\n## Learning objectives\n\n1. Write a bilevel optimization problem and recognize its structure.\n2. Reformulate a convex-lower-level bilevel as MPCC / MPEC via KKT.\n3. Use big-M relaxations of complementarity constraints.\n4. Recognize Stackelberg games and toll-setting as bilevel."
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## 1. Bilevel structure\n\n$$\n\\begin{aligned}\n\\min_{x, y}\\quad & F(x, y) \\\\\n\\text{s.t.}\\quad & G(x, y) \\le 0 \\\\\n& y \\in \\arg\\min_{y'} \\{ f(x, y') : g(x, y') \\le 0 \\}.\n\\end{aligned}\n$$\n\nOuter problem (leader): $x$. Inner problem (follower): $y$ depends on $x$. Examples: pricing where competitors react, defender-attacker games, network design with user-equilibrium routing {cite:p}`Dempe2002,LuoPangRalph1996`.\n\nBilevel is *strictly harder* than the union of two NLPs \u2014 even with linear inner and outer it is NP-hard."
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## 2. KKT reformulation\n\nIf the inner problem is convex with strong duality (Slater holds), replace $y \\in \\arg\\min$ with the inner KKT conditions. With $g : \\mathbb{R}^{n+m} \\to \\mathbb{R}^p$ and Jacobian $\\nabla_y g(x, y) \\in \\mathbb{R}^{p \\times m}$:\n\n$$\\nabla_y f(x, y) + \\nabla_y g(x, y)^\\top \\lambda = 0, \\quad g(x, y) \\le 0, \\quad \\lambda \\ge 0, \\quad \\lambda \\circ g(x, y) = 0.$$\n\nThe complementarity $\\lambda \\circ g = 0$ is the troublesome bit \u2014 it's nonconvex (a union of $2^p$ faces depending on which inequalities are active). The reformulated problem is a **Mathematical Program with Complementarity Constraints (MPCC)** {cite:p}`LuoPangRalph1996`."
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## 3. Solving MPCC\n\nThree approaches:\n\n- **Big-M / disjunctive MILP**: introduce binary $z_i$, add $\\lambda_i \\le M z_i$, $-g_i \\le M(1 - z_i)$. Tight bounds critical.\n- **Penalty / regularization**: $\\lambda^\\top g \\le \\epsilon$ for shrinking $\\epsilon$.\n- **Active-set**: enumerate $\\lambda_i > 0$ vs $g_i < 0$ partitions.\n\nSpecialized solvers: PATH, MILES (mixed complementarity); IPOPT with NLP-relaxation often works for small MPCC."
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## 4. Stackelberg pricing\n\nLeader sets prices $p$; follower (consumer) chooses quantity $q(p)$ minimizing cost. Leader maximizes revenue $p \\cdot q(p)$. The follower's best-response problem is convex; its KKT becomes the bilevel constraint.\n\nBig-M reformulation gives a MILP for piecewise-linear demand."
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## 5. Network toll-setting\n\nYou set tolls on a road network; users follow Wardrop equilibrium (each driver picks shortest-cost path). Maximize revenue subject to user equilibrium.\n\nUser-equilibrium \u2192 variational inequality \u2192 KKT \u2192 MPCC. Solved at scale only for moderate networks; instances with $n \\sim 10^3$ links are challenging.\n\n## References\n{cite:p}`Dempe2002,LuoPangRalph1996`."
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "# Standard discopt course imports. The lessons target the real\n# `discopt.modeling.core.Model` API: `m.continuous(name, shape=..., lb=..., ub=...)`,\n# `m.binary(name, shape=...)`, `m.integer(name, shape=..., lb=..., ub=...)`,\n# `m.subject_to(...)`, `m.minimize(...) / .maximize(...)`, `m.solve(...)`.\n# Result attributes: `r.status`, `r.objective`, `r.gap`, `r.bound`,\n# `r.wall_time`, `r.node_count`, and `r.value(var)` for variable arrays.\nimport numpy as np\nimport discopt as do\nimport discopt.modeling as dm\n"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "import numpy as np, discopt as do\nfrom discopt.modeling import Model\n\n# Toy bilevel: leader picks tax t in [0, 5]; follower picks q in [0, 10]\n# minimizing (q - 4)^2 + t * q.\n# Leader maximizes revenue t * q*(t).\n# Inner KKT: 2(q - 4) + t = 0 -> q* = 4 - t/2 (if positive).\n# So leader: max_t t * (4 - t/2). Optimum t* = 4, q* = 2, revenue = 8.\n\nm = Model(\"bilevel_toy\")\nt = m.continuous(\"t\", lb=0, ub=5)\nq = m.continuous(\"q\", lb=0)\nlam = m.continuous(\"lam\", lb=0)        # KKT multiplier for q >= 0\nm.subject_to(2*(q - 4) + t - lam == 0)    # inner stationarity\nm.subject_to(lam * q == 0)                # complementarity (nonconvex!)\nm.maximize(t * q)\nr = m.solve()\nprint(\"leader's tax:\", r.value(t), \" follower q:\", r.value(q), \" revenue:\", r.objective)\n"
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/python/discopt/course/advanced/28_bilevel_and_complementarity/rubric.md
+++ b/python/discopt/course/advanced/28_bilevel_and_complementarity/rubric.md
@@ -1,0 +1,25 @@
+# Rubric — Lesson 28
+
+## Exercises (70)
+- E1 (10) analytical solution; matches solver.
+- E2 (15) big-M MPCC; M trade-offs.
+- E3 (20) Stackelberg with 3 firms.
+- E4 (15) toll-setting solved.
+- E5 (10) penalty regularization convergence.
+
+## Writing (30)
+
+- **Concept coverage (10):** the response names ≥ 3 specific concepts from
+  this lesson with a one-line definition or formula each, AND references at
+  least one numerical result the student produced in the exercise notebook
+  (objective value, runtime, gap, plot point).
+- **Technical correctness (10):** every claim about complexity, an algorithm,
+  or a solver's behaviour is either a citation or a derivation; nothing
+  factually wrong per the assessor's checklist for this lesson.
+- **Citations (5):** ≥ 2 `{cite:p}` keys resolve in `docs/references.bib`,
+  at least one of which is a recommended reference for this lesson; no
+  invented or unverifiable keys.
+- **Engagement (5):** the response cites a specific surprise, equation,
+  measurement, or solver-log line the student personally observed — not a
+  generic platitude.
+

--- a/python/discopt/course/advanced/28_bilevel_and_complementarity/writing.md
+++ b/python/discopt/course/advanced/28_bilevel_and_complementarity/writing.md
@@ -1,0 +1,6 @@
+# Writing assignment — Lesson 28
+
+In ~700 words, explain why bilevel optimization is *fundamentally* harder
+than nested NLP. Address: (i) the role of the follower's reaction function;
+(ii) why complementarity constraints are nonconvex; (iii) when MPCC
+reformulation is the right tool. Cite {cite:p}`Dempe2002,LuoPangRalph1996`.

--- a/python/discopt/course/advanced/29_reformulations_and_symmetry/exercises.ipynb
+++ b/python/discopt/course/advanced/29_reformulations_and_symmetry/exercises.ipynb
@@ -1,0 +1,89 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "# Lesson 29 \u2014 Exercises"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## Exercise 1 \u2014 Bin-packing symmetry (15 pts)\n\nFor 8 items into 4 identical bins, solve the assignment MILP $x_{i,k} \\in \\{0,1\\}$ (item $i$ in bin $k$) once with no symmetry breaking. Then add a **bin-load lex** tightening: define $L_k = \\sum_i w_i \\, x_{i,k}$ and impose $L_1 \\ge L_2 \\ge L_3 \\ge L_4$ (heaviest bin first). Compare node counts and verify the optimum is unchanged."
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "# Standard discopt course imports. The lessons target the real\n# `discopt.modeling.core.Model` API: `m.continuous(name, shape=..., lb=..., ub=...)`,\n# `m.binary(name, shape=...)`, `m.integer(name, shape=..., lb=..., ub=...)`,\n# `m.subject_to(...)`, `m.minimize(...) / .maximize(...)`, `m.solve(...)`.\n# Result attributes: `r.status`, `r.objective`, `r.gap`, `r.bound`,\n# `r.wall_time`, `r.node_count`, and `r.value(var)` for variable arrays.\nimport numpy as np\nimport discopt as do\nimport discopt.modeling as dm\n"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "# TODO\n"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## Exercise 2 \u2014 Graph coloring (20 pts)\n\nColor a 10-node graph with $k = 4$ colors. Symmetry: colors interchangeable. Add lex on color usage. Compare to no symmetry breaking and to orbital fixing."
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "# TODO\n"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## Exercise 3 \u2014 Perspective reformulation (15 pts)\n\nFor $\\min y \\cdot x^2 + c y$ with $y \\in \\{0,1\\}, x \\ge 0$, derive the perspective formulation $y \\cdot f(x/y)$ and the SOC reformulation. Solve a 5-instance test bed; compare LP gap and node count."
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "# TODO\n"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## Exercise 4 \u2014 Detect symmetry (10 pts)\n\nFor an MILP of your choice, write code that *detects* a permutation symmetry by checking the constraint-matrix invariance. (Can be slow / heuristic.)"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "# TODO\n"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## Exercise 5 \u2014 Reformulate via Claude (10 pts)\n\nUse the `/reformulate` skill (or your own analysis) on a slow MILP from `discopt_benchmarks/instances/`. Report the suggestions, verify any apply, measure speedup."
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "# TODO\n"
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/python/discopt/course/advanced/29_reformulations_and_symmetry/reading.ipynb
+++ b/python/discopt/course/advanced/29_reformulations_and_symmetry/reading.ipynb
@@ -1,0 +1,61 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "# Lesson 29 \u2014 Reformulations and Symmetry\n\n## Learning objectives\n\n1. Recognize symmetric MILPs and the cost they impose on B&B.\n2. Apply orbital, lex, and isomorphism-pruning techniques.\n3. Recognize convexification reformulations: extended formulations, perspective.\n4. Use `discopt`'s reformulation infrastructure / `/reformulate` skill."
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## 1. Symmetry hurts B&B\n\nIf two variables $x_i, x_j$ are interchangeable (the constraint matrix is invariant under their swap), B&B explores symmetric subtrees independently. Each leaves equivalent solutions multiple times in the tree {cite:p}`Margot2010`.\n\nExamples: bin packing with identical bins; multi-machine scheduling with identical machines; coloring with interchangeable colors."
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## 2. Symmetry breaking\n\n- **Lex constraints:** $x_1 \\preceq_{\\text{lex}} x_2 \\preceq \\dots$ \u2014 valid **only when the variables lie in a single orbit of the formulation's symmetry group**, i.e., they really are interchangeable. Adding lex on non-symmetric variables can cut off optimal solutions.\n- **Orbital fixing/branching** {cite:p}`Margot2010`: at each node, identify orbits of the symmetry group; fix all members of an orbit consistently.\n- **Isomorphism pruning:** in heavily symmetric problems (e.g., graph coloring), prune nodes that are isomorphic to one already explored.\n\nModern solvers detect simple symmetries automatically; complex ones require user input."
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## 3. Reformulation as a reasoning task\n\nThree families of reformulations matter most:\n\n- **Extended formulations:** add auxiliary variables to make the formulation tighter (smaller LP-relaxation gap). Classic example: SOS2 piecewise via $\\lambda$-binaries vs SOS-native.\n- **Perspective reformulation:** for an *indicator-conditional* convex epigraph constraint of the form \"$y = 1 \\Rightarrow f(x) \\le t$ and $y = 0 \\Rightarrow x = 0$\" with $y \\in \\{0, 1\\}$ and $f$ convex, the convex hull of the disjunction is the **perspective** $y f(x / y) \\le t$ (with the convention $0 \\cdot f(0/0) = 0$). This is strictly tighter than the corresponding big-M and is a workhorse for fixed-cost / indicator constraints in MINLP {cite:p}`Trespalacios2015,Grossmann2013`.\n- **Convexification of bilinear terms:** McCormick (Lesson 16) is one option; if the bilinear term has special structure (e.g., $x_i x_j$ both binary), there may be a stronger formulation.\n\n{cite:p}`Liberti2009` is a systematic catalogue."
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## 4. discopt's reformulation pipeline\n\n`discopt.reformulate` runs:\n\n1. **Detect** symmetries via constraint-matrix automorphisms.\n2. **Detect** weak big-M and replace with tight bounds.\n3. **Detect** disjunctive structure and apply convex-hull reformulation when better.\n4. **Detect** bilinear terms and apply McCormick or RLT.\n\nLogs explain each transformation. Use the `/reformulate` Claude Code skill (in `.claude/commands/reformulate.md`) to get an LLM-assisted suggestion list \u2014 but always verify."
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "# Standard discopt course imports. The lessons target the real\n# `discopt.modeling.core.Model` API: `m.continuous(name, shape=..., lb=..., ub=...)`,\n# `m.binary(name, shape=...)`, `m.integer(name, shape=..., lb=..., ub=...)`,\n# `m.subject_to(...)`, `m.minimize(...) / .maximize(...)`, `m.solve(...)`.\n# Result attributes: `r.status`, `r.objective`, `r.gap`, `r.bound`,\n# `r.wall_time`, `r.node_count`, and `r.value(var)` for variable arrays.\nimport numpy as np\nimport discopt as do\nimport discopt.modeling as dm\n"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "import numpy as np, discopt as do\n\n# A small symmetric MILP: assign 4 jobs to 3 identical machines, minimise makespan.\ndef build(symbreak: bool):\n    m = do.Model(\"makespan_sb\" if symbreak else \"makespan\")\n    n_jobs, n_mach = 4, 3\n    p = np.array([3, 5, 2, 4])\n    x = m.binary(\"x\", shape=(n_jobs, n_mach))\n    C = m.continuous(\"C\", lb=0, ub=20)\n    for j in range(n_jobs):\n        m.subject_to(dm.sum(x[j, :]) == 1)\n    for k in range(n_mach):\n        m.subject_to(p @ x[:, k] <= C)\n    if symbreak:\n        # Bin-load lex: heaviest machine first.\n        loads = [p @ x[:, k] for k in range(n_mach)]\n        for k in range(n_mach - 1):\n            m.subject_to(loads[k] >= loads[k + 1])\n    m.minimize(C)\n    return m, x, C\n\nfor label, sb in [(\"no symmetry breaking\", False), (\"with bin-load lex\", True)]:\n    mm, _, _ = build(sb)\n    r = mm.solve()\n    print(f\"{label:24s} nodes={r.node_count:4d}  time={r.wall_time:.3f}s  C*={r.objective}\")\n"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## 5. Reformulation as a research practice\n\nWhen stuck on a slow MILP/MINLP:\n\n1. Look at the LP relaxation gap. If big, formulation is weak.\n2. Inspect big-M values; tighten via OBBT.\n3. Check for symmetry; add lex constraints.\n4. Look for disjunctive structure; consider convex-hull reformulation.\n5. Look for bilinear/concave terms; apply tighter relaxation.\n\nThis loop is the difference between a 2-day solve and a 2-second solve.\n\n## References\n{cite:p}`Margot2010,Liberti2009,Williams2013`."
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/python/discopt/course/advanced/29_reformulations_and_symmetry/rubric.md
+++ b/python/discopt/course/advanced/29_reformulations_and_symmetry/rubric.md
@@ -1,0 +1,25 @@
+# Rubric — Lesson 29
+
+## Exercises (70)
+- E1 (15) bin-packing nodes reduced via lex.
+- E2 (20) coloring with three strategies; node counts reported.
+- E3 (15) perspective + SOC reformulation works.
+- E4 (10) symmetry-detection code finds a known symmetry.
+- E5 (10) Claude-suggested reformulation applied; speedup measured.
+
+## Writing (30)
+
+- **Concept coverage (10):** the response names ≥ 3 specific concepts from
+  this lesson with a one-line definition or formula each, AND references at
+  least one numerical result the student produced in the exercise notebook
+  (objective value, runtime, gap, plot point).
+- **Technical correctness (10):** every claim about complexity, an algorithm,
+  or a solver's behaviour is either a citation or a derivation; nothing
+  factually wrong per the assessor's checklist for this lesson.
+- **Citations (5):** ≥ 2 `{cite:p}` keys resolve in `docs/references.bib`,
+  at least one of which is a recommended reference for this lesson; no
+  invented or unverifiable keys.
+- **Engagement (5):** the response cites a specific surprise, equation,
+  measurement, or solver-log line the student personally observed — not a
+  generic platitude.
+

--- a/python/discopt/course/advanced/29_reformulations_and_symmetry/writing.md
+++ b/python/discopt/course/advanced/29_reformulations_and_symmetry/writing.md
@@ -1,0 +1,6 @@
+# Writing assignment — Lesson 29
+
+In ~700 words, argue that **reformulation is research**, not just engineering.
+Use {cite:p}`Liberti2009,Margot2010,Williams2013`. Address: (i) what counts as
+a reformulation; (ii) the LP-relaxation-gap perspective; (iii) one
+reformulation insight from your own work that materially changed solve time.

--- a/python/discopt/course/advanced/30_capstone_advanced/exercises.ipynb
+++ b/python/discopt/course/advanced/30_capstone_advanced/exercises.ipynb
@@ -1,0 +1,36 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "# Capstone deliverable\n\nThe complete writeup is `writing_response.md` (or, preferably, `writing_response.pdf`). Code lives in `writing_response.ipynb` plus any supporting scripts."
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "# Standard discopt course imports. The lessons target the real\n# `discopt.modeling.core.Model` API: `m.continuous(name, shape=..., lb=..., ub=...)`,\n# `m.binary(name, shape=...)`, `m.integer(name, shape=..., lb=..., ub=...)`,\n# `m.subject_to(...)`, `m.minimize(...) / .maximize(...)`, `m.solve(...)`.\n# Result attributes: `r.status`, `r.objective`, `r.gap`, `r.bound`,\n# `r.wall_time`, `r.node_count`, and `r.value(var)` for variable arrays.\nimport numpy as np\nimport discopt as do\nimport discopt.modeling as dm\n"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "# TODO: your project here.\n"
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/python/discopt/course/advanced/30_capstone_advanced/reading.ipynb
+++ b/python/discopt/course/advanced/30_capstone_advanced/reading.ipynb
@@ -1,0 +1,34 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "# Lesson 30 \u2014 Capstone (Advanced)\n\n## Goal\n\nProduce a **paper-quality writeup** with original computational results on a\nresearch-flavoured optimization problem.\n\n## Choose ONE\n\n### A) Algorithmic: a new bound-tightening rule for MINLP\n\nImplement an OBBT variant tailored to a structured class (signomial,\nposynomial, ratio-of-affine). Benchmark vs default OBBT on hard MINLPs.\nReport when your variant helps; theorize why. {cite:p}`Belotti2009,Tawarmalani2005`.\n\n### B) Application: NN-embedded design optimization\n\nChoose a real engineering surrogate (heat exchanger, airfoil, reactor).\nTrain a NN; embed via Lesson 24; optimize globally; compare to gradient-based\nmultistart and to a Bayesian baseline. {cite:p}`Fischetti2018,Ceccon2022`.\n\n### C) Theoretical: a tightening result\n\nFormulate and prove (or sharply conjecture, with computational evidence) a\nnew valid inequality, perspective reformulation, or convex-hull\ncharacterization for a class of constraint you care about.\n{cite:p}`Liberti2009,Cornuejols2008`."
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## Deliverables\n\n1. **Paper-style PDF** (8\u201312 pages, IEEE / SIAM-format-ish): introduction,\n   background, method, experiments, discussion, references.\n2. **Reproducibility kit**: notebook + scripts that run end-to-end from a\n   fresh checkout.\n3. **Presentation slides** (10\u201315 slides) summarising for a 30-minute talk.\n\n## Scope\n\n20\u201340 hours of work. This should feel like a *small research paper*, not\nan extended homework. If your project doesn't have a clean conclusion,\nreport it honestly \u2014 null results have value when carefully analysed.\n\n## Milestones\n\nTo prevent self-paced stalls, the capstone has three checkpoints. Submit\neach as a markdown file in this directory; ask Claude (`/course:assess\nadvanced/30_capstone_advanced --milestone <N>`) to review.\n\n- **M1 \u2014 Proposal (\u2248 1 page)**: project choice, motivating question,\n  baseline, success criterion, one-sentence risk. Aim: end of week 1.\n- **M2 \u2014 Method + initial results (\u2248 3 pages)**: math + algorithm written\n  up; first end-to-end run on at least one instance; preliminary numbers.\n  Aim: end of week 3.\n- **M3 \u2014 Final paper + slides**: the full deliverable. Aim: end of week 5.\n\nThe milestones are not graded individually but they are required \u2014 Claude\nwill refuse to grade the final submission if M1 and M2 do not exist."
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "# Standard discopt course imports. The lessons target the real\n# `discopt.modeling.core.Model` API: `m.continuous(name, shape=..., lb=..., ub=...)`,\n# `m.binary(name, shape=...)`, `m.integer(name, shape=..., lb=..., ub=...)`,\n# `m.subject_to(...)`, `m.minimize(...) / .maximize(...)`, `m.solve(...)`.\n# Result attributes: `r.status`, `r.objective`, `r.gap`, `r.bound`,\n# `r.wall_time`, `r.node_count`, and `r.value(var)` for variable arrays.\nimport numpy as np\nimport discopt as do\nimport discopt.modeling as dm\n"
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/python/discopt/course/advanced/30_capstone_advanced/rubric.md
+++ b/python/discopt/course/advanced/30_capstone_advanced/rubric.md
@@ -1,0 +1,21 @@
+# Rubric — Lesson 30 (Advanced Capstone)
+
+**Total: 100**
+
+## Computational deliverable (50)
+- (10) Project well-scoped; reproducible end-to-end.
+- (15) Method correctly implemented; integrated with `discopt`.
+- (15) Experiments well-designed; baselines chosen; CIs reported.
+- (10) Honest reporting (failures, limits acknowledged).
+
+## Writeup (40)
+- (5) Introduction motivates clearly.
+- (10) Background covers the literature; ≥ 8 citations.
+- (10) Method section is rigorous and reproducible.
+- (10) Experiments tell a clean story; tables/plots labelled.
+- (5) Discussion + limitations honest.
+
+## Presentation (10)
+- (10) 10-15 slides; coherent talk-track.
+
+**Pass: 70.** Below 70 → revise and resubmit.

--- a/python/discopt/course/advanced/30_capstone_advanced/writing.md
+++ b/python/discopt/course/advanced/30_capstone_advanced/writing.md
@@ -1,0 +1,15 @@
+# Capstone — Lesson 30
+
+Write your project as a **conference-paper-style** PDF (8–12 pages,
+two-column or single, IEEE/SIAM-ish). Sections:
+
+1. **Introduction & motivation** (~1 page).
+2. **Background / related work** (~1.5 pages, ≥ 8 citations).
+3. **Method** (~2 pages): math, algorithm, implementation, complexity.
+4. **Experiments** (~2.5 pages): instances, baselines, statistics, plots.
+5. **Discussion** (~1 page): when does your method help, fail, generalize.
+6. **Limitations & future work** (~0.5 page).
+7. **References**.
+
+Cite at least 12 references from `docs/references.bib`. Verify with
+`/course:cite-check` before submission.

--- a/python/discopt/course/basic/01_intro_to_optimization/exercises.ipynb
+++ b/python/discopt/course/basic/01_intro_to_optimization/exercises.ipynb
@@ -1,0 +1,92 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "# Lesson 1 \u2014 Exercises\n\nFill in each `# TODO` cell. When done, run all cells top-to-bottom (they\nshould all execute without error) and then ask Claude to grade with\n\n```\n/course:assess basic/01_intro_to_optimization\n```\n\n> **Tip:** stuck? Run `/course:hint basic/01_intro_to_optimization <ex#>` for\n> a graduated hint that doesn't reveal the answer.\n"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## Exercise 1 \u2014 Classify these problems (10 pts)\n\nFor each of the following problems, state the optimization class\n(LP / MILP / NLP / MINLP) and *one* property that justifies your choice.\n\na) Minimize the L2-norm of a vector subject to a linear matrix inequality.\nb) Schedule 12 nurses across 21 shifts, minimizing total wage paid, with a\n   minimum of 3 nurses per shift.\nc) Design a chemical reactor: minimize CAPEX subject to mass-balance ODEs\n   discretized over 50 time steps.\nd) Place 8 wind turbines on a farm to maximize total power; turbines must be\n   at least 200 m apart and inside the property polygon.\n\nWrite your answer in the markdown cell below.\n"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "**Your answer:**\n\n- a) ...\n- b) ...\n- c) ...\n- d) ...\n"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## Exercise 2 \u2014 Diet problem with eggs (15 pts)\n\nExtend the diet model in the reading by adding a fourth food **eggs** with\ncost \\$0.40 per unit and nutrient contribution\n$(150,\\, 12,\\, 50)$ to (calories, protein, calcium). Add an additional\nconstraint: at most 8 units of any single food per day (an upper bound\n$x_i \\le 8$). Solve and report which foods are bought and the total cost.\n\n> This is still a pure LP \u2014 we don't need integer variables yet.\n> (The \"use at least two distinct foods\" version of this constraint\n> requires big-M; we'll meet it in Lesson 5.)\n"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "# Standard discopt course imports. The lessons target the real\n# `discopt.modeling.core.Model` API: `m.continuous(name, shape=..., lb=..., ub=...)`,\n# `m.binary(name, shape=...)`, `m.integer(name, shape=..., lb=..., ub=...)`,\n# `m.subject_to(...)`, `m.minimize(...) / .maximize(...)`, `m.solve(...)`.\n# Result attributes: `r.status`, `r.objective`, `r.gap`, `r.bound`,\n# `r.wall_time`, `r.node_count`, and `r.value(var)` for variable arrays.\nimport numpy as np\nimport discopt as do\nimport discopt.modeling as dm\n"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "import numpy as np\nimport discopt as do\n\n# TODO: build and solve the LP with the new food and the per-food cap.\n# Print: quantities purchased of each food, total cost.\n"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## Exercise 3 \u2014 The LP relaxation gap (15 pts)\n\nFor the knapsack instance in the reading (`n=10`, seed 0):\n\n1. Solve the **LP relaxation** (replace `vtype=\"binary\"` with `lb=0, ub=1`).\n2. Solve the **MILP** (as in the reading).\n3. Compute the **integrality gap**: $\\frac{z_{LP} - z_{MILP}}{z_{MILP}}$.\n\nWhat does the size of this gap tell you about how hard the MILP is for\nbranch-and-bound?\n"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "# TODO: solve LP relaxation and MILP for the same knapsack instance,\n# print both objectives and the integrality gap.\n"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## Exercise 4 \u2014 Find all six minima of the camel function (15 pts)\n\nThe Six-Hump Camel has six local minima. Find them all by running a local\nNLP solve from a grid of starting points and recording the unique results\n(round to 3 decimal places to deduplicate).\n\nHow many distinct minima do you find? List the objective values.\n"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "# TODO: scan a grid of starting points; record unique minima.\n"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## Exercise 5 \u2014 Read the solver result (15 pts)\n\nSolve the diet LP from the reading and report:\n\na) the **status** of the solve (`\"optimal\"`, `\"infeasible\"`, `\"time_limit\"`, ...);\nb) the **objective value** at the optimum, to 4 decimal places;\nc) the **node count** the solver reports;\nd) the **wall time** for the solve.\n\nThen deliberately *break* the model and report the resulting status:\n(i) make the calcium requirement $b_3 = 10^{12}$ \u2014 should return `\"infeasible\"`.\n(ii) make the model *practically unbounded* by dropping the cost objective entirely\nand minimizing $-\\sum_i x_i$ on variables with very loose `ub=1e6`. The solver\nwill return `\"optimal\"` with $x$ pegged to the upper bound \u2014 note that\n`discopt`'s real API requires *finite* bounds, so a truly infinite-`UNBOUNDED`\nreturn is impossible; instead, **inspect the optimum** and notice it sits at\nthe bound. That's the practical signal of an underspecified model.\n\n(Numerical residuals, KKT, and complementary slackness come in Lessons 4 and 9.)\n"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "# TODO: solve the diet LP and inspect status/objective/iterations/time.\n# Then construct (i) infeasible and (ii) practically-unbounded variants.\n"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "**Your answer:**\n\n- a) status: ...\n- b) objective: ...\n- c) node count: ...\n- d) wall time: ...\n- (i) infeasible variant status: ...\n- (ii) practically-unbounded variant: optimum sits at $x_i = $ ...\n"
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/python/discopt/course/basic/01_intro_to_optimization/reading.ipynb
+++ b/python/discopt/course/basic/01_intro_to_optimization/reading.ipynb
@@ -1,0 +1,80 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "# Lesson 1 \u2014 Introduction to Optimization\n\n**Track:** Basic &nbsp;&nbsp;|&nbsp;&nbsp; **Estimated time:** 90 minutes\n\n## Learning objectives\n\nAfter this lesson you will be able to:\n\n1. State the standard form of a mathematical optimization problem.\n2. Distinguish LP, IP/MILP, NLP, and MINLP.\n3. Recognize when an \"optimization problem\" in the wild is in fact an LP, an\n   MILP, or a (possibly nonconvex) MINLP.\n4. Solve a small LP and a small MILP with `discopt` and read the output.\n5. Cite the canonical references for the field {cite:p}`Bertsimas1997,Wolsey1998,Boyd2004`.\n"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## 1. Standard form\n\nA mathematical optimization problem (or **mathematical program**) is\n\n$$\n\\begin{aligned}\n\\min_{x \\in \\mathbb{R}^n}\\quad & f(x) \\\\\n\\text{s.t.}\\quad & g_i(x) \\le 0, \\quad i = 1, \\dots, m \\\\\n& h_j(x) = 0, \\quad j = 1, \\dots, p \\\\\n& x \\in X\n\\end{aligned}\n$$\n\n- $x$ are **decision variables**.\n- $f$ is the **objective**.\n- $g_i, h_j$ are **constraints**.\n- $X$ encodes set membership constraints (e.g., $x \\in \\mathbb{Z}^n$ for\n  integer variables, $x_i \\in \\{0,1\\}$ for binaries).\n\nThe problem class is determined by the structure of $f$, $g_i$, $h_j$, and $X$:\n\n| Class | $f, g, h$ | $X$ |\n|-------|-----------|-----|\n| LP    | linear (affine) | $\\mathbb{R}^n_{\\ge 0}$ usually |\n| IP/MILP | linear | $\\mathbb{Z}^n$ or mixed |\n| NLP   | nonlinear (smooth) | continuous |\n| MINLP | nonlinear | mixed integer |\n\n`discopt` is built for **MINLP**, the most general of these \u2014 every other\nclass is a special case it can handle by recognizing structure\n{cite:p}`Belotti2013,Tawarmalani2005`.\n"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## 2. Why this matters\n\nOptimization is the lingua franca of decision making under constraints. In\noperations, you optimize schedules, routing, allocation\n{cite:p}`Williams2013`. In engineering design, you optimize structures and\nprocesses {cite:p}`Biegler2010`. In machine learning, training itself is\noptimization. Markowitz's portfolio model {cite:p}`Markowitz1952` is an LP/QP;\nStigler's diet problem {cite:p}`Stigler1945` is the canonical LP.\n\nThree observations animate the entire course:\n\n- **Convexity is the watershed.** Convex problems have global optima\n  reachable in polynomial time {cite:p}`Boyd2004`. Nonconvex problems may\n  have many local optima, and finding the global one is hard.\n- **Integer variables make a problem combinatorial.** MILP is NP-hard\n  {cite:p}`Wolsey1998`, even when the LP relaxation is trivial.\n- **Structure is exploitable.** A solver that recognizes a problem is in\n  fact an LP, or convex, or has totally-unimodular constraint matrix, can be\n  *vastly* faster than a generic MINLP solver.\n"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## 3. A first LP \u2014 the diet problem\n\nWe pick quantities $x_1, x_2, x_3$ of three foods (say bread, milk, beans) to\nminimize cost while meeting nutritional requirements. From\n{cite:t}`Stigler1945`:\n\n$$\n\\begin{aligned}\n\\min_{x \\ge 0}\\quad & c^\\top x \\\\\n\\text{s.t.}\\quad & A x \\ge b\n\\end{aligned}\n$$\n\nwhere $c \\in \\mathbb{R}^3$ are unit costs, $A_{ij}$ is nutrient $i$ per unit\nof food $j$, and $b_i$ is the daily requirement of nutrient $i$. Let's solve\nit with `discopt`.\n"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "# Standard discopt course imports. The lessons target the real\n# `discopt.modeling.core.Model` API: `m.continuous(name, shape=..., lb=..., ub=...)`,\n# `m.binary(name, shape=...)`, `m.integer(name, shape=..., lb=..., ub=...)`,\n# `m.subject_to(...)`, `m.minimize(...) / .maximize(...)`, `m.solve(...)`.\n# Result attributes: `r.status`, `r.objective`, `r.gap`, `r.bound`,\n# `r.wall_time`, `r.node_count`, and `r.value(var)` for variable arrays.\nimport numpy as np\nimport discopt as do\nimport discopt.modeling as dm\n"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "import numpy as np\nimport discopt as do\n\n# Costs ($/unit) for [bread, milk, beans]\nc = np.array([0.50, 0.80, 0.30])\n\n# Nutrients per unit: rows are [calories, protein, calcium]\nA = np.array([\n    [250, 120, 350],   # calories\n    [  8,   8,  20],   # protein (g)\n    [ 30, 300,  60],   # calcium (mg)\n])\nb = np.array([2000, 50, 800])  # daily requirements\n\nm = do.Model(\"diet\")\nx = m.continuous(\"x\", shape=(3,), lb=0)\nm.subject_to(A @ x >= b)\nm.minimize(c @ x)\n\nresult = m.solve()\nprint(result)\nprint(\"Foods purchased:\", result.x)\nprint(\"Daily cost: $\", round(result.objective, 2))\n"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## 4. A first MILP \u2014 the knapsack\n\nNow suppose we choose **whether** to take each item (yes/no) \u2014 a binary\ndecision. The 0/1 knapsack:\n\n$$\n\\max_{x \\in \\{0,1\\}^n} \\; v^\\top x \\quad \\text{s.t.} \\quad w^\\top x \\le W\n$$\n\nThis is the canonical NP-hard MILP. With $n = 5$ items it's trivial; with\n$n = 100$, the LP relaxation gives only an upper bound and we need\nbranch-and-bound (Lesson 6) to close the gap.\n"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "rng = np.random.default_rng(0)\nn = 10\nv = rng.integers(1, 20, size=n)   # values\nw = rng.integers(1, 15, size=n)   # weights\nW = int(0.4 * w.sum())            # capacity = 40 % of total\n\nm = do.Model(\"knapsack\")\nx = m.binary(\"x\", shape=(n,))\nm.subject_to(w @ x <= W)\nm.maximize(v @ x)\nres = m.solve()\n\nx_val = res.value(x)                          # ndarray (r.x is a dict by name)\nprint(\"Selected items:\", np.where(x_val > 0.5)[0].tolist())\nprint(\"Total value:\", res.objective, \"Capacity used:\", int(w @ x_val), \"/\", W)\n"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## 5. A nonconvex NLP \u2014 and why it's harder\n\nConsider minimizing the Six-Hump Camel function on a box:\n\n$$\nf(x_1, x_2) = (4 - 2.1 x_1^2 + x_1^4/3)\\,x_1^2 + x_1 x_2 + (-4 + 4 x_2^2) x_2^2\n$$\n\nIt has six local minima, two of them global at\n$(\\pm 0.0898, \\mp 0.7126)$ with $f^\\star \\approx -1.0316$. A local NLP\nsolver started from a random point can land on any of the six. Spatial\nbranch-and-bound (Lesson 21) provably finds the best one\n{cite:p}`Tawarmalani2005,Floudas1999`.\n\n`discopt`'s solver auto-detects nonconvexity (`r.convex_fast_path` will be\n`False` here) and applies its global routine; you don't choose `local` vs\n`global` explicitly.\n"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "from discopt.modeling import Model, sin, cos  # noqa: F401\n\nm = Model(\"camel\")\nx1 = m.continuous(\"x1\", lb=-3, ub=3)\nx2 = m.continuous(\"x2\", lb=-2, ub=2)\nf = (4 - 2.1*x1**2 + x1**4/3)*x1**2 + x1*x2 + (-4 + 4*x2**2)*x2**2\nm.minimize(f)\n\nr = m.solve()\nprint(f\"f* = {r.objective:.4f}   x = ({r.value(x1):.4f}, {r.value(x2):.4f})\")\nprint(f\"convex fast path: {r.convex_fast_path}   nodes: {r.node_count}\")\n# This single solve recovers ONE of the six local minima \u2014 Exercise 4 below\n# asks you to find all six by sweeping initial points.\n"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## 6. The taxonomy in one diagram\n\n```\n        +-------------------- Optimization --------------------+\n        |                                                      |\n       LP                                                  Nonlinear\n        |                                                      |\n        +-- IP / MILP                              +-- Convex NLP\n        |                                          |\n        +-- Network flow (TUM)                     +-- Nonconvex NLP\n        |                                          |\n        +-- Conic (SOCP, SDP)                      +-- MINLP (convex)\n                                                   |\n                                                   +-- MINLP (nonconvex)\n```\n\nWe will visit every node of this tree.\n\n## 7. What's next\n\n- Lesson 2 dives into LP geometry and the simplex method.\n- Lesson 3 walks through the `discopt` modeling API in detail.\n- Exercise notebook for this lesson is in `exercises.ipynb`.\n\n## References\n\nThe canonical textbook references for this lesson are\n{cite:p}`Bertsimas1997` (LP), {cite:p}`Wolsey1998` (IP/MILP),\n{cite:p}`Boyd2004` (convex), {cite:p}`Nocedal2006` (NLP), and\n{cite:p}`Williams2013` (modeling). For the history,\n{cite:t}`Dantzig1963,Kantorovich1960,Dorfman1958` are foundational.\n"
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/python/discopt/course/basic/01_intro_to_optimization/rubric.md
+++ b/python/discopt/course/basic/01_intro_to_optimization/rubric.md
@@ -1,0 +1,50 @@
+# Rubric — Lesson 1
+
+**Total: 100 points** (Exercises: 70, Writing: 30)
+
+## Exercises (70 pts)
+
+### Exercise 1 — Classification (10 pts)
+- (4) All four problems classified correctly.
+- (3) Justification names a specific structural feature.
+- (3) Subtle cases noted (e.g., (a) is a convex SDP/SOCP, not LP).
+
+### Exercise 2 — Diet with eggs (15 pts)
+- (6) Four continuous food variables with $0 \le x_i \le 8$ (per-food cap).
+- (5) Cost vector and nutrient matrix correctly extended to 4 foods.
+- (2) Solver returns `OPTIMAL`; prints purchased quantities and cost.
+- (2) Numerical answer matches reference within 1e-3.
+
+### Exercise 3 — LP relaxation gap (15 pts)
+- (4) LP relaxation correctly solved (continuous $[0,1]$).
+- (4) MILP correctly solved.
+- (3) Gap formula correct.
+- (4) Discussion connects gap to B&B difficulty.
+
+### Exercise 4 — Six minima (15 pts)
+- (5) Grid of ≥ 25 starts.
+- (5) Six distinct local minima recovered after deduplication.
+- (5) Two global minima identified at $f^\star \approx -1.0316$.
+
+### Exercise 5 — Read the solver result (15 pts)
+- (4) Reports status, objective, iteration/node count, wall time for the diet LP.
+- (5) Constructs an *infeasible* variant (e.g., $b_3 = 10^{12}$); solver returns `INFEASIBLE`.
+- (5) Constructs a *practically-unbounded* variant (drop cost, minimize $-\sum x$ with loose `ub`); reports that the optimum pegs to the bound.
+- (1) Briefly notes that "optimum at a default bound" usually means a missing bound.
+
+## Writing (30)
+
+- **Concept coverage (10):** the response names ≥ 3 specific concepts from
+  this lesson with a one-line definition or formula each, AND references at
+  least one numerical result the student produced in the exercise notebook
+  (objective value, runtime, gap, plot point).
+- **Technical correctness (10):** every claim about complexity, an algorithm,
+  or a solver's behaviour is either a citation or a derivation; nothing
+  factually wrong per the assessor's checklist for this lesson.
+- **Citations (5):** ≥ 2 `{cite:p}` keys resolve in `docs/references.bib`,
+  at least one of which is a recommended reference for this lesson; no
+  invented or unverifiable keys.
+- **Engagement (5):** the response cites a specific surprise, equation,
+  measurement, or solver-log line the student personally observed — not a
+  generic platitude.
+

--- a/python/discopt/course/basic/01_intro_to_optimization/writing.md
+++ b/python/discopt/course/basic/01_intro_to_optimization/writing.md
@@ -1,0 +1,36 @@
+# Writing assignment — Lesson 1
+
+**Length:** ≈ 1 page (500–700 words). Save your response as
+`writing_response.md` in this directory.
+
+## Prompt
+
+In a brief essay, address all three of the following:
+
+1. **A real problem you'd model.** Pick a decision problem from your own
+   domain (work, hobby, research, sports, household logistics) that you'd
+   describe as "an optimization problem." State (in words) the decision
+   variables, the objective, and the constraints. Then classify it (LP /
+   MILP / NLP / MINLP) and justify the classification.
+
+2. **What the classification buys you.** Once you've classified the
+   problem, what does that classification *tell you* about how hard it is
+   to solve, what algorithms apply, and what kind of guarantee a solver
+   can give? Reference at least one of {cite:p}`Bertsimas1997,Wolsey1998,Boyd2004`
+   to ground your answer.
+
+3. **One thing that surprised you.** From the reading, the runnable code,
+   or the exercises, name one thing you didn't expect, and explain *why*
+   it's surprising.
+
+## Style
+
+- Use math notation (`$...$` or `$$...$$`) for any equations.
+- Use `{cite:p}` MyST citations with keys from `docs/references.bib`.
+  Don't invent citations; run `/course:cite-check` if unsure.
+- Personal voice is fine.
+
+## Grading
+
+See `rubric.md`. Writing is worth 30 points (10 clarity, 10 technical
+correctness, 5 citations, 5 engagement).

--- a/python/discopt/course/basic/02_lp_fundamentals/exercises.ipynb
+++ b/python/discopt/course/basic/02_lp_fundamentals/exercises.ipynb
@@ -1,0 +1,89 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "# Lesson 2 \u2014 Exercises\n\nFill in `# TODO` cells, run all, then `/course:assess basic/02_lp_fundamentals`."
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## Exercise 1 \u2014 Convert to standard form (10 pts)\n\nGiven $\\min\\, x_1 - 2x_2$ s.t. $x_1 + x_2 \\le 4$, $x_1 - x_2 \\ge -1$, $x_1$ free, $x_2 \\ge 0$, write it in *standard form* $\\min c^\\top x$ s.t. $Ax = b, x \\ge 0$. Show $c$, $A$, $b$ as numpy arrays."
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "# Standard discopt course imports. The lessons target the real\n# `discopt.modeling.core.Model` API: `m.continuous(name, shape=..., lb=..., ub=...)`,\n# `m.binary(name, shape=...)`, `m.integer(name, shape=..., lb=..., ub=...)`,\n# `m.subject_to(...)`, `m.minimize(...) / .maximize(...)`, `m.solve(...)`.\n# Result attributes: `r.status`, `r.objective`, `r.gap`, `r.bound`,\n# `r.wall_time`, `r.node_count`, and `r.value(var)` for variable arrays.\nimport numpy as np\nimport discopt as do\nimport discopt.modeling as dm\n"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "import numpy as np\n# TODO: write c, A, b corresponding to standard form\nc = ...\nA = ...\nb = ...\nprint(c); print(A); print(b)"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## Exercise 2 \u2014 Solve and verify duality (15 pts)\n\nUse `discopt` to solve the original LP. Then **verify by hand** (using the dual values) that the primal and dual objectives match within 1e-9."
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "import discopt as do\n# TODO: solve and check b'y == c'x\n"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## Exercise 3 \u2014 Klee\u2013Minty cube (15 pts)\n\nBuild the 3-dimensional Klee\u2013Minty cube {cite:p}`KleeMinty1972`:\n\n$$\\max\\sum_{j=1}^n 10^{n-j} x_j \\;\\;\\text{s.t.}\\;\\; 2\\sum_{j<i} 10^{i-j} x_j + x_i \\le 100^{i-1}, \\; x \\ge 0.$$\n\nSolve with `discopt` for $n=3, 5, 7$. Report objective values and (if accessible) iteration counts."
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "# TODO: build Klee\u2013Minty for n in [3, 5, 7] and solve\n"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## Exercise 4 \u2014 Shadow prices via finite-difference (15 pts)\n\nReturn to the diet problem (Lesson 1). Solve it; call the optimum $z^\\star(b)$. Now solve again with $b_3$ (calcium) bumped by $h = 1$, getting $z^\\star(b + h e_3)$. The shadow price is $\\hat y_3 \\approx (z^\\star(b + h e_3) - z^\\star(b))/h$. Repeat for each constraint; report the full $\\hat y$ vector. Verify (a) $A^\\top \\hat y \\le c$ within 1e-6, and (b) $b^\\top \\hat y \\approx c^\\top x^\\star$. (This is the empirical recipe Lesson 4 walks in detail.)"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "# TODO: solve diet, perturb b3, re-solve, compare cost change to y3\n"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## Exercise 5 \u2014 Bounded, unbounded, infeasible (15 pts)\n\nWrite *three* LPs in `discopt` \u2014 one with a bounded optimum, one unbounded, one infeasible. For each, print what `result.status` says. Briefly explain how the solver decides each."
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "# TODO: three LPs, three statuses\n"
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/python/discopt/course/basic/02_lp_fundamentals/reading.ipynb
+++ b/python/discopt/course/basic/02_lp_fundamentals/reading.ipynb
@@ -1,0 +1,61 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "# Lesson 2 \u2014 Linear Programming Fundamentals\n\n**Track:** Basic &nbsp;|&nbsp; **Estimated time:** 2 hours\n\n## Learning objectives\n\n1. Write any LP in standard form.\n2. Describe the geometry of the feasible polyhedron and why optima sit at vertices.\n3. State the simplex method at a conceptual level (no proof).\n4. Recognize the LP dual and state weak/strong duality.\n5. Use `discopt`'s LP solver and inspect the basis."
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## 1. Standard form\n\nThe standard-form LP {cite:p}`Bertsimas1997,Dantzig1963` is:\n\n$$\n\\min_{x} \\; c^\\top x \\quad \\text{s.t.} \\quad Ax = b, \\; x \\ge 0\n$$\n\nwith $A \\in \\mathbb{R}^{m \\times n}$, $b \\in \\mathbb{R}^m$, $c \\in \\mathbb{R}^n$. Any LP can be converted: inequalities $a^\\top x \\le b$ become $a^\\top x + s = b, s \\ge 0$ with a *slack* variable; free variables $x$ become $x^+ - x^-$ with $x^+, x^- \\ge 0$.\n\n## 2. Geometry\n\nThe feasible set $\\{x : Ax = b, x \\ge 0\\}$ is a **polyhedron**. Three facts:\n\n- **Vertices = basic feasible solutions (BFS).** A BFS picks $m$ of the $n$ columns of $A$ to be the \"basis\"; the remaining variables are 0.\n- **Fundamental theorem of LP** {cite:p}`Bertsimas1997`: if an LP has a finite optimum, at least one optimum is at a vertex.\n- **Bounded vs unbounded vs infeasible.** Three possible outcomes; a solver must distinguish them."
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## 3. Simplex, in one paragraph\n\nStart at any BFS. Examine adjacent vertices (those differing by one basis swap). If any adjacent vertex has lower cost, move there; otherwise, current vertex is optimal. The algorithm is **finite** under anti-cycling rules like Bland's {cite:p}`Bland1977`. In the worst case it is exponential ({cite:t}`KleeMinty1972` constructed a cube where simplex visits all $2^n$ vertices), but in practice it is fast on most LPs."
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## 4. Duality\n\nEvery LP has a **dual**. For the primal $\\min c^\\top x$ s.t. $Ax \\ge b, x \\ge 0$, the dual is\n\n$$\n\\max_{y \\ge 0} \\; b^\\top y \\quad \\text{s.t.} \\quad A^\\top y \\le c.\n$$\n\nDual variables $y$ are **shadow prices**: $y_i$ = marginal change in optimal cost per unit relaxation of constraint $i$.\n\n- **Weak duality:** $b^\\top y \\le c^\\top x$ for any primal-feasible $x$, dual-feasible $y$.\n- **Strong duality:** if either has a finite optimum, both do, and the values are equal.\n- **Complementary slackness** (two conditions): at optimum, **(CS-row)** $y_i \\cdot (a_i^\\top x - b_i) = 0$ for all $i$ \u2014 multiplier vanishes on slack constraints \u2014 and **(CS-col)** $x_j \\cdot (c_j - A_j^\\top y) = 0$ for all $j$ \u2014 variables vanish unless their reduced cost is zero. Both hold simultaneously at optimum.\n\nWe use this constantly: feasible duals certify lower bounds; complementary slackness identifies which constraints are binding."
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "# Standard discopt course imports. The lessons target the real\n# `discopt.modeling.core.Model` API: `m.continuous(name, shape=..., lb=..., ub=...)`,\n# `m.binary(name, shape=...)`, `m.integer(name, shape=..., lb=..., ub=...)`,\n# `m.subject_to(...)`, `m.minimize(...) / .maximize(...)`, `m.solve(...)`.\n# Result attributes: `r.status`, `r.objective`, `r.gap`, `r.bound`,\n# `r.wall_time`, `r.node_count`, and `r.value(var)` for variable arrays.\nimport numpy as np\nimport discopt as do\nimport discopt.modeling as dm\n"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "import numpy as np\nimport discopt as do\n\n# Primal: min c'x  s.t.  Ax >= b, x >= 0\nc = np.array([3.0, 2.0])\nA = np.array([[1, 1], [2, 1], [1, 3]])\nb = np.array([4.0, 5.0, 6.0])\n\nm = do.Model(\"lp\")\nx = m.continuous(\"x\", shape=(2,), lb=0)\n# Three named row-constraints so we can look up their duals by name.\nm.subject_to(A[0, 0] * x[0] + A[0, 1] * x[1] >= b[0])\nm.subject_to(A[1, 0] * x[0] + A[1, 1] * x[1] >= b[1])\nm.subject_to(A[2, 0] * x[0] + A[2, 1] * x[1] >= b[2])\nm.minimize(c[0] * x[0] + c[1] * x[1])\nr = m.solve()\nprint(\"primal optimum:\", round(r.objective, 4), \"at x =\", r.value(x).round(4))\nprint(\"status:\", r.status, \"  wall time:\", round(r.wall_time, 4), \"s\")\n# discopt exposes the LP dual (shadow prices) in r.constraint_duals,\n# keyed by Constraint.name (default names are \"c0\", \"c1\", ...). Lesson 4\n# does the full sensitivity / duality discussion.\nprint(\"shadow prices y* =\", r.constraint_duals)\n"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## 5. Verifying duality numerically\n\n`discopt` exposes the LP dual values $y$ in `r.constraint_duals`, keyed by\nconstraint name. Given a candidate $y$, verify the **three KKT conditions**:\n\n1. **Dual feasibility:** $A^\\top y \\le c$.\n2. **Equal objectives:** $b^\\top y = c^\\top x^\\star$.\n3. **Complementary slackness:** $y_i = 0$ on slack constraints, $y_i > 0$\n   on tight constraints (under non-degeneracy).\n\nIf you want to convince yourself the reported $y$ really is the marginal\n$\\partial z^\\star / \\partial b_i$, do a quick finite-difference check\n(solve at $b$, then at $b + h e_i$ for small $h$, take\n$(z(b + h e_i) - z(b))/h$) and compare. Lesson 4 works this comparison in\ndetail; we revisit KKT for general NLP in Lesson 9 {cite:p}`Boyd2004,Nocedal2006`."
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## 6. The two ways LPs go wrong\n\n| Pathology | Symptom | Diagnosis |\n|-----------|---------|-----------|\n| **Degeneracy** | Multiple BFS map to same vertex; simplex may stall | Use Bland's rule {cite:p}`Bland1977` |\n| **Numerical** | Bad scaling; ill-conditioned basis | Rescale, use IPM (Lesson 12) |\n\nThe presolve step, which we cover in Lesson 15 {cite:p}`Savelsbergh1994`, eliminates many of these issues automatically.\n\n## References\n{cite:p}`Bertsimas1997,Dantzig1963,Bland1977,Boyd2004` for the algorithmic side; {cite:p}`Williams2013` for modeling style."
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/python/discopt/course/basic/02_lp_fundamentals/rubric.md
+++ b/python/discopt/course/basic/02_lp_fundamentals/rubric.md
@@ -1,0 +1,27 @@
+# Rubric — Lesson 2
+
+**Total: 100** (Exercises: 70, Writing: 30)
+
+## Exercises
+- E1 (10): Standard-form conversion correct. Specifically: (i) the free variable $x_1$ is split into $x_1^+ - x_1^-$ with both $\ge 0$; (ii) one slack added per inequality (and the $\ge$ inequality flipped to $\le$ before slack-adding); (iii) the resulting $A x = b, x \ge 0$ system has the same primal optimum as the original LP, verified numerically.
+- E2 (15): LP solved; primal/dual objectives equal within 1e-9; identifies tight constraints.
+- E3 (15): KM correctly built; objectives are $100^{n-1}$.
+- E4 (15): Cost change equals $y_3 \cdot \Delta b_3$ within solver tol.
+- E5 (15): Three LPs with correct statuses; brief explanation references duality / Farkas.
+
+## Writing (30)
+
+- **Concept coverage (10):** the response names ≥ 3 specific concepts from
+  this lesson with a one-line definition or formula each, AND references at
+  least one numerical result the student produced in the exercise notebook
+  (objective value, runtime, gap, plot point).
+- **Technical correctness (10):** every claim about complexity, an algorithm,
+  or a solver's behaviour is either a citation or a derivation; nothing
+  factually wrong per the assessor's checklist for this lesson.
+- **Citations (5):** ≥ 2 `{cite:p}` keys resolve in `docs/references.bib`,
+  at least one of which is a recommended reference for this lesson; no
+  invented or unverifiable keys.
+- **Engagement (5):** the response cites a specific surprise, equation,
+  measurement, or solver-log line the student personally observed — not a
+  generic platitude.
+

--- a/python/discopt/course/basic/02_lp_fundamentals/writing.md
+++ b/python/discopt/course/basic/02_lp_fundamentals/writing.md
@@ -1,0 +1,7 @@
+# Writing assignment — Lesson 2
+
+In ~600 words, explain the **economic meaning of LP duality** to a colleague
+who's seen LPs but never seen the dual. Use the diet problem as a running
+example: what does it mean economically that the calcium constraint has a
+positive shadow price? What does Bland's rule {cite:p}`Bland1977` solve, and
+what would happen without it? Cite at least two of the recommended references.

--- a/python/discopt/course/basic/03_modeling_in_discopt/exercises.ipynb
+++ b/python/discopt/course/basic/03_modeling_in_discopt/exercises.ipynb
@@ -1,0 +1,89 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "# Lesson 3 \u2014 Exercises"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## Exercise 1 \u2014 Transportation with surplus penalty (15 pts)\n\nExtend the transportation example: each supply node has a *surplus penalty* of \\$2 per unit unshipped. Modify the objective accordingly. How does the optimal allocation change?"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "# Standard discopt course imports. The lessons target the real\n# `discopt.modeling.core.Model` API: `m.continuous(name, shape=..., lb=..., ub=...)`,\n# `m.binary(name, shape=...)`, `m.integer(name, shape=..., lb=..., ub=...)`,\n# `m.subject_to(...)`, `m.minimize(...) / .maximize(...)`, `m.solve(...)`.\n# Result attributes: `r.status`, `r.objective`, `r.gap`, `r.bound`,\n# `r.wall_time`, `r.node_count`, and `r.value(var)` for variable arrays.\nimport numpy as np\nimport discopt as do\nimport discopt.modeling as dm\n"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "# TODO\n"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## Exercise 2 \u2014 Absolute deviation regression (15 pts)\n\nGiven 30 data points $(t_i, y_i)$ with noise, fit a line $y = a t + b$ minimizing $\\sum |y_i - (a t_i + b)|$ (an L1 fit). Use the auxiliary-variable trick from the reading. Compare to ordinary least squares. Which is more robust to a single outlier?"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "# TODO: generate data with one outlier; fit L1 and L2; plot.\n"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## Exercise 3 \u2014 Logical AND/OR (15 pts)\n\nA factory has 3 binary decisions: build line A, build line B, build line C. Constraints:\n- If A and B both built, then C must be built.\n- If C is built, total cost adds 100; if A is built, +60; if B is built, +50.\n- We require at least 2 lines.\n\nFind the cheapest configuration. Encode 'A and B \u2192 C' linearly."
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "# TODO\n"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## Exercise 4 \u2014 Bounds matter (10 pts)\n\nTake any small bilinear problem you've seen (e.g., $\\min x \\cdot y$ s.t. $x + y \\ge 1, x, y \\ge 0$). Solve it with bounds $[0, 100]$ vs $[0, 10]$ on each. Time both solves and print node counts. Discuss."
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "# TODO\n"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## Exercise 5 \u2014 Vectorize this (15 pts)\n\nHere's a slow Python loop:\n\n```python\nfor i in range(n):\n    for j in range(n):\n        if i != j:\n            m.subject_to(x[i] + x[j] <= 1)\n```\n\nReplace it with one or two vectorized constraints. Show that the resulting model size (nonzeros) matches."
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "# TODO\n"
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/python/discopt/course/basic/03_modeling_in_discopt/reading.ipynb
+++ b/python/discopt/course/basic/03_modeling_in_discopt/reading.ipynb
@@ -1,0 +1,56 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "# Lesson 3 \u2014 Modeling in `discopt`\n\n**Track:** Basic &nbsp;|&nbsp; **Estimated time:** 90 minutes\n\n## Learning objectives\n\n1. Use the `Model` API: variables, constraints, objective.\n2. Build expressions with operator overloading and recognize the underlying DAG.\n3. Use vectorized variables, indexing, and `sum()` patterns.\n4. Detect modeling errors that the solver will turn into infeasibility/unboundedness."
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## 1. The four-step recipe\n\nEvery `discopt` model is:\n\n```python\nm = do.Model(\"name\")\nx = m.continuous(\"x\", shape=(n,), lb=0, ub=10)   # 1. variables\nm.subject_to(...)                                # 2. constraints\nm.minimize(...)                                  # 3. objective\nresult = m.solve()                               # 4. solve\n```\n\nVariable factories: `m.continuous(name, shape=..., lb=..., ub=...)`,\n`m.binary(name, shape=...)`, `m.integer(name, shape=..., lb=..., ub=...)`.\nAggregations like row/column sums use `dm.sum(expr, axis=k)` (not\n`expr.sum()`). The expression DAG is built lazily as you compose operators.\n\nSee {cite:p}`Williams2013` for the broader modeling philosophy."
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "# Standard discopt course imports. The lessons target the real\n# `discopt.modeling.core.Model` API: `m.continuous(name, shape=..., lb=..., ub=...)`,\n# `m.binary(name, shape=...)`, `m.integer(name, shape=..., lb=..., ub=...)`,\n# `m.subject_to(...)`, `m.minimize(...) / .maximize(...)`, `m.solve(...)`.\n# Result attributes: `r.status`, `r.objective`, `r.gap`, `r.bound`,\n# `r.wall_time`, `r.node_count`, and `r.value(var)` for variable arrays.\nimport numpy as np\nimport discopt as do\nimport discopt.modeling as dm\n"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "import numpy as np, discopt as do\n\nm = do.Model(\"transport\")\nnS, nD = 3, 4\nx = m.continuous(\"x\", shape=(nS, nD), lb=0)         # ship from supply i to demand j\n\nsupply = np.array([100, 150, 80])\ndemand = np.array([60, 90, 70, 110])\ncost   = np.array([\n    [4, 6, 9, 8],\n    [5, 4, 7, 6],\n    [9, 8, 3, 4],\n])\n\n# Supply: row sums <= supply\nfor i in range(nS):\n    m.subject_to(dm.sum(x[i, :]) <= supply[i])\n\n# Demand: column sums >= demand\nfor j in range(nD):\n    m.subject_to(dm.sum(x[:, j]) >= demand[j])\n\nm.minimize(dm.sum(cost * x))\nr = m.solve()\nprint(\"cost:\", r.objective)\nprint(\"shipments:\")\nprint(r.value(x))\n"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## 2. Expression DAG\n\nEvery operator (`+`, `*`, `**`, `<=`, etc.) returns an Expression node, not a number. The Rust backend turns the DAG into the IR for the solver. Two practical implications:\n\n- **Reuse** subexpressions; the DAG deduplicates them: `e = x[0]*x[1]; m.subject_to(e <= 10); m.minimize(e + x[2])`.\n- **Avoid Python-level loops** for big models; prefer vectorized expressions or `sum()` over generators.\n\n## 3. Common modeling tricks\n\n| Want | How |\n|------|-----|\n| Either-or constraint | Big-M with binary indicator (Lesson 5) |\n| Absolute value $|y - a|$ | Auxiliary $u \\ge y - a$, $u \\ge a - y$ (in min objective only) |\n| Max of expressions $\\max(e_1, e_2)$ | Aux $u \\ge e_i$, minimize $u$ |\n| Piecewise linear $f(x)$ | SOS2 or convex combination formulation |\n| Logical $z = x \\land y$ | $z \\le x$, $z \\le y$, $z \\ge x + y - 1$ |\n\nSee {cite:p}`Williams2013,Wolsey1998` for the full catalogue."
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## 4. Bounds matter\n\nTight bounds on variables are crucial:\n\n- They **make presolve effective** {cite:p}`Savelsbergh1994,Belotti2009`.\n- For nonconvex problems they **enable McCormick relaxations** {cite:p}`McCormick1976` (Lesson 16).\n- Loose or missing bounds lead to long solves or unbounded LP relaxations.\n\nIf you don't know the right bound, *guess generously and shrink later*. `discopt` will warn if a variable is unbounded in a context where bounds are required."
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## 5. Diagnosing a bad model\n\nBefore blaming the solver:\n\n1. **Print `m.summary()`** \u2014 number of vars, constraints, nonzeros.\n2. **Solve the LP relaxation** of an MILP \u2014 if it's infeasible, your model is wrong.\n3. **Drop the objective, just check feasibility** \u2014 `m.solve()`.\n4. **Slacken** suspect constraints with a penalty term \u2014 see which ones are tight in your \"wrong\" answer.\n\nThese tricks save days of debugging.\n\n## References\n{cite:p}`Williams2013` is the model-builder's bible; {cite:p}`Wolsey1998` for IP-specific tricks; {cite:p}`Belotti2009` for how presolve uses your bounds."
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/python/discopt/course/basic/03_modeling_in_discopt/rubric.md
+++ b/python/discopt/course/basic/03_modeling_in_discopt/rubric.md
@@ -1,0 +1,27 @@
+# Rubric — Lesson 3
+
+**Total: 100**
+
+## Exercises (70)
+- E1 (15): Surplus penalty term added correctly; allocation changes documented.
+- E2 (15): L1 formulation correct; outlier shown to pull L2 fit but not L1.
+- E3 (15): A∧B→C linearized correctly via $C \ge A + B - 1$; cheapest config found.
+- E4 (10): Both solves done, node counts compared; discussion mentions bound tightness.
+- E5 (15): Vectorized formulation correct; nonzero count matches.
+
+## Writing (30)
+
+- **Concept coverage (10):** the response names ≥ 3 specific concepts from
+  this lesson with a one-line definition or formula each, AND references at
+  least one numerical result the student produced in the exercise notebook
+  (objective value, runtime, gap, plot point).
+- **Technical correctness (10):** every claim about complexity, an algorithm,
+  or a solver's behaviour is either a citation or a derivation; nothing
+  factually wrong per the assessor's checklist for this lesson.
+- **Citations (5):** ≥ 2 `{cite:p}` keys resolve in `docs/references.bib`,
+  at least one of which is a recommended reference for this lesson; no
+  invented or unverifiable keys.
+- **Engagement (5):** the response cites a specific surprise, equation,
+  measurement, or solver-log line the student personally observed — not a
+  generic platitude.
+

--- a/python/discopt/course/basic/03_modeling_in_discopt/writing.md
+++ b/python/discopt/course/basic/03_modeling_in_discopt/writing.md
@@ -1,0 +1,7 @@
+# Writing assignment — Lesson 3
+
+In ~500 words, write a *modeling cookbook* for a practitioner colleague: list
+five non-obvious modeling tricks (absolute value, max, logical conjunction,
+piecewise linear, and one of your own). For each, show the algebraic
+formulation in 2–3 lines and cite a source. Use {cite:p}`Williams2013` and
+{cite:p}`Wolsey1998` at minimum.

--- a/python/discopt/course/basic/04_sensitivity_and_duality/exercises.ipynb
+++ b/python/discopt/course/basic/04_sensitivity_and_duality/exercises.ipynb
@@ -1,0 +1,89 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "# Lesson 4 \u2014 Exercises"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## Exercise 1 \u2014 Derive the dual by hand (15 pts)\n\nFor the LP $\\min 5 x_1 + 4 x_2 + 3 x_3$ s.t. $2x_1 + 3x_2 + x_3 \\ge 5,\\; 4x_1 + x_2 + 2x_3 \\ge 11,\\; 3x_1 + 4x_2 + 2x_3 \\ge 8,\\; x \\ge 0$, write the dual *explicitly* (variables, objective, constraints). Then solve both numerically and verify the values match."
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "# Standard discopt course imports. The lessons target the real\n# `discopt.modeling.core.Model` API: `m.continuous(name, shape=..., lb=..., ub=...)`,\n# `m.binary(name, shape=...)`, `m.integer(name, shape=..., lb=..., ub=...)`,\n# `m.subject_to(...)`, `m.minimize(...) / .maximize(...)`, `m.solve(...)`.\n# Result attributes: `r.status`, `r.objective`, `r.gap`, `r.bound`,\n# `r.wall_time`, `r.node_count`, and `r.value(var)` for variable arrays.\nimport numpy as np\nimport discopt as do\nimport discopt.modeling as dm\n"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "# TODO\n"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## Exercise 2 \u2014 RHS ranging (15 pts)\n\nFor the LP in Exercise 1, take constraint 1's RHS $b_1 = 5$ and perturb to $b_1 \\in \\{4, 4.5, 5, 5.5, 6, 7\\}$. Plot $z^\\star$ vs $b_1$. Is it linear? Where does the slope change? Connect this to *basis changes*."
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "# TODO\n"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## Exercise 3 \u2014 Shadow prices: direct vs. empirical (10 pts)\n\n`discopt` exposes the LP shadow prices in `r.constraint_duals`. To convince yourself that those numbers really *are* the marginal change in optimal cost, recover them **two ways** and compare:\n\n1. **Direct**: read $y_i^\\star = $ `r.constraint_duals[\"c<i>\"]` straight off the solve result.\n2. **Empirical**: solve once at $b_i$, again at $b_i + h$ for small $h$ (e.g., $h = 10^{-3}$), and report $\\hat y_i = (z(b_i + h) - z(b_i))/h$ for each $i$.\n\nReport the two vectors side by side and the elementwise difference. Then verify dual feasibility $A^\\top y^\\star \\le c$ and zero duality gap $b^\\top y^\\star = c^\\top x^\\star$ using the direct values."
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "# TODO\n"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## Exercise 4 \u2014 Find a degenerate LP (15 pts)\n\nConstruct a 2D LP that is degenerate (i.e., three or more constraints meet at the optimum vertex). Show that small perturbations of the RHS shift the optimum *non-smoothly* \u2014 that's the empirical signature of degeneracy when you don't have direct basis access."
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "# TODO\n"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## Exercise 5 \u2014 Certified bound (15 pts)\n\nGiven a primal feasible $\\hat x$ that you suspect is optimal but you don't trust the solver, find any dual feasible $\\hat y$ and use weak duality to give a *certified lower bound* on the true $z^\\star$. Show that if $b^\\top \\hat y = c^\\top \\hat x$ then $\\hat x$ is provably optimal."
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "# TODO\n"
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/python/discopt/course/basic/04_sensitivity_and_duality/reading.ipynb
+++ b/python/discopt/course/basic/04_sensitivity_and_duality/reading.ipynb
@@ -1,0 +1,61 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "# Lesson 4 \u2014 Sensitivity, Duality, Shadow Prices\n\n## Learning objectives\n\n1. Derive the LP dual mechanically from the primal.\n2. Interpret reduced costs and shadow prices.\n3. Read a sensitivity report: ranging on RHS and on objective coefficients.\n4. Use duality to *certify* optimality and detect degeneracy.\n\nWe assume Lesson 2's geometry of the polyhedron."
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## 1. Mechanical derivation of the dual\n\nFor the canonical primal\n\n$$\\min c^\\top x \\;\\;\\text{s.t.}\\;\\; Ax \\ge b, x \\ge 0,$$\n\nthe dual is\n\n$$\\max b^\\top y \\;\\;\\text{s.t.}\\;\\; A^\\top y \\le c, y \\ge 0.$$\n\nThe mapping (primal \u2194 dual):\n\n| Primal | Dual |\n|--------|------|\n| min | max |\n| $\\ge$ constraint | $y_i \\ge 0$ |\n| $=$ constraint | $y_i$ free |\n| $x_j \\ge 0$ | $\\le$ constraint |\n| $x_j$ free | $=$ constraint |\n\nThis is **mechanical**, but it codifies a deep fact: every degree of freedom in one problem is constrained by a constraint in the other {cite:p}`Bertsimas1997,Boyd2004`."
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## 2. Shadow prices\n\nThe dual variable $y_i^\\star$ is the **shadow price** of constraint $i$. It is the marginal change in optimal cost per unit relaxation of $b_i$:\n\n$$\\frac{\\partial z^\\star}{\\partial b_i} = y_i^\\star \\quad \\text{(within the basis range).}$$\n\n**Two interpretations:**\n\n- *Economic*: in production planning, $y_i$ tells you the maximum you'd pay for one more unit of resource $i$.\n- *Algorithmic*: the simplex method uses dual values to decide which non-basic variable to bring in (entering variable rule)."
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## 3. Reduced costs\n\nFor non-basic variable $x_j$, the **reduced cost** $\\bar c_j = c_j - A_j^\\top y^\\star$ is the *rate* at which the objective changes if you push $x_j$ above 0. Optimality means all reduced costs are non-negative (for a min problem); otherwise simplex pivots.\n\nReduced costs also give **objective ranging**: by how much can $c_j$ change before the current basis stops being optimal? Answer: until $\\bar c_j$ would change sign."
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "# Standard discopt course imports. The lessons target the real\n# `discopt.modeling.core.Model` API: `m.continuous(name, shape=..., lb=..., ub=...)`,\n# `m.binary(name, shape=...)`, `m.integer(name, shape=..., lb=..., ub=...)`,\n# `m.subject_to(...)`, `m.minimize(...) / .maximize(...)`, `m.solve(...)`.\n# Result attributes: `r.status`, `r.objective`, `r.gap`, `r.bound`,\n# `r.wall_time`, `r.node_count`, and `r.value(var)` for variable arrays.\nimport numpy as np\nimport discopt as do\nimport discopt.modeling as dm\n"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "import numpy as np, discopt as do\n\nc = np.array([3.0, 2.0])\nA = np.array([[1, 1], [2, 1], [1, 3]])\nb = np.array([4.0, 5.0, 6.0])\n\nm = do.Model(\"sens\")\nx = m.continuous(\"x\", shape=(2,), lb=0)\n# Build the three rows individually so each gets a stable name we can look\n# up in r.constraint_duals.\nm.subject_to(A[0, 0] * x[0] + A[0, 1] * x[1] >= b[0])\nm.subject_to(A[1, 0] * x[0] + A[1, 1] * x[1] >= b[1])\nm.subject_to(A[2, 0] * x[0] + A[2, 1] * x[1] >= b[2])\nm.minimize(c[0] * x[0] + c[1] * x[1])\nr = m.solve()\nprint(\"primal x =\", r.value(x).round(4), \"  obj =\", round(r.objective, 4))\n\n# discopt exposes KKT multipliers directly when the solver returns them:\n#   r.constraint_duals      -- dict keyed by Constraint.name (shadow prices y_i)\n#   r.bound_duals_lower     -- dict keyed by Variable.name (reduced costs at lb)\n#   r.bound_duals_upper     -- dict keyed by Variable.name (reduced costs at ub)\n# All values are in the internal-minimization sign convention.\nprint(\"shadow prices y* =\", r.constraint_duals)\nprint(\"reduced costs at x>=0 =\", r.bound_duals_lower)\n\n# Cross-check b^T y == c^T x (zero duality gap):\ny = np.array([float(r.constraint_duals[name]) for name in (\"c0\", \"c1\", \"c2\")])\nprint(\"b^T y =\", round(float(b @ y), 4), \"  c^T x =\", round(float(c @ r.value(x)), 4))\n"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## 4. Verifying optimality without resolving\n\nYou can certify a primal solution $\\hat x$ is optimal by exhibiting a $\\hat y$ with:\n\n1. $A^\\top \\hat y \\le c, \\hat y \\ge 0$ (dual feasibility),\n2. $b^\\top \\hat y = c^\\top \\hat x$ (zero duality gap),\n3. complementary slackness $\\hat y_i \\cdot (A_i \\hat x - b_i) = 0$.\n\nIn B&B for MILP (Lesson 6), this is exactly how the LP relaxation provides a certified bound at each node."
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## 5. Degeneracy\n\nA BFS is **degenerate** if some basic variable is at its bound (typically 0). At a degenerate vertex, multiple bases describe the same point, so pivots may make zero progress (cycling). Bland's rule {cite:p}`Bland1977` and lexicographic perturbation prevent cycles. In modeling, degeneracy often signals **redundant constraints** \u2014 sometimes an opportunity for presolve {cite:p}`Savelsbergh1994`.\n\n## References\n{cite:p}`Bertsimas1997` Ch 4\u20135; {cite:p}`Boyd2004` Ch 5 (general convex duality); {cite:p}`Dantzig1963`."
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/python/discopt/course/basic/04_sensitivity_and_duality/rubric.md
+++ b/python/discopt/course/basic/04_sensitivity_and_duality/rubric.md
@@ -1,0 +1,27 @@
+# Rubric — Lesson 4
+
+**Total: 100**
+
+## Exercises (70)
+- E1 (15): Dual stated correctly; primal/dual objectives match.
+- E2 (15): Plot piecewise linear; basis-change corners identified.
+- E3 (10): finite-difference shadow prices computed; dual feasibility and equal-objective conditions verified within 1e-4.
+- E4 (15): Genuinely degenerate 2D LP; non-smooth perturbation behaviour exhibited.
+- E5 (15): Dual certificate constructed and verified.
+
+## Writing (30)
+
+- **Concept coverage (10):** the response names ≥ 3 specific concepts from
+  this lesson with a one-line definition or formula each, AND references at
+  least one numerical result the student produced in the exercise notebook
+  (objective value, runtime, gap, plot point).
+- **Technical correctness (10):** every claim about complexity, an algorithm,
+  or a solver's behaviour is either a citation or a derivation; nothing
+  factually wrong per the assessor's checklist for this lesson.
+- **Citations (5):** ≥ 2 `{cite:p}` keys resolve in `docs/references.bib`,
+  at least one of which is a recommended reference for this lesson; no
+  invented or unverifiable keys.
+- **Engagement (5):** the response cites a specific surprise, equation,
+  measurement, or solver-log line the student personally observed — not a
+  generic platitude.
+

--- a/python/discopt/course/basic/04_sensitivity_and_duality/writing.md
+++ b/python/discopt/course/basic/04_sensitivity_and_duality/writing.md
@@ -1,0 +1,9 @@
+# Writing assignment — Lesson 4
+
+Write ~600 words for a fellow graduate student explaining duality through a
+*concrete economic story* (factory, farm, datacenter — your pick). Address:
+(a) what each shadow price means physically; (b) why a zero shadow price is
+informative ("not at all binding"); (c) one situation in which the LP is
+degenerate and what that means about the underlying problem. Cite
+{cite:p}`Bertsimas1997` and one applied paper of your choice from
+`docs/references.bib`.

--- a/python/discopt/course/basic/05_integer_programming_basics/exercises.ipynb
+++ b/python/discopt/course/basic/05_integer_programming_basics/exercises.ipynb
@@ -1,0 +1,87 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "# Lesson 5 \u2014 Exercises"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## Exercise 1 \u2014 Tight big-M (15 pts)\n\nFor the constraint 'if $z = 1$ then $\\sum_j a_j x_j \\ge b$, else no constraint' with $x_j \\in [0, U_j]$, derive the *smallest valid* $M$ and the standard linearization. Then code an example with $a = (2, -1, 3)$, $U = (5, 4, 6)$, $b = 4$ and check it works as expected."
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "# Standard discopt course imports. The lessons target the real\n# `discopt.modeling.core.Model` API: `m.continuous(name, shape=..., lb=..., ub=...)`,\n# `m.binary(name, shape=...)`, `m.integer(name, shape=..., lb=..., ub=...)`,\n# `m.subject_to(...)`, `m.minimize(...) / .maximize(...)`, `m.solve(...)`.\n# Result attributes: `r.status`, `r.objective`, `r.gap`, `r.bound`,\n# `r.wall_time`, `r.node_count`, and `r.value(var)` for variable arrays.\nimport numpy as np\nimport discopt as do\nimport discopt.modeling as dm\n"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "# TODO: build the constraint, test with z=0 vs z=1.\n"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## Exercise 2 \u2014 Facility location (15 pts)\n\nGiven 5 candidate facility locations with fixed costs $f$, capacities $U$, and a 10-customer demand vector with shipment costs $c_{ij}$, write the *uncapacitated facility location* problem as an MILP. Solve it with the disaggregated formulation; then with the aggregated formulation; compare LP relaxation gaps and node counts."
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "# TODO\n"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## Exercise 3 \u2014 TUM in the wild (15 pts)\n\nThe assignment problem (assign $n$ workers to $n$ tasks, minimize total cost) has a TUM constraint matrix. Solve it as an LP (no integer variables). Verify the LP solution is naturally integer, and matches the MILP solution exactly."
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "# TODO\n"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## Exercise 4 \u2014 SOS2 piecewise (15 pts)\n\nPiecewise linearize $f(x) = x^2$ on $[0, 4]$ at break points $\\{0, 1, 2, 3, 4\\}$ using SOS2 variables. Use the result inside an MILP that also constrains $x \\ge 1.5$. Compare the SOS2 piecewise approximation to the true value at $x = 1.5$."
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "# TODO\n"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## Exercise 5 \u2014 Spot the bad formulation (10 pts)\n\nA student writes the constraint 'either $x_1 + x_2 \\le 5$ or $x_1 - x_2 \\ge 1$' as\n```\nm.subject_to(x1 + x2 <= 5 + 1e9 * z)\nm.subject_to(x1 - x2 >= 1 - 1e9 * (1 - z))\n```\nDescribe two issues with this formulation and propose tightenings."
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "**Your answer:**\n\n- Issue 1: ...\n- Issue 2: ...\n- Tightening: ..."
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/python/discopt/course/basic/05_integer_programming_basics/reading.ipynb
+++ b/python/discopt/course/basic/05_integer_programming_basics/reading.ipynb
@@ -1,0 +1,54 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "# Lesson 5 \u2014 Integer Programming Basics\n\n## Learning objectives\n\n1. Recognize when integrality matters and write IP/MILP formulations.\n2. Apply the canonical IP modeling tricks (big-M, indicator constraints, SOS, fixed-cost charges).\n3. Understand totally unimodular (TUM) matrices and why some \"IPs\" are really LPs.\n4. Distinguish *strong* from *weak* formulations."
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## 1. The integrality leap\n\nLP is polynomial-time {cite:p}`Khachiyan1979,Karmarkar1984` ({cite:t}`Khachiyan1979`'s ellipsoid was the first poly-time algorithm; {cite:t}`Karmarkar1984` was the first practical interior-point one). Adding $x \\in \\mathbb{Z}^n$ makes the problem NP-hard {cite:p}`Wolsey1998`. Two reasons:\n\n1. **Combinatorial:** the feasible set is a finite (or countable) set of points.\n2. **Non-convex:** the convex hull of feasible integer points (the **integer hull**) is a polytope distinct from the LP relaxation; finding it is the heart of cutting-plane methods (Lesson 13)."
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## 2. Big-M\n\nEncode \"if $z = 1$ then $a^\\top x \\le b$, else no constraint\":\n\n$$a^\\top x \\le b + M (1 - z)$$\n\nwith $M$ a constant chosen so the inequality is vacuous when $z = 0$. Tight $M$ is critical: too-loose $M$ gives a weak LP relaxation and slow B&B {cite:p}`Williams2013,Belotti2009`.\n\n> **Rule:** always derive the *smallest valid* $M$ from variable bounds. Never pick $10^9$ \"to be safe.\"\n\n## 3. Fixed-cost charges\n\n$$\\text{cost} = \\sum_i (f_i z_i + c_i x_i), \\quad x_i \\le U_i z_i$$\n\n$z_i = 1$ if facility $i$ is opened ($U_i$ = capacity). Classic facility-location pattern."
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## 4. SOS / piecewise linear\n\nA *Special Ordered Set Type 2* (SOS2) is a set of variables of which at most two consecutive may be nonzero. Used to encode piecewise linear $f(x)$:\n\n$$x = \\sum_k \\lambda_k \\hat x_k, \\; f(x) = \\sum_k \\lambda_k f(\\hat x_k), \\; \\lambda \\in \\text{SOS2}, \\sum \\lambda_k = 1.$$\n\nMany MILP solvers (and `discopt`) accept SOS as a special constraint type with a tailored branching rule {cite:p}`Conforti2014`."
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## 5. Totally unimodular (TUM)\n\nA matrix $A$ is TUM if every square submatrix has determinant $0, +1,$ or $-1$. **Theorem:** if $A$ is TUM and $b$ is integer, the LP $\\min c^\\top x$ s.t. $Ax \\le b, x \\ge 0$ has integer optimal vertices automatically.\n\nStandard examples: bipartite matching, network flow, assignment, shortest path, max flow {cite:p}`Conforti2014,Wolsey1998`. If you can recognize TUM structure, you don't need integer variables \u2014 the LP gives the IP answer."
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## 6. Strong vs weak formulations\n\nTwo formulations of the same IP can have very different LP relaxations. The one with smaller LP-relaxation feasible set is **stronger** \u2014 its B&B tree is smaller. Example: facility location.\n\n- *Aggregated:* $\\sum_i x_{ij} \\le M z_j$ for each facility $j$.\n- *Disaggregated:* $x_{ij} \\le z_j$ for each $(i, j)$ pair.\n\nDisaggregated is stronger (and has more constraints). The trade-off shows up everywhere; understanding it is the difference between models that solve in seconds vs hours {cite:p}`Williams2013,Wolsey1998`.\n\n## References\n{cite:p}`Wolsey1998,Williams2013,Conforti2014` are the canonical IP textbooks. {cite:p}`Belotti2009` discusses bound tightening in MINLP."
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "# Standard discopt course imports. The lessons target the real\n# `discopt.modeling.core.Model` API: `m.continuous(name, shape=..., lb=..., ub=...)`,\n# `m.binary(name, shape=...)`, `m.integer(name, shape=..., lb=..., ub=...)`,\n# `m.subject_to(...)`, `m.minimize(...) / .maximize(...)`, `m.solve(...)`.\n# Result attributes: `r.status`, `r.objective`, `r.gap`, `r.bound`,\n# `r.wall_time`, `r.node_count`, and `r.value(var)` for variable arrays.\nimport numpy as np\nimport discopt as do\nimport discopt.modeling as dm\n"
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/python/discopt/course/basic/05_integer_programming_basics/rubric.md
+++ b/python/discopt/course/basic/05_integer_programming_basics/rubric.md
@@ -1,0 +1,27 @@
+# Rubric — Lesson 5
+
+**Total: 100**
+
+## Exercises (70)
+- E1 (15): tight $M$ derived; linearization correct; tested.
+- E2 (15): both formulations correct; LP gap and node count compared (disagg ≪ agg).
+- E3 (15): LP solved; integer solution; matches MILP.
+- E4 (15): SOS2 set correct; piecewise approximation $0.5\cdot 1 + 0.5\cdot 4 = 2.5$ at $x=1.5$ (linear interpolation between consecutive break points).
+- E5 (10): identifies loose $M$ and missing convex-hull tightening.
+
+## Writing (30)
+
+- **Concept coverage (10):** the response names ≥ 3 specific concepts from
+  this lesson with a one-line definition or formula each, AND references at
+  least one numerical result the student produced in the exercise notebook
+  (objective value, runtime, gap, plot point).
+- **Technical correctness (10):** every claim about complexity, an algorithm,
+  or a solver's behaviour is either a citation or a derivation; nothing
+  factually wrong per the assessor's checklist for this lesson.
+- **Citations (5):** ≥ 2 `{cite:p}` keys resolve in `docs/references.bib`,
+  at least one of which is a recommended reference for this lesson; no
+  invented or unverifiable keys.
+- **Engagement (5):** the response cites a specific surprise, equation,
+  measurement, or solver-log line the student personally observed — not a
+  generic platitude.
+

--- a/python/discopt/course/basic/05_integer_programming_basics/writing.md
+++ b/python/discopt/course/basic/05_integer_programming_basics/writing.md
@@ -1,0 +1,8 @@
+# Writing assignment — Lesson 5
+
+In ~600 words, explain to a non-OR colleague *why integer variables are
+hard*. Use a concrete example (knapsack or facility location). Address:
+- the fundamental difference between LP and IP feasible sets;
+- why "rounding the LP solution" can produce infeasible or arbitrarily-bad IP solutions;
+- what 'strong vs weak formulation' means and why it's the most important
+  modeling lever you have. Cite {cite:p}`Wolsey1998` and {cite:p}`Williams2013`.

--- a/python/discopt/course/basic/06_branch_and_bound/exercises.ipynb
+++ b/python/discopt/course/basic/06_branch_and_bound/exercises.ipynb
@@ -1,0 +1,89 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "# Lesson 6 \u2014 Exercises"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## Exercise 1 \u2014 Trace by hand (15 pts)\n\nFor the 4-item knapsack in the reading, trace the B&B tree manually. Submit your trace as a Python dictionary in the cell below: keys are node ids (root = 0), values are tuples `(lp_value, branched_var, prune_reason)` where `prune_reason \u2208 {'integer', 'bound', 'infeasible', 'open'}` and `branched_var = None` for pruned leaves. The tree should have at most 7 nodes. The assessor will compare your dict to `discopt`'s log."
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "# Standard discopt course imports. The lessons target the real\n# `discopt.modeling.core.Model` API: `m.continuous(name, shape=..., lb=..., ub=...)`,\n# `m.binary(name, shape=...)`, `m.integer(name, shape=..., lb=..., ub=...)`,\n# `m.subject_to(...)`, `m.minimize(...) / .maximize(...)`, `m.solve(...)`.\n# Result attributes: `r.status`, `r.objective`, `r.gap`, `r.bound`,\n# `r.wall_time`, `r.node_count`, and `r.value(var)` for variable arrays.\nimport numpy as np\nimport discopt as do\nimport discopt.modeling as dm\n"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "# Replace the placeholder with your trace.\nbnb_trace = {\n    0: (None, None, 'open'),  # root\n    # 1: (...), 2: (...), ...\n}\n# Optional sanity check: total nodes you claim must match discopt.\nassert len(bnb_trace) <= 7\n"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## Exercise 2 \u2014 Bound vs branch (15 pts)\n\nGenerate a knapsack with $n = 30$ items, two ways:\n\n(a) **Easy**: weights $\\sim$ Uniform(1, 10), values $\\sim$ Uniform(1, 10).\n(b) **Hard**: values $=$ weights (degenerate).\n\nSolve both, compare nodes, LP gap, and runtime. Why is (b) so much harder?"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "# TODO\n"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## Exercise 3 \u2014 Node selection on a toy B&B (10 pts)\n\n`discopt`'s solver does not expose a node-selection switch in its public API. So implement a tiny B&B yourself in ~80 lines of Python: at each node solve the LP relaxation with `scipy.optimize.linprog`, branch on the most-fractional variable. Run with three node-selection strategies (best-first / depth-first / best-estimate) on the same MILP; compare nodes processed and time-to-first-incumbent. When would you prefer each?"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "# TODO\n"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## Exercise 4 \u2014 Symmetry (15 pts)\n\nConstruct a small MILP where the variables $x_1, x_2, x_3$ are completely symmetric (e.g., bin packing with 3 identical bins). Solve as-is, then add a *lex-ordering* tightening (e.g., $x_1 \\le x_2 \\le x_3$ if applicable). Compare node counts."
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "# TODO\n"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## Exercise 5 \u2014 When does B&B finish in one node? (15 pts)\n\nGive an example MILP whose LP relaxation has an integer optimum (so B&B prunes by integrality at the root). What structural property of your matrix is responsible?"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "# TODO\n"
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/python/discopt/course/basic/06_branch_and_bound/reading.ipynb
+++ b/python/discopt/course/basic/06_branch_and_bound/reading.ipynb
@@ -1,0 +1,56 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "# Lesson 6 \u2014 Branch and Bound, Conceptually\n\n## Learning objectives\n\n1. Trace by hand a B&B tree for a small MILP.\n2. Distinguish *bounding*, *branching*, and *node selection*.\n3. Read a `discopt` B&B log and identify when nodes are pruned by bound, by integrality, or by infeasibility.\n4. Reason about why some MILPs blow up the tree and others close in 1 node."
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## 1. The algorithm in pseudocode\n\n```\nLB = -inf, UB = +inf, incumbent = None\npush root LP relaxation onto stack\n\nwhile stack non-empty:\n    pop node\n    solve LP relaxation -> z_LP\n    if infeasible:                  prune (infeasibility)\n    elif z_LP >= UB:                prune (bound)\n    elif x_LP is integer:           if z_LP < UB: UB = z_LP; incumbent = x_LP\n    else:                           branch on a fractional variable, push children\n```\n\nThis is {cite:p}`Land1960` and {cite:p}`Dakin1965`. Modern solvers add presolve, cuts, heuristics, and clever branching/node selection on top \u2014 but this is the core."
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## 2. Branching choices\n\nWhen $x_j^\\star$ in the LP solution is fractional ($x_j = 1.7$, say), branch:\n\n- **Down child:** add $x_j \\le 1$.\n- **Up child:** add $x_j \\ge 2$.\n\nWhich fractional variable to pick is the *branching rule*. Lesson 14 covers strong branching {cite:p}`Achterberg2005`. For now: most fractional, or pseudo-cost based, are common heuristics.\n\n## 3. Node selection\n\nOrder in which to process the open nodes:\n\n- **Best-first** (lowest LP bound first) \u2014 minimizes nodes processed.\n- **Depth-first** \u2014 minimizes memory; finds incumbents fast.\n- **Best-estimate / hybrid** \u2014 balances both.\n\n`discopt` defaults to best-estimate {cite:p}`Achterberg2007`."
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "# Standard discopt course imports. The lessons target the real\n# `discopt.modeling.core.Model` API: `m.continuous(name, shape=..., lb=..., ub=...)`,\n# `m.binary(name, shape=...)`, `m.integer(name, shape=..., lb=..., ub=...)`,\n# `m.subject_to(...)`, `m.minimize(...) / .maximize(...)`, `m.solve(...)`.\n# Result attributes: `r.status`, `r.objective`, `r.gap`, `r.bound`,\n# `r.wall_time`, `r.node_count`, and `r.value(var)` for variable arrays.\nimport numpy as np\nimport discopt as do\nimport discopt.modeling as dm\n"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "import numpy as np, discopt as do\n\n# Small knapsack we'll trace by hand\nv = np.array([10, 14, 12, 11])\nw = np.array([5, 7, 6, 5])\nW = 13\n\nm = do.Model(\"k4\")\nx = m.binary(\"x\", shape=(4,))\nm.subject_to(w @ x <= W)\nm.maximize(v @ x)\nr = m.solve()\n\nprint(\"optimal:\", r.objective, \"  x*:\", r.value(x))\nprint(\"nodes processed:\", r.node_count, \"  wall time:\", round(r.wall_time, 4))\nprint(\"dual bound:\", r.bound, \"  gap:\", r.gap)\n"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## 4. Pruning logic\n\nA node is pruned by:\n\n- **Infeasibility:** LP relaxation has no solution.\n- **Bound:** LP value is worse than the incumbent ($z_{LP} \\ge \\text{UB}$ for min).\n- **Integrality:** LP solution is integer; update incumbent and prune.\n\nStronger LP relaxations \u2192 more pruning by bound \u2192 smaller tree. Hence the obsession with cuts (Lesson 13) and tight formulations (Lesson 5)."
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## 5. Why some MILPs explode\n\nTwo pathologies:\n\n- **Symmetry** \u2014 equivalent feasible solutions reached by swapping variable indices. The tree must still explore branches that lead to identical solutions {cite:p}`Margot2010`.\n- **Weak bounds** \u2014 LP relaxation far above the IP optimum, so few prunings happen.\n\nBoth are addressable: symmetry breaking via lex constraints; bounds via tighter formulation, presolve, and cuts.\n\n## References\n{cite:p}`Land1960,Dakin1965` (originals), {cite:p}`Wolsey1998` (textbook), {cite:p}`Achterberg2007` (modern engineering)."
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/python/discopt/course/basic/06_branch_and_bound/rubric.md
+++ b/python/discopt/course/basic/06_branch_and_bound/rubric.md
@@ -1,0 +1,27 @@
+# Rubric — Lesson 6
+
+**Total: 100**
+
+## Exercises (70)
+- E1 (15): `bnb_trace` dict supplied; node count matches `discopt`'s log; LP values within 1e-6 of the solver; prune reasons match.
+- E2 (15): hard instance shown to be vastly harder; LP gap explanation.
+- E3 (10): three strategies compared; trade-offs articulated.
+- E4 (15): symmetric instance built; lex constraint reduces nodes.
+- E5 (15): TUM (or other) example with integer LP at root.
+
+## Writing (30)
+
+- **Concept coverage (10):** the response names ≥ 3 specific concepts from
+  this lesson with a one-line definition or formula each, AND references at
+  least one numerical result the student produced in the exercise notebook
+  (objective value, runtime, gap, plot point).
+- **Technical correctness (10):** every claim about complexity, an algorithm,
+  or a solver's behaviour is either a citation or a derivation; nothing
+  factually wrong per the assessor's checklist for this lesson.
+- **Citations (5):** ≥ 2 `{cite:p}` keys resolve in `docs/references.bib`,
+  at least one of which is a recommended reference for this lesson; no
+  invented or unverifiable keys.
+- **Engagement (5):** the response cites a specific surprise, equation,
+  measurement, or solver-log line the student personally observed — not a
+  generic platitude.
+

--- a/python/discopt/course/basic/06_branch_and_bound/writing.md
+++ b/python/discopt/course/basic/06_branch_and_bound/writing.md
@@ -1,0 +1,7 @@
+# Writing assignment — Lesson 6
+
+In ~600 words, explain B&B as if to a strong undergraduate who knows LP. Walk
+through the tree pseudocode, then explain the *three* prune reasons. End with
+why "B&B is just smart enumeration" is misleading — what makes it *smart* is
+the bound, and the bound's tightness is determined by the formulation. Cite
+{cite:p}`Land1960` and {cite:p}`Wolsey1998`.

--- a/python/discopt/course/basic/07_convexity/exercises.ipynb
+++ b/python/discopt/course/basic/07_convexity/exercises.ipynb
@@ -1,0 +1,85 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "# Lesson 7 \u2014 Exercises"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## Exercise 1 \u2014 Convex or not? (15 pts)\n\nClassify each as convex / concave / neither and *prove* it (Hessian sign or convexity calculus):\n\na) $f(x) = x^\\top P x$ with $P = \\text{diag}(1, -1)$\nb) $f(x_1, x_2) = e^{x_1 + x_2} + x_1^2 + x_2^4$\nc) $f(x_1, x_2) = \\max(x_1^2, x_2^2 - 1)$\nd) $f(x) = \\frac{x^2}{1 + x^2}$"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "**Your answers:**\n- a) ...\n- b) ...\n- c) ...\n- d) ..."
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## Exercise 2 \u2014 Build a convex problem (15 pts)\n\nFormulate (in `discopt`) a convex problem with at least one log term, one quadratic term, and one linear inequality. Solve, and confirm `r.convex_fast_path == True` to verify the solver took the convex path. Report the optimum."
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "# Standard discopt course imports. The lessons target the real\n# `discopt.modeling.core.Model` API: `m.continuous(name, shape=..., lb=..., ub=...)`,\n# `m.binary(name, shape=...)`, `m.integer(name, shape=..., lb=..., ub=...)`,\n# `m.subject_to(...)`, `m.minimize(...) / .maximize(...)`, `m.solve(...)`.\n# Result attributes: `r.status`, `r.objective`, `r.gap`, `r.bound`,\n# `r.wall_time`, `r.node_count`, and `r.value(var)` for variable arrays.\nimport numpy as np\nimport discopt as do\nimport discopt.modeling as dm\n"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "# TODO\n"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## Exercise 3 \u2014 Break it (15 pts)\n\nStarting from your convex problem in Ex. 2, change *one term* to make it nonconvex (e.g., add an $x_1 x_2$ bilinear term or a $-x^2$ concave term). Re-solve. Confirm `r.convex_fast_path == False` (the solver now takes the spatial-B&B path). Compare the optima from several `initial_solution` warm-starts: how many distinct local optima do you find?"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "# TODO\n"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## Exercise 4 \u2014 DC decomposition (15 pts)\n\nThe function $f(x) = x^4 - 2 x^2$ on $[-2, 2]$ is nonconvex but DC. Find any decomposition $f = g - h$ with $g, h$ convex, and verify by plotting both."
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "# TODO: try g(x) = x^4 + something convex; h is the difference\n"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## Exercise 5 \u2014 Concave maximization is convex (10 pts)\n\nShow algebraically that if $f$ is concave, then $\\max_x f(x)$ over a convex set is *equivalent* to a convex optimization problem. Why does the field then largely talk about \"convex optimization\" without belaboring the max case?"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "**Your answer:** ..."
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/python/discopt/course/basic/07_convexity/reading.ipynb
+++ b/python/discopt/course/basic/07_convexity/reading.ipynb
@@ -1,0 +1,61 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "# Lesson 7 \u2014 Convexity\n\n## Learning objectives\n\n1. State the definitions of convex set and convex function.\n2. List operations that preserve convexity.\n3. Recognize convexity in a problem written down on paper.\n4. Understand why convexity \u2192 \"any local optimum is global\" and what that buys you computationally."
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## 1. Definitions\n\nA set $C \\subseteq \\mathbb{R}^n$ is **convex** if for every $x, y \\in C$ and $\\theta \\in [0, 1]$, $\\theta x + (1 - \\theta) y \\in C$.\n\nA function $f : \\mathbb{R}^n \\to \\mathbb{R}$ is **convex** if for every $x, y$ and $\\theta \\in [0, 1]$:\n\n$$f(\\theta x + (1 - \\theta) y) \\le \\theta f(x) + (1 - \\theta) f(y).$$\n\nStrictly convex if the inequality is strict for $x \\ne y, \\theta \\in (0, 1)$.\n\n**First- and second-order conditions** (for differentiable $f$):\n\n- $f$ convex iff $f(y) \\ge f(x) + \\nabla f(x)^\\top (y - x)$ everywhere (tangent below).\n- $f \\in C^2$ convex iff $\\nabla^2 f(x) \\succeq 0$ (Hessian PSD) everywhere.\n\nSee {cite:t}`Boyd2004` Ch. 3 and {cite:t}`Rockafellar1970`."
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## 2. Convex problem\n\nA *convex optimization problem* is\n\n$$\\min_x f_0(x) \\;\\;\\text{s.t.}\\;\\; f_i(x) \\le 0, \\; A x = b$$\n\nwith $f_0, f_i$ convex. The feasible set $\\{x : f_i(x) \\le 0, Ax = b\\}$ is then convex.\n\n**The big payoff:** any local minimum is global. There are no \"false summits\" {cite:p}`Boyd2004`.\n\nAlgorithmically: gradient descent, Newton's method, interior-point methods all converge to the global optimum from any starting point. Polynomial-time complexity (in fixed precision)."
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## 3. Operations that preserve convexity\n\nIf $f, g$ convex, then so are:\n\n- $\\alpha f$ for $\\alpha \\ge 0$\n- $f + g$\n- $\\max(f, g)$\n- $f \\circ A$ (composition with affine map)\n- $\\sup_y f(x, y)$ (pointwise supremum)\n- $-\\log f$ if $f$ is *log-concave*\n\nThis **calculus of convexity** lets you check convexity of a complex expression by inspection. It's also how *disciplined convex programming* (CVX, CVXPY) works."
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## 4. Pop quiz\n\n| Function | Convex? |\n|----------|---------|\n| $x^2$ | yes |\n| $|x|$ | yes |\n| $-\\log x$ on $x > 0$ | yes |\n| $\\log(1 + e^x)$ | yes (softplus) |\n| $\\frac{1}{x}$ on $x > 0$ | yes |\n| $\\sqrt{x}$ on $x \\ge 0$ | no \u2014 *concave* |\n| $x \\log x$ on $x > 0$ | yes |\n| $\\sin x$ | no |\n\n`discopt` runs a convexity classifier internally during `m.solve()` \u2014 a convex model takes a *fast path* that solves the NLP directly without B&B. Check `r.convex_fast_path` after solving to confirm. Trust your eye too: a sum of *one* nonconvex term ruins everything {cite:p}`Maranas1997`."
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "# Standard discopt course imports. The lessons target the real\n# `discopt.modeling.core.Model` API: `m.continuous(name, shape=..., lb=..., ub=...)`,\n# `m.binary(name, shape=...)`, `m.integer(name, shape=..., lb=..., ub=...)`,\n# `m.subject_to(...)`, `m.minimize(...) / .maximize(...)`, `m.solve(...)`.\n# Result attributes: `r.status`, `r.objective`, `r.gap`, `r.bound`,\n# `r.wall_time`, `r.node_count`, and `r.value(var)` for variable arrays.\nimport numpy as np\nimport discopt as do\nimport discopt.modeling as dm\n"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "import numpy as np, discopt as do\nfrom discopt.modeling import Model, log, exp\n\nm = Model(\"convex_demo\")\nx = m.continuous(\"x\", lb=0.01, ub=10)\ny = m.continuous(\"y\", lb=-5, ub=5)\n# This is convex (softplus is convex, (x-2)**2 is convex, sum-of-convex is convex)\nm.minimize(log(1 + exp(y)) + (x - 2)**2)\nr = m.solve()\nprint(\"status:\", r.status, \" convex fast path used:\", r.convex_fast_path)\n"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## 5. Quasi-convex, log-convex, and other generalizations\n\nSeveral weaker notions are useful:\n\n- **Quasi-convex:** sublevel sets are convex. Single-mode functions; bisection-friendly. {cite:p}`Boyd2004` Ch 3.\n- **Log-convex:** $\\log f$ is convex. Common in statistics; products are log-convex.\n- **DC (difference of convex):** $f = g - h$ with $g, h$ convex. *Many* nonconvex problems decompose this way; gives algorithmic handles {cite:p}`HorstTuy1996`.\n\n## References\n{cite:p}`Boyd2004` is the standard text. {cite:p}`Rockafellar1970` for the deep theory."
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/python/discopt/course/basic/07_convexity/rubric.md
+++ b/python/discopt/course/basic/07_convexity/rubric.md
@@ -1,0 +1,27 @@
+# Rubric — Lesson 7
+
+**Total: 100**
+
+## Exercises (70)
+- E1 (15): each function correctly classified with proof.
+- E2 (15): convex model built; `r.convex_fast_path == True` after solve; optimum reported.
+- E3 (15): one term changed to create nonconvexity; `r.convex_fast_path == False`; multiple local optima found.
+- E4 (15): valid DC decomposition; both convex pieces verified.
+- E5 (10): max of concave reformulated as min of convex (negation).
+
+## Writing (30)
+
+- **Concept coverage (10):** the response names ≥ 3 specific concepts from
+  this lesson with a one-line definition or formula each, AND references at
+  least one numerical result the student produced in the exercise notebook
+  (objective value, runtime, gap, plot point).
+- **Technical correctness (10):** every claim about complexity, an algorithm,
+  or a solver's behaviour is either a citation or a derivation; nothing
+  factually wrong per the assessor's checklist for this lesson.
+- **Citations (5):** ≥ 2 `{cite:p}` keys resolve in `docs/references.bib`,
+  at least one of which is a recommended reference for this lesson; no
+  invented or unverifiable keys.
+- **Engagement (5):** the response cites a specific surprise, equation,
+  measurement, or solver-log line the student personally observed — not a
+  generic platitude.
+

--- a/python/discopt/course/basic/07_convexity/writing.md
+++ b/python/discopt/course/basic/07_convexity/writing.md
@@ -1,0 +1,8 @@
+# Writing assignment — Lesson 7
+
+In ~500 words, explain *why convexity is the watershed* in optimization, to a
+reader who knows calculus. Address: (i) the local→global property; (ii) why
+detecting convexity is computationally important (it changes which solver you
+use); (iii) one concrete example where a nonconvex problem trapped someone
+(your own work, or a published case from {cite:p}`Floudas1999`). Cite
+{cite:p}`Boyd2004` and at least one other reference.

--- a/python/discopt/course/basic/08_unconstrained_nlp/exercises.ipynb
+++ b/python/discopt/course/basic/08_unconstrained_nlp/exercises.ipynb
@@ -1,0 +1,89 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "# Lesson 8 \u2014 Exercises"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## Exercise 1 \u2014 GD vs Newton on Rosenbrock (15 pts)\n\nImplement plain gradient descent (with constant step $10^{-3}$) and Newton's method (with line search) on the Rosenbrock function. Plot iterates; report iteration count to reach $\\|x - x^\\star\\| < 10^{-6}$."
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "# Standard discopt course imports. The lessons target the real\n# `discopt.modeling.core.Model` API: `m.continuous(name, shape=..., lb=..., ub=...)`,\n# `m.binary(name, shape=...)`, `m.integer(name, shape=..., lb=..., ub=...)`,\n# `m.subject_to(...)`, `m.minimize(...) / .maximize(...)`, `m.solve(...)`.\n# Result attributes: `r.status`, `r.objective`, `r.gap`, `r.bound`,\n# `r.wall_time`, `r.node_count`, and `r.value(var)` for variable arrays.\nimport numpy as np\nimport discopt as do\nimport discopt.modeling as dm\n"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "# TODO\n"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## Exercise 2 \u2014 Backtracking line search (15 pts)\n\nImplement Armijo backtracking ($c_1 = 10^{-4}$, $\\beta = 0.5$). Apply to GD on a poorly-conditioned quadratic (e.g., $f(x) = 0.5 x^\\top A x$ with $A = \\text{diag}(1, 100)$). Compare to fixed step. How many backtracking inner iterations per outer iteration?"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "# TODO\n"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## Exercise 3 \u2014 BFGS update by hand (15 pts)\n\nImplement BFGS in 30 lines or fewer. Run on Rosenbrock and on a 50-D quadratic. Compare to GD on iteration count. Confirm that the BFGS approximate Hessian \u2192 true Hessian as iterations \u2192 \u221e on the quadratic."
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "# TODO\n"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## Exercise 4 \u2014 Trust region warm-up (10 pts)\n\nImplement the *Cauchy point* update of trust region: at each iterate, take the step in $-\\nabla f$ direction up to the trust-region boundary $\\Delta$. Apply to Rosenbrock; show that $\\Delta$ adaptation is what gives you robustness vs pure line-search GD."
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "# TODO\n"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## Exercise 5 \u2014 Saddle point hunt (15 pts)\n\nThe function $f(x, y) = x^2 - y^2$ has a saddle at $(0, 0)$. From a random start, run (a) GD, (b) Newton, (c) BFGS. Which methods escape the saddle? Why?"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "# TODO\n"
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/python/discopt/course/basic/08_unconstrained_nlp/reading.ipynb
+++ b/python/discopt/course/basic/08_unconstrained_nlp/reading.ipynb
@@ -1,0 +1,61 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "# Lesson 8 \u2014 Unconstrained NLP\n\n## Learning objectives\n\n1. State first- and second-order optimality conditions.\n2. Walk through gradient descent, Newton's method, and quasi-Newton (BFGS).\n3. Understand line search vs trust region; appreciate why pure Newton can fail.\n4. Use `discopt`'s NLP solver and inspect convergence behaviour."
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## 1. Optimality conditions\n\nFor unconstrained $\\min_x f(x)$ with $f \\in C^2$:\n\n- **First-order:** $\\nabla f(x^\\star) = 0$ (necessary).\n- **Second-order:** $\\nabla^2 f(x^\\star) \\succeq 0$ (necessary), $\\succ 0$ sufficient for strict local min.\n\nThese are necessary, not sufficient \u2014 saddle points satisfy first-order. {cite:p}`Nocedal2006` Ch 2."
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## 2. Gradient descent\n\n$$x_{k+1} = x_k - \\alpha_k \\nabla f(x_k).$$\n\n- Cheap (just need gradients).\n- Linear convergence on strongly convex $f$ with condition number $\\kappa$: error shrinks by $(1 - 1/\\kappa)$ each step. Slow when $\\kappa$ is large.\n- Step $\\alpha_k$: line search (Armijo, Wolfe) or fixed $\\alpha = 1/L$ if you know the Lipschitz constant {cite:p}`Nocedal2006`."
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## 3. Newton's method\n\n$$x_{k+1} = x_k - [\\nabla^2 f(x_k)]^{-1} \\nabla f(x_k).$$\n\n- **Quadratic convergence** in a neighbourhood of $x^\\star$ when $\\nabla^2 f(x^\\star)$ is *positive definite* (not merely PSD) and the Hessian is locally Lipschitz {cite:p}`Nocedal2006` (Thm 3.5). Without the PD hypothesis, convergence can drop to linear \u2014 e.g., for $f(x) = x^4$ the Hessian vanishes at the optimum and Newton gives $x_{k+1} = \\frac{2}{3} x_k$.\n- Requires Hessians (and inverting them).\n- Far from optimum, can diverge \u2014 modified Newton with damping or trust region {cite:p}`Nocedal2006`.\n\n## 4. Quasi-Newton (BFGS)\n\nBuild an approximate Hessian $B_k$ from gradient differences:\n\n$$B_{k+1} = B_k - \\frac{B_k s_k s_k^\\top B_k}{s_k^\\top B_k s_k} + \\frac{y_k y_k^\\top}{y_k^\\top s_k},$$\n\nwith $s_k = x_{k+1} - x_k$, $y_k = \\nabla f(x_{k+1}) - \\nabla f(x_k)$. Superlinear convergence; no Hessian needed; the workhorse for unconstrained NLP."
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "# Standard discopt course imports. The lessons target the real\n# `discopt.modeling.core.Model` API: `m.continuous(name, shape=..., lb=..., ub=...)`,\n# `m.binary(name, shape=...)`, `m.integer(name, shape=..., lb=..., ub=...)`,\n# `m.subject_to(...)`, `m.minimize(...) / .maximize(...)`, `m.solve(...)`.\n# Result attributes: `r.status`, `r.objective`, `r.gap`, `r.bound`,\n# `r.wall_time`, `r.node_count`, and `r.value(var)` for variable arrays.\nimport numpy as np\nimport discopt as do\nimport discopt.modeling as dm\n"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "import numpy as np\n\n# Rosenbrock \u2014 non-convex but a unique global min at (1,1).\n# We compute gradients via JAX directly (which discopt itself uses internally).\nimport jax\nimport jax.numpy as jnp\n\ndef f(x): return (1 - x[0])**2 + 100 * (x[1] - x[0]**2)**2\ngrad_f = jax.grad(lambda x: f(x))\n\nx = np.array([-1.2, 1.0])\nfor k in range(50):\n    g = np.asarray(grad_f(jnp.array(x)))\n    x = x - 0.001 * g\nprint(\"after 50 GD steps: x =\", x, \"  f =\", f(x))\n# (Far from the optimum (1,1) \u2014 GD is slow on Rosenbrock.)\n"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## 5. Line search\n\nWe want $\\alpha_k$ such that $f(x_k + \\alpha_k p_k)$ decreases sufficiently. Wolfe conditions:\n\n- $f(x + \\alpha p) \\le f(x) + c_1 \\alpha \\nabla f^\\top p$ (Armijo / sufficient decrease).\n- $|\\nabla f(x + \\alpha p)^\\top p| \\le c_2 |\\nabla f^\\top p|$ (curvature).\n\nPractical choice $c_1 = 10^{-4}, c_2 = 0.9$. See {cite:p}`Nocedal2006` Ch 3."
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## 6. Trust region\n\nSolve a *local quadratic model* in a ball $\\|p\\| \\le \\Delta$:\n\n$$\\min_p \\; m_k(p) = f_k + \\nabla f_k^\\top p + \\tfrac{1}{2} p^\\top B_k p \\;\\;\\text{s.t.}\\;\\; \\|p\\| \\le \\Delta.$$\n\nAdapt $\\Delta$ based on agreement between $m_k$ and $f$. More robust than line search when Hessian has indefinite directions.\n\n## References\n{cite:p}`Nocedal2006` is the standard reference. Also {cite:p}`Wright1997`."
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/python/discopt/course/basic/08_unconstrained_nlp/rubric.md
+++ b/python/discopt/course/basic/08_unconstrained_nlp/rubric.md
@@ -1,0 +1,27 @@
+# Rubric — Lesson 8
+
+**Total: 100**
+
+## Exercises (70)
+- E1 (15): both methods implemented; iteration counts compared (Newton ≪ GD).
+- E2 (15): backtracking implemented; backtracking-iter count reported.
+- E3 (15): BFGS works; B → H_true on quadratic.
+- E4 (10): Cauchy point implemented; $\Delta$ adaptation visible.
+- E5 (15): the response correctly identifies that $f = x^2 - y^2$ has no minimum (saddle + unbounded along $\pm y$); GD diverges to $-\infty$ from a non-axis start; Newton stalls/oscillates on the indefinite Hessian; BFGS behaviour traced to its initial $B_0$.
+
+## Writing (30)
+
+- **Concept coverage (10):** the response names ≥ 3 specific concepts from
+  this lesson with a one-line definition or formula each, AND references at
+  least one numerical result the student produced in the exercise notebook
+  (objective value, runtime, gap, plot point).
+- **Technical correctness (10):** every claim about complexity, an algorithm,
+  or a solver's behaviour is either a citation or a derivation; nothing
+  factually wrong per the assessor's checklist for this lesson.
+- **Citations (5):** ≥ 2 `{cite:p}` keys resolve in `docs/references.bib`,
+  at least one of which is a recommended reference for this lesson; no
+  invented or unverifiable keys.
+- **Engagement (5):** the response cites a specific surprise, equation,
+  measurement, or solver-log line the student personally observed — not a
+  generic platitude.
+

--- a/python/discopt/course/basic/08_unconstrained_nlp/writing.md
+++ b/python/discopt/course/basic/08_unconstrained_nlp/writing.md
@@ -1,0 +1,8 @@
+# Writing assignment — Lesson 8
+
+In ~600 words, explain to a colleague who has used SciPy's `minimize` (but
+never thought about what's inside) the trade-offs between GD, Newton, and
+BFGS. Use the diagonal-quadratic example to make the convergence rates
+concrete. Address: (i) when each is preferred; (ii) why we almost never run
+*pure* Newton; (iii) how the line-search vs trust-region distinction shows up
+in practice. Cite {cite:p}`Nocedal2006`.

--- a/python/discopt/course/basic/09_constrained_nlp/exercises.ipynb
+++ b/python/discopt/course/basic/09_constrained_nlp/exercises.ipynb
@@ -1,0 +1,89 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "# Lesson 9 \u2014 Exercises"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## Exercise 1 \u2014 KKT by hand (15 pts)\n\nWrite the KKT system for $\\min x_1^2 + x_2^2$ s.t. $x_1 + x_2 \\ge 1, x_1 \\ge 0, x_2 \\ge 0$. Solve algebraically. Verify against `discopt`."
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "# Standard discopt course imports. The lessons target the real\n# `discopt.modeling.core.Model` API: `m.continuous(name, shape=..., lb=..., ub=...)`,\n# `m.binary(name, shape=...)`, `m.integer(name, shape=..., lb=..., ub=...)`,\n# `m.subject_to(...)`, `m.minimize(...) / .maximize(...)`, `m.solve(...)`.\n# Result attributes: `r.status`, `r.objective`, `r.gap`, `r.bound`,\n# `r.wall_time`, `r.node_count`, and `r.value(var)` for variable arrays.\nimport numpy as np\nimport discopt as do\nimport discopt.modeling as dm\n"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "# TODO\n"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## Exercise 2 \u2014 When KKT fails (15 pts)\n\nConstruct a problem where LICQ fails at the optimum (e.g., $\\min x_1$ s.t. $-x_1^3 + x_2 \\le 0, -x_2 \\le 0$ at the origin). Verify the failure by:\n\n1. Computing `numpy.linalg.matrix_rank` of the active-constraint Jacobian at $x^\\star = (0, 0)$. It should be **less than the number of active constraints**.\n2. Trying to solve algebraically and observing that the multipliers are *unbounded* (any $\\lambda \\ge 0$ satisfies stationarity).\n3. Running `discopt.solve()` from a feasible nearby point and reporting the solver's terminal `status` (likely `MULTIPLIER_UNBOUNDED`, `RESTORATION_FAILED`, or similar)."
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "# TODO\n"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## Exercise 3 \u2014 Walk the central path (15 pts)\n\nFor the circle problem in the reading, **build the barrier subproblem yourself** for $\\mu \\in \\{10, 1, 0.1, 0.01, 0.001\\}$:\n\n$$\\min (x-1)^2 + (y-2)^2 - \\mu \\log(1 - x^2 - y^2)$$\n\nas an *unconstrained* NLP and solve each with `cyipopt` (or `scipy.optimize.minimize`, method `trust-constr`). `discopt` does not expose the barrier parameter directly. Plot the iterates $(x_\\mu, y_\\mu)$ approaching the optimum on the unit circle as $\\mu \\to 0$."
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "# TODO\n"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## Exercise 4 \u2014 Equality constrained quadratic (15 pts)\n\nFor $\\min \\tfrac{1}{2} x^\\top Q x + c^\\top x$ s.t. $Ax = b$, derive the closed-form KKT system and solve it directly with a single linear solve. Check against `discopt`'s solver. (Use $Q = I_3$, $c = (1, 2, 3)^\\top$, $A = (1, 1, 1)$, $b = 1$.)"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "# TODO\n"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## Exercise 5 \u2014 Slater's condition (10 pts)\n\nGive an example of a convex problem where Slater's condition *fails*. Try to solve it; do you still get a finite optimum? What does this say about the necessity vs sufficiency of CQs?"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "# TODO\n"
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/python/discopt/course/basic/09_constrained_nlp/reading.ipynb
+++ b/python/discopt/course/basic/09_constrained_nlp/reading.ipynb
@@ -1,0 +1,61 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "# Lesson 9 \u2014 Constrained NLP, KKT, IPOPT\n\n## Learning objectives\n\n1. State the KKT conditions for an inequality-constrained NLP.\n2. Recognize constraint qualifications and what they buy you.\n3. Walk through the interior-point barrier method conceptually.\n4. Use `discopt`'s IPOPT wrapper {cite:p}`Wachter2006` and read its output."
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## 1. KKT conditions\n\nFor\n\n$$\\min f(x) \\;\\;\\text{s.t.}\\;\\; g_i(x) \\le 0,\\; h_j(x) = 0,$$\n\na *local* min $x^\\star$ satisfying a constraint qualification (CQ) admits multipliers $\\lambda \\ge 0, \\mu$ with:\n\n$$\n\\begin{aligned}\n\\nabla f + \\sum_i \\lambda_i \\nabla g_i + \\sum_j \\mu_j \\nabla h_j &= 0 & \\text{(stationarity)} \\\\\ng_i(x^\\star) \\le 0,\\; h_j(x^\\star) = 0 & & \\text{(primal feasibility)} \\\\\n\\lambda_i \\ge 0 & & \\text{(dual feasibility)} \\\\\n\\lambda_i g_i(x^\\star) = 0 & & \\text{(complementary slackness)}\n\\end{aligned}\n$$\n\nFor convex problems, KKT is *sufficient* \u2014 any KKT point is a global optimum {cite:p}`Boyd2004`."
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## 2. Constraint qualifications\n\nCQs ensure KKT is necessary. Common ones:\n\n- **LICQ:** active constraint gradients are linearly independent.\n- **MFCQ:** there exists a direction strictly improving every active inequality.\n- **Slater's condition** (convex): there's a strictly feasible point.\n\nWithout a CQ, the multipliers may not exist (or may be unbounded) at $x^\\star$ {cite:p}`Nocedal2006`.\n\n## 3. Interior-point methods (IPM)\n\nReformulate inequalities with a logarithmic barrier:\n\n$$\\min f(x) - \\mu \\sum_i \\log(-g_i(x)) \\;\\;\\text{s.t.}\\;\\; h(x) = 0$$\n\nSolve the equality-constrained problem for decreasing $\\mu \\to 0$. Each subproblem is solved with Newton on the KKT system. This is the heart of IPOPT {cite:p}`Wachter2006`."
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## 4. The KKT linear system\n\nAt each Newton step:\n\n$$\\begin{bmatrix} W_k & A_k^\\top \\\\ A_k & 0 \\end{bmatrix} \\begin{bmatrix} \\Delta x \\\\ \\Delta \\lambda \\end{bmatrix} = -\\begin{bmatrix} \\nabla L_k \\\\ c_k \\end{bmatrix}$$\n\nwith $W_k$ the Hessian of the Lagrangian and $A_k$ the constraint Jacobian. Sparse direct solvers (MA27, MUMPS, HSL_MA86) are the bottleneck for large problems."
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "# Standard discopt course imports. The lessons target the real\n# `discopt.modeling.core.Model` API: `m.continuous(name, shape=..., lb=..., ub=...)`,\n# `m.binary(name, shape=...)`, `m.integer(name, shape=..., lb=..., ub=...)`,\n# `m.subject_to(...)`, `m.minimize(...) / .maximize(...)`, `m.solve(...)`.\n# Result attributes: `r.status`, `r.objective`, `r.gap`, `r.bound`,\n# `r.wall_time`, `r.node_count`, and `r.value(var)` for variable arrays.\nimport numpy as np\nimport discopt as do\nimport discopt.modeling as dm\n"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "import numpy as np, discopt as do\nfrom discopt.modeling import Model\n\n# Constrained NLP: min (x-1)^2 + (y-2)^2  s.t.  x^2 + y^2 <= 1.\n# Algebraically: KKT predicts x*=1/(1+lam), y*=2/(1+lam), with the\n# constraint active: 1/(1+lam)^2 + 4/(1+lam)^2 = 1  -->  lam = sqrt(5)-1.\nm = Model(\"circ\")\nx = m.continuous(\"x\", lb=-2, ub=2)\ny = m.continuous(\"y\", lb=-2, ub=2)\nm.subject_to(x**2 + y**2 <= 1)\nm.minimize((x - 1)**2 + (y - 2)**2)\nr = m.solve()\n\nprint(\"x*, y* =\", r.value(x), r.value(y))\nprint(\"f*     =\", round(r.objective, 6))\nprint(\"on the unit circle? x^2 + y^2 =\", round(r.value(x)**2 + r.value(y)**2, 6))\n\n# discopt exposes the KKT multipliers passed back by IPOPT in\n# r.constraint_duals (keyed by Constraint.name). The single inequality here\n# is named \"c0\", so:\nlam = float(r.constraint_duals[\"c0\"])\nprint(f\"discopt lambda* = {lam:.6f}   (algebraic: sqrt(5) - 1 = {np.sqrt(5) - 1:.6f})\")\n# Exercise 1 derives this same lambda by hand from the KKT system; comparing\n# the two is the cleanest way to convince yourself the numerics are right.\n"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## 5. KKT in the small example\n\nFor our problem, $\\nabla f = (2(x-1), 2(y-2))$, $\\nabla g = (2x, 2y)$, so stationarity gives\n\n$$(2(x-1), 2(y-2)) + \\lambda (2x, 2y) = 0,$$\n\ni.e., $x = 1/(1+\\lambda)$, $y = 2/(1+\\lambda)$. Combined with $x^2 + y^2 = 1$ (active): $5/(1+\\lambda)^2 = 1$, so $\\lambda = \\sqrt 5 - 1 \\approx 1.236$. Verify against the solver's multiplier."
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## 6. Why the barrier works\n\nThe log-barrier $-\\mu \\log(-g)$ blows up at the boundary, keeping iterates strictly feasible. As $\\mu \\to 0$, the central path converges to the constrained optimum. Polynomial-time complexity (in the conic case) is the great theoretical achievement of {cite:p}`Karmarkar1984` and successors {cite:p}`Wright1997,Nocedal2006`.\n\n## References\n{cite:p}`Nocedal2006` Ch 12, 19; {cite:p}`Wachter2006` for IPOPT itself; {cite:p}`Boyd2004` for the convex case."
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/python/discopt/course/basic/09_constrained_nlp/rubric.md
+++ b/python/discopt/course/basic/09_constrained_nlp/rubric.md
@@ -1,0 +1,27 @@
+# Rubric — Lesson 9
+
+**Total: 100**
+
+## Exercises (70)
+- E1 (15): KKT system written; solution computed; matches solver.
+- E2 (15): LICQ failure exhibited via Jacobian rank deficiency *and* unbounded-multiplier observation *and* a reproducible solver-status report.
+- E3 (15): central path traced; iterates converge to optimum.
+- E4 (15): closed-form KKT linear system; matches numerical.
+- E5 (10): Slater violation; sufficiency vs necessity articulated.
+
+## Writing (30)
+
+- **Concept coverage (10):** the response names ≥ 3 specific concepts from
+  this lesson with a one-line definition or formula each, AND references at
+  least one numerical result the student produced in the exercise notebook
+  (objective value, runtime, gap, plot point).
+- **Technical correctness (10):** every claim about complexity, an algorithm,
+  or a solver's behaviour is either a citation or a derivation; nothing
+  factually wrong per the assessor's checklist for this lesson.
+- **Citations (5):** ≥ 2 `{cite:p}` keys resolve in `docs/references.bib`,
+  at least one of which is a recommended reference for this lesson; no
+  invented or unverifiable keys.
+- **Engagement (5):** the response cites a specific surprise, equation,
+  measurement, or solver-log line the student personally observed — not a
+  generic platitude.
+

--- a/python/discopt/course/basic/09_constrained_nlp/writing.md
+++ b/python/discopt/course/basic/09_constrained_nlp/writing.md
@@ -1,0 +1,8 @@
+# Writing assignment — Lesson 9
+
+In ~600 words, explain KKT to a colleague who is comfortable with multivariate
+calculus but has never seen optimization. Address: (i) why complementary
+slackness is the most non-obvious of the four conditions; (ii) what
+constraint qualifications buy you (and what fails without them, with a
+concrete example); (iii) how IPOPT {cite:p}`Wachter2006` actually finds KKT
+points. Cite {cite:p}`Nocedal2006` and {cite:p}`Wachter2006`.

--- a/python/discopt/course/basic/10_capstone_basic/exercises.ipynb
+++ b/python/discopt/course/basic/10_capstone_basic/exercises.ipynb
@@ -1,0 +1,41 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "# Lesson 10 \u2014 Capstone deliverable\n\nThis lesson does not have separate small exercises. Build your full problem in `writing_response.ipynb` (created from this template) and write up the supporting essay in `writing_response.md`."
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## Stub for your model\n\nReplace this with your full formulation, code, runs, and sensitivity analysis."
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "# Standard discopt course imports. The lessons target the real\n# `discopt.modeling.core.Model` API: `m.continuous(name, shape=..., lb=..., ub=...)`,\n# `m.binary(name, shape=...)`, `m.integer(name, shape=..., lb=..., ub=...)`,\n# `m.subject_to(...)`, `m.minimize(...) / .maximize(...)`, `m.solve(...)`.\n# Result attributes: `r.status`, `r.objective`, `r.gap`, `r.bound`,\n# `r.wall_time`, `r.node_count`, and `r.value(var)` for variable arrays.\nimport numpy as np\nimport discopt as do\nimport discopt.modeling as dm\n"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "# TODO: import discopt, build your chosen problem, solve, analyse.\nimport numpy as np\nimport discopt as do\n"
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/python/discopt/course/basic/10_capstone_basic/reading.ipynb
+++ b/python/discopt/course/basic/10_capstone_basic/reading.ipynb
@@ -1,0 +1,39 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "# Lesson 10 \u2014 Capstone (Basic)\n\nYou're going to formulate, solve, and analyse a real optimization problem.\nThis integrates Lessons 1\u20139.\n\n## Choose ONE of three problems\n\nThe basic capstone should stick to **MILP or convex NLP** material. (Bilinear\nrefinery blending and cardinality-constrained portfolios appear in Lessons\n21 and 17 respectively \u2014 pick those for the intermediate / advanced\ncapstones.)\n\n### A) Hospital nurse scheduling (MILP) \u2014 *recommended default*\n\n12 nurses, 21 shifts (3 shifts/day \u00d7 7 days). Each shift requires \u2265 3 nurses.\nEach nurse can work at most 5 of 7 days, has a max of 40 hours/week, and may\nnot work two consecutive overnight shifts. Minimize weighted overtime cost.\nBuild a synthetic dataset (nurse skill levels, preferences) and report:\n\n- the number of variables and constraints;\n- the LP relaxation value;\n- the MILP optimum, and the integrality gap;\n- a discussion of one symmetry you can break.\n\n### B) Single-period inventory / production planning (LP)\n\nA factory makes 4 products from 3 shared resources with bounded supply.\nDemand is known. Maximize profit. Then add a fixed cost for activating\neach product line (MILP version). Compare LP and MILP answers and explain\nthe gap.\n\n### C) Markowitz portfolio (convex QP)\n\nMean-variance {cite:p}`Markowitz1952` over 20 assets, *no* cardinality\n(cardinality is intermediate-track material \u2014 Lesson 17). Solve for the\n**efficient frontier** by sweeping a target return; plot risk vs return.\nCompare to a 1/n equal-weight portfolio."
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## What to deliver\n\nA single Jupyter notebook (`writing_response.ipynb`) and a short writeup\n(`writing_response.md`) that includes:\n\n1. Mathematical formulation in standard form (variables, objective, constraints).\n2. The `discopt` model code, fully runnable.\n3. Solver run with logs.\n4. **Sensitivity analysis:** pick one parameter, perturb it, plot.\n5. A reflection on what was hard, what surprised you, and what you'd do\n   differently next time.\n\n## Scope guidance\n\nAim for **8\u201312 hours of work**. Don't pick the nurse-scheduling problem if\nyou're new to scheduling \u2014 pick whichever maps closest to your domain."
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## References\n\nYou may need any of: {cite:p}`Williams2013` (modeling), {cite:p}`Wolsey1998`\n(IP), {cite:p}`Boyd2004` (convex), {cite:p}`Markowitz1952` (portfolio),\n{cite:p}`Smith1999` (refinery)."
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "# Standard discopt course imports. The lessons target the real\n# `discopt.modeling.core.Model` API: `m.continuous(name, shape=..., lb=..., ub=...)`,\n# `m.binary(name, shape=...)`, `m.integer(name, shape=..., lb=..., ub=...)`,\n# `m.subject_to(...)`, `m.minimize(...) / .maximize(...)`, `m.solve(...)`.\n# Result attributes: `r.status`, `r.objective`, `r.gap`, `r.bound`,\n# `r.wall_time`, `r.node_count`, and `r.value(var)` for variable arrays.\nimport numpy as np\nimport discopt as do\nimport discopt.modeling as dm\n"
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/python/discopt/course/basic/10_capstone_basic/rubric.md
+++ b/python/discopt/course/basic/10_capstone_basic/rubric.md
@@ -1,0 +1,25 @@
+# Rubric — Lesson 10 (Capstone)
+
+**Total: 100**
+
+## Computational deliverable (60 pts)
+
+- (10) Problem chosen and well-scoped.
+- (15) Formulation correct: variables, objective, constraints all justified
+  and consistent with the math.
+- (10) `discopt` model implements the formulation correctly; all cells run.
+- (10) Solver invoked correctly with appropriate options (mode, tolerances).
+- (10) Sensitivity analysis: at least one parameter swept, results plotted,
+  interpreted.
+- (5) Code is reasonably clean (no copy-paste smell, named variables, comments
+  where non-obvious).
+
+## Writeup (40 pts)
+
+- (10) Problem statement clear.
+- (10) Formulation prose matches the code.
+- (10) Results discussion is quantitative (numbers, not vague claims).
+- (5) At least 4 citations resolving in `references.bib`.
+- (5) Reflection is specific.
+
+**Pass: 70.** Below 70 → resubmit with specific revision targets.

--- a/python/discopt/course/basic/10_capstone_basic/writing.md
+++ b/python/discopt/course/basic/10_capstone_basic/writing.md
@@ -1,0 +1,24 @@
+# Writing assignment — Lesson 10 (Capstone)
+
+You are writing the **capstone report** for the basic track. ~1,500–2,500
+words.
+
+Structure:
+
+1. **Problem statement** (~200 words) — domain, decision, why it's an
+   optimization problem.
+2. **Formulation** (~500 words) — math, modeling decisions, choices made
+   and rejected. Show the equations.
+3. **Computational results** (~400 words) — what you ran, sizes, runtimes,
+   solutions. Reproduce solver logs in figures or tables.
+4. **Sensitivity analysis** (~300 words) — perturb one parameter, plot,
+   interpret economically.
+5. **Reflection** (~300 words) — what was hard, what surprised you, what
+   you'd change.
+
+## Citations
+
+Cite at least four references from `docs/references.bib`. At least one
+should be the core textbook for your problem class
+({cite:p}`Williams2013,Wolsey1998,Boyd2004,Markowitz1952,Smith1999`). At
+least one should be a paper specific to your problem domain.

--- a/python/discopt/course/install_skills.sh
+++ b/python/discopt/course/install_skills.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# Install the discopt course's slash commands and assessor skill into the
+# project-level .claude/ directory.
+#
+# Usage:
+#   bash course/install_skills.sh           # install into ./.claude (project)
+#   bash course/install_skills.sh --user    # install into ~/.claude (global)
+#
+# Idempotent: safely re-runnable. Existing files are overwritten only with
+# --force.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SRC="$SCRIPT_DIR/_claude_assets"
+
+DEST=".claude"
+FORCE=0
+for arg in "$@"; do
+  case "$arg" in
+    --user)  DEST="$HOME/.claude" ;;
+    --force) FORCE=1 ;;
+    *)       echo "unknown flag: $arg"; exit 1 ;;
+  esac
+done
+
+mkdir -p "$DEST/commands/course" "$DEST/skills/course-assessor"
+
+copy() {
+  local src="$1" dst="$2"
+  if [[ -e "$dst" && $FORCE -eq 0 ]]; then
+    echo "  skip (exists): $dst"
+  else
+    cp "$src" "$dst"
+    echo "  ok           : $dst"
+  fi
+}
+
+echo "Installing course commands -> $DEST/commands/course/"
+for f in "$SRC"/commands/course/*.md; do
+  copy "$f" "$DEST/commands/course/$(basename "$f")"
+done
+
+echo "Installing course-assessor skill -> $DEST/skills/course-assessor/"
+copy "$SRC/skills/course-assessor/SKILL.md" "$DEST/skills/course-assessor/SKILL.md"
+
+echo "Done. Slash commands available: /course:lesson, /course:assess, /course:hint, /course:progress, /course:grade-writing, /course:cite-check"

--- a/python/discopt/course/intermediate/11_simplex_revealed/exercises.ipynb
+++ b/python/discopt/course/intermediate/11_simplex_revealed/exercises.ipynb
@@ -1,0 +1,89 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "# Lesson 11 \u2014 Exercises"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## Exercise 1 \u2014 Trace the pivot (15 pts)\n\nFor $\\min -3 x_1 - 2 x_2$ s.t. $x_1 + x_2 \\le 4, 2 x_1 + x_2 \\le 5, x_1 + 3 x_2 \\le 6, x \\ge 0$, list every pivot performed by the revised simplex starting from the all-slack basis. Show the basis, $\\bar c$, and ratios at each step."
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "# Standard discopt course imports. The lessons target the real\n# `discopt.modeling.core.Model` API: `m.continuous(name, shape=..., lb=..., ub=...)`,\n# `m.binary(name, shape=...)`, `m.integer(name, shape=..., lb=..., ub=...)`,\n# `m.subject_to(...)`, `m.minimize(...) / .maximize(...)`, `m.solve(...)`.\n# Result attributes: `r.status`, `r.objective`, `r.gap`, `r.bound`,\n# `r.wall_time`, `r.node_count`, and `r.value(var)` for variable arrays.\nimport numpy as np\nimport discopt as do\nimport discopt.modeling as dm\n"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "# TODO\n"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## Exercise 2 \u2014 Add Phase 1 (15 pts)\n\nExtend the `revised_simplex` from the reading to handle problems where the all-slack basis is not feasible. Use the *Big-M* or *two-phase* method; explain your choice."
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "# TODO\n"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## Exercise 3 \u2014 Klee-Minty timing (15 pts)\n\nUsing your implementation, time it on the 4D, 6D, 8D Klee-Minty cube. How many iterations does each take? Compare against `discopt`'s production simplex, which uses different pricing rules."
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "# TODO\n"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## Exercise 4 \u2014 Bland's rule (10 pts)\n\nSwap your pricing rule from Dantzig (most negative reduced cost) to Bland (smallest index with $\\bar c_j < 0$). Construct a degenerate LP where Dantzig cycles but Bland terminates. (Beale's classic example works.)"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "# TODO\n"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## Exercise 5 \u2014 LU update (15 pts)\n\nReplace the `np.linalg.solve(B, \u00b7)` calls with an LU factorization that you *update* across pivots (use `scipy.linalg.lu_factor` once at restart, then a rank-one update via product-form-of-the-inverse). Time vs the naive solve on a 1000-row LP."
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "# TODO\n"
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/python/discopt/course/intermediate/11_simplex_revealed/reading.ipynb
+++ b/python/discopt/course/intermediate/11_simplex_revealed/reading.ipynb
@@ -1,0 +1,56 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "# Lesson 11 \u2014 Simplex Revealed\n\n## Learning objectives\n\n1. Walk through one full simplex iteration (entering variable, ratio test, pivot).\n2. Understand the revised simplex method (basis inverse, factorizations).\n3. Recognize and handle degeneracy and cycling.\n4. State the worst-case (Klee-Minty) and average-case complexity."
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## 1. The dictionary view\n\nExpress each basic variable as a function of the non-basic variables:\n\n$$x_B = B^{-1} b - B^{-1} N x_N, \\quad z = c_B^\\top B^{-1} b + (c_N^\\top - c_B^\\top B^{-1} N) x_N.$$\n\nThe reduced-cost vector is $\\bar c_N = c_N - c_B^\\top B^{-1} N$. Optimality: $\\bar c_N \\ge 0$.\n\n## 2. One iteration\n\n1. **Pricing:** find $j$ with $\\bar c_j < 0$ (Dantzig: most negative; Bland: smallest index {cite:p}`Bland1977`).\n2. **Ratio test:** find $i$ minimizing $\\bar b_i / d_i$ over rows with $d_i > 0$, where $\\bar b = B^{-1} b$ is the *current* dictionary RHS and $d = B^{-1} A_j$. (If $d \\le 0$ everywhere: unbounded.)\n3. **Pivot:** swap $A_j$ into the basis, evict the row-$i$ basic variable.\n\nUpdating $B^{-1}$ explicitly is O($m^2$); modern solvers maintain LU factors and update them incrementally (Forrest-Tomlin, Bartels-Golub) {cite:p}`Bertsimas1997`."
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## 3. Revised simplex\n\nDon't compute $B^{-1}$ explicitly. Solve $B^\\top y = c_B$ for the dual; price with $\\bar c_j = c_j - A_j^\\top y$. Solve $B d = A_j$ for the column update. Two solves per iteration with a sparse LU.\n\nWhy it matters: an LP with $m = 10^5$ rows and $10\\%$-sparse columns has a basis matrix with maybe $10^6$ nonzeros \u2014 $B$ is sparse, $B^{-1}$ is not."
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## 4. Degeneracy and cycling\n\nA degenerate pivot makes zero progress. A *cycle* visits the same basis twice. Anti-cycling rules:\n\n- **Bland's rule:** entering = smallest index with $\\bar c_j < 0$; leaving = smallest index in tie. Provably finite {cite:p}`Bland1977`.\n- **Lexicographic perturbation:** treat ties using a lexicographic ordering of rows.\n\nIn practice, modern LP solvers use the **Harris two-pass ratio test** to allow slightly larger pivots and improve **numerical stability** \u2014 note this is a stability device, *not* an anti-cycling guarantee. Anti-cycling proper still rests on Bland's rule or lexicographic perturbation."
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "# Standard discopt course imports. The lessons target the real\n# `discopt.modeling.core.Model` API: `m.continuous(name, shape=..., lb=..., ub=...)`,\n# `m.binary(name, shape=...)`, `m.integer(name, shape=..., lb=..., ub=...)`,\n# `m.subject_to(...)`, `m.minimize(...) / .maximize(...)`, `m.solve(...)`.\n# Result attributes: `r.status`, `r.objective`, `r.gap`, `r.bound`,\n# `r.wall_time`, `r.node_count`, and `r.value(var)` for variable arrays.\nimport numpy as np\nimport discopt as do\nimport discopt.modeling as dm\n"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "import numpy as np\n\ndef revised_simplex(c, A, b, max_iter=200):\n    m, n = A.shape\n    # Phase 2 only: assume b >= 0, identity columns at the end gave a starting basis.\n    # (Real implementations use Phase 1; left as exercise.)\n    A = np.hstack([A, np.eye(m)])\n    c = np.concatenate([c, np.zeros(m)])\n    basis = list(range(n, n + m))\n\n    for it in range(max_iter):\n        B = A[:, basis]\n        cB = c[basis]\n        y = np.linalg.solve(B.T, cB)\n        rc = c - A.T @ y\n        nb = [j for j in range(n + m) if j not in basis]\n        rc_nb = rc[nb]\n        if np.all(rc_nb >= -1e-9): return basis, c[basis] @ np.linalg.solve(B, b)\n        j_in = nb[int(np.argmin(rc_nb))]\n        d = np.linalg.solve(B, A[:, j_in])\n        if np.all(d <= 1e-9): raise RuntimeError(\"unbounded\")\n        ratios = np.where(d > 1e-9, np.linalg.solve(B, b) / d, np.inf)\n        i_out = int(np.argmin(ratios))\n        basis[i_out] = j_in\n    raise RuntimeError(\"max iter\")\n\nc = np.array([-3, -2.0])\nA = np.array([[1, 1], [2, 1], [1, 3.0]])\nb = np.array([4, 5, 6.0])\nbasis, z = revised_simplex(c, A, b)\nprint(\"optimum (max):\", -z, \"basis:\", basis)\n"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## 5. Complexity\n\n- Worst case: exponential. Klee-Minty {cite:p}`KleeMinty1972` constructed an LP where Dantzig's rule visits all $2^n$ vertices.\n- Average case: polynomial. Borgwardt (1982) proved expected polynomial behaviour under random LP distributions; Spielman & Teng's smoothed-analysis result (2004) strengthened this further. *(See {cite:p}`Bertsimas1997` for both citations within an LP textbook context.)*\n\nIn practice: LP solvers are blazingly fast, and the choice of simplex vs IPM (Lesson 12) is more about problem structure than worst-case theory.\n\n## References\n{cite:p}`Bertsimas1997` Ch 3, {cite:p}`Dantzig1963`, {cite:p}`Bland1977`."
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/python/discopt/course/intermediate/11_simplex_revealed/rubric.md
+++ b/python/discopt/course/intermediate/11_simplex_revealed/rubric.md
@@ -1,0 +1,25 @@
+# Rubric — Lesson 11
+
+## Exercises (70)
+- E1 (15) Pivot trace correct, all bases listed.
+- E2 (15) Phase 1 implemented; works on infeasible-start problem.
+- E3 (15) KM timing reported; iteration counts $\approx 2^n - 1$.
+- E4 (10) Beale (or other) cycling instance built; Bland terminates.
+- E5 (15) LU update implemented; speedup measured.
+
+## Writing (30)
+
+- **Concept coverage (10):** the response names ≥ 3 specific concepts from
+  this lesson with a one-line definition or formula each, AND references at
+  least one numerical result the student produced in the exercise notebook
+  (objective value, runtime, gap, plot point).
+- **Technical correctness (10):** every claim about complexity, an algorithm,
+  or a solver's behaviour is either a citation or a derivation; nothing
+  factually wrong per the assessor's checklist for this lesson.
+- **Citations (5):** ≥ 2 `{cite:p}` keys resolve in `docs/references.bib`,
+  at least one of which is a recommended reference for this lesson; no
+  invented or unverifiable keys.
+- **Engagement (5):** the response cites a specific surprise, equation,
+  measurement, or solver-log line the student personally observed — not a
+  generic platitude.
+

--- a/python/discopt/course/intermediate/11_simplex_revealed/writing.md
+++ b/python/discopt/course/intermediate/11_simplex_revealed/writing.md
@@ -1,0 +1,8 @@
+# Writing assignment — Lesson 11
+
+In ~600 words, explain why the **revised** simplex method is the form
+implemented in production solvers, even though textbooks introduce the
+**tableau** simplex. Address: (i) the cost of materializing $B^{-1}$;
+(ii) why sparse LU updates beat dense pivoting; (iii) numerical
+robustness (refactorization, scaling). Cite {cite:p}`Bertsimas1997` and
+{cite:p}`Bland1977`.

--- a/python/discopt/course/intermediate/12_interior_point_methods/exercises.ipynb
+++ b/python/discopt/course/intermediate/12_interior_point_methods/exercises.ipynb
@@ -1,0 +1,89 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "# Lesson 12 \u2014 Exercises"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## Exercise 1 \u2014 One predictor-corrector step (15 pts)\n\nFor a 4-variable LP of your choice, write down the affine direction, compute $\\sigma$, and apply one full Mehrotra step. Report the duality gap before and after."
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "# Standard discopt course imports. The lessons target the real\n# `discopt.modeling.core.Model` API: `m.continuous(name, shape=..., lb=..., ub=...)`,\n# `m.binary(name, shape=...)`, `m.integer(name, shape=..., lb=..., ub=...)`,\n# `m.subject_to(...)`, `m.minimize(...) / .maximize(...)`, `m.solve(...)`.\n# Result attributes: `r.status`, `r.objective`, `r.gap`, `r.bound`,\n# `r.wall_time`, `r.node_count`, and `r.value(var)` for variable arrays.\nimport numpy as np\nimport discopt as do\nimport discopt.modeling as dm\n"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "# TODO\n"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## Exercise 2 \u2014 Bench LP (15 pts)\n\nGenerate three LPs (sparse, tall-dense, fat-dense). Solve each with `scipy.optimize.linprog(..., method='highs-ds')` (simplex) and `method='highs-ipm'` (IPM). Tabulate solve time and iteration count. Discuss which problem structure favours which method."
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "# TODO\n"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## Exercise 3 \u2014 Roll your own (15 pts)\n\nImplement a basic primal-dual IPM in ~80 lines. (Skip Mehrotra; use the affine + centring direction with constant $\\sigma = 0.1$.) Test on small LPs."
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "# TODO\n"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## Exercise 4 \u2014 Crossover (10 pts)\n\nSolve a small degenerate LP using `scipy.optimize.linprog(..., method='highs-ipm')` once with crossover enabled (default) and once with `options={'crossover': False}`. Print both $x^\\star$ vectors. How do they differ? When would you care about the basic solution?"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "# TODO\n"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## Exercise 5 \u2014 Warm start failure (15 pts)\n\nIPMs *don't* warm-start as easily as simplex. Use the toy IPM you wrote in Ex. 3: solve an LP, perturb $b$ slightly, re-solve from the previous IPM iterate, and from cold. Compare iteration counts. Repeat with simplex (via `scipy.optimize.linprog(method='highs-ds')`)."
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "# TODO\n"
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/python/discopt/course/intermediate/12_interior_point_methods/reading.ipynb
+++ b/python/discopt/course/intermediate/12_interior_point_methods/reading.ipynb
@@ -1,0 +1,61 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "# Lesson 12 \u2014 Interior-Point Methods\n\n## Learning objectives\n\n1. State the path-following IPM for LP.\n2. Walk through one Mehrotra predictor-corrector step {cite:p}`Mehrotra1992`.\n3. Compare IPM vs simplex on tall, fat, and dense LPs.\n4. Recognize crossover (turning IPM solution into a basic solution)."
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## 1. The KKT system for LP\n\nFor $\\min c^\\top x$ s.t. $Ax = b, x \\ge 0$, the KKT conditions are\n\n$$Ax = b, \\quad A^\\top y + s = c, \\quad x_i s_i = 0, \\quad x, s \\ge 0.$$\n\nReplace the complementarity $x_i s_i = 0$ with $x_i s_i = \\mu$ for a *barrier parameter* $\\mu > 0$. Solve this perturbed system, then drive $\\mu \\to 0$. The locus of solutions is the **central path** {cite:p}`Wright1997`."
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## 2. Newton step on the perturbed KKT\n\n$$\\begin{bmatrix} 0 & A^\\top & I \\\\ A & 0 & 0 \\\\ S & 0 & X \\end{bmatrix} \\begin{bmatrix} \\Delta x \\\\ \\Delta y \\\\ \\Delta s \\end{bmatrix} = \\begin{bmatrix} c - A^\\top y - s \\\\ b - Ax \\\\ \\mu e - X S e \\end{bmatrix}$$\n\nwith $X = \\text{diag}(x), S = \\text{diag}(s), e = (1, ..., 1)^\\top$. Eliminate $\\Delta s$ to get a smaller normal-equation system $A D A^\\top \\Delta y = r$ with $D = X S^{-1}$ \u2014 solve via Cholesky."
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## 3. Mehrotra's predictor-corrector\n\nA practical IPM {cite:p}`Mehrotra1992`:\n\n1. **Predictor:** solve the linear system with $\\mu = 0$ on the right-hand side (the affine-scaling direction $\\Delta^{\\text{aff}}$). Compute the maximal step $\\alpha^{\\text{aff}} \\in (0, 1]$ keeping $x, s$ positive, and the post-step duality measure $\\mu_{\\text{aff}} = (x + \\alpha^{\\text{aff}} \\Delta x^{\\text{aff}})^\\top (s + \\alpha^{\\text{aff}} \\Delta s^{\\text{aff}}) / n$.\n2. **Centering parameter:** $\\sigma = (\\mu_{\\text{aff}} / \\mu_{\\text{cur}})^3$ \u2014 the cube reflects \"if the affine step works well, centre less; if it doesn't, centre more\". The new target is $\\mu_{\\text{new}} = \\sigma \\, \\mu_{\\text{cur}}$.\n3. **Corrector:** re-solve with right-hand side $\\sigma \\mu_{\\text{cur}} e - X S e - \\Delta X^{\\text{aff}} \\Delta S^{\\text{aff}} e$, picking up second-order centring terms.\n\nThe resulting algorithm typically converges in 20\u201350 iterations regardless of problem size."
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## 4. Crossover\n\nIPM converges to an *interior* solution near the central path. To get a *basic* (vertex) solution (which simplex returns natively), run a *crossover* phase: a small simplex run starting from the IPM iterate. Many users want crossover for warm-starting subsequent solves; some don't care.\n\n`discopt`'s stable solve API does not let you toggle simplex-vs-IPM-vs-crossover from Python \u2014 the Rust backend chooses. To *measure* the trade-off in the exercises below you'll use `scipy.optimize.linprog` (which exposes `method=\"highs-ds\"` for simplex and `method=\"highs-ipm\"` for IPM), or roll your own toy IPM in pure Python."
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "# Standard discopt course imports. The lessons target the real\n# `discopt.modeling.core.Model` API: `m.continuous(name, shape=..., lb=..., ub=...)`,\n# `m.binary(name, shape=...)`, `m.integer(name, shape=..., lb=..., ub=...)`,\n# `m.subject_to(...)`, `m.minimize(...) / .maximize(...)`, `m.solve(...)`.\n# Result attributes: `r.status`, `r.objective`, `r.gap`, `r.bound`,\n# `r.wall_time`, `r.node_count`, and `r.value(var)` for variable arrays.\nimport numpy as np\nimport discopt as do\nimport discopt.modeling as dm\n"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "import numpy as np, discopt as do, time\n\n# Generate a tall, dense LP (a regime where IPM-style methods shine).\nrng = np.random.default_rng(0)\nm_, n_ = 1000, 200\nA = rng.normal(size=(m_, n_))\nb = A @ np.abs(rng.normal(size=n_)) + np.abs(rng.normal(size=m_))\nc = rng.normal(size=n_)\n\nmod = do.Model(\"tall\")\nx = mod.continuous(\"x\", shape=(n_,), lb=0)\nmod.subject_to(A @ x <= b)\nmod.minimize(c @ x)\n\nt = time.time(); r = mod.solve(); dt = time.time() - t\nprint(f\"objective = {r.objective:.6f}   wall_time = {dt:.2f}s   status = {r.status}\")\n# `discopt.solve()` does not let you choose simplex vs IPM at the public\n# API level; the Rust backend picks the appropriate path. Exercises below\n# implement a toy IPM in pure Python so you can see the iteration counts.\n"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## 5. When IPM beats simplex (and vice versa)\n\n| Structure | Winner |\n|-----------|--------|\n| Sparse, well-conditioned, \"few\" constraints active | simplex |\n| Dense, many constraints, high dim | IPM |\n| Re-solving with small perturbation | simplex (warm start) |\n| First solve, large LP | IPM |\n| Need basic solution | simplex (or IPM + crossover) |\n\nThis trade-off is the practical flip side of the polynomial-vs-exponential theory.\n\n## References\n{cite:p}`Karmarkar1984` (the breakthrough), {cite:p}`Mehrotra1992` (practical), {cite:p}`Wright1997` (textbook), {cite:p}`Khachiyan1979` (the earlier ellipsoid result)."
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/python/discopt/course/intermediate/12_interior_point_methods/rubric.md
+++ b/python/discopt/course/intermediate/12_interior_point_methods/rubric.md
@@ -1,0 +1,25 @@
+# Rubric — Lesson 12
+
+## Exercises (70)
+- E1 (15): Mehrotra step computed; gap reduced.
+- E2 (15): three structures tested; correct conclusions.
+- E3 (15): toy IPM works on small LPs.
+- E4 (10): crossover demonstrated; basic vs interior contrasted.
+- E5 (15): warm-start failure for IPM exhibited.
+
+## Writing (30)
+
+- **Concept coverage (10):** the response names ≥ 3 specific concepts from
+  this lesson with a one-line definition or formula each, AND references at
+  least one numerical result the student produced in the exercise notebook
+  (objective value, runtime, gap, plot point).
+- **Technical correctness (10):** every claim about complexity, an algorithm,
+  or a solver's behaviour is either a citation or a derivation; nothing
+  factually wrong per the assessor's checklist for this lesson.
+- **Citations (5):** ≥ 2 `{cite:p}` keys resolve in `docs/references.bib`,
+  at least one of which is a recommended reference for this lesson; no
+  invented or unverifiable keys.
+- **Engagement (5):** the response cites a specific surprise, equation,
+  measurement, or solver-log line the student personally observed — not a
+  generic platitude.
+

--- a/python/discopt/course/intermediate/12_interior_point_methods/writing.md
+++ b/python/discopt/course/intermediate/12_interior_point_methods/writing.md
@@ -1,0 +1,7 @@
+# Writing assignment — Lesson 12
+
+In ~600 words, explain when an OR practitioner should reach for IPM rather
+than simplex. Cover: (i) Karmarkar's theoretical contribution
+{cite:p}`Karmarkar1984`; (ii) why production solvers use Mehrotra
+{cite:p}`Mehrotra1992`; (iii) the role of crossover and why basic solutions
+matter. Cite {cite:p}`Wright1997`.

--- a/python/discopt/course/intermediate/13_cutting_planes/exercises.ipynb
+++ b/python/discopt/course/intermediate/13_cutting_planes/exercises.ipynb
@@ -1,0 +1,89 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "# Lesson 13 \u2014 Exercises"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## Exercise 1 \u2014 Verify a Chv\u00e1tal\u2013Gomory cut (15 pts)\n\nFor the LP $\\max x_1 + x_2$ s.t. $2 x_1 + x_2 \\le 7, x_1 + 3 x_2 \\le 9, x \\in \\mathbb{Z}^2_+$, the LP relaxation has a fractional optimum near $(2.4, 2.2)$. The provided cut\n\n$$x_1 + x_2 \\le 4$$\n\nis a Chv\u00e1tal\u2013Gomory cut for this system (derive it by adding the two original constraints with multipliers $u = (1/3, 1/3)$ to get $x_1 + (4/3) x_2 \\le 16/3$, then round LHS coefficients down and the RHS down to integers). Your job is to **verify**: (a) the cut is satisfied by every integer-feasible point in $[0, 5]^2$ that satisfies the original constraints; (b) the cut is violated by the LP optimum (LHS $\\approx 4.6 > 4$); (c) re-solve the LP with this extra constraint and report the new objective."
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "# Standard discopt course imports. The lessons target the real\n# `discopt.modeling.core.Model` API: `m.continuous(name, shape=..., lb=..., ub=...)`,\n# `m.binary(name, shape=...)`, `m.integer(name, shape=..., lb=..., ub=...)`,\n# `m.subject_to(...)`, `m.minimize(...) / .maximize(...)`, `m.solve(...)`.\n# Result attributes: `r.status`, `r.objective`, `r.gap`, `r.bound`,\n# `r.wall_time`, `r.node_count`, and `r.value(var)` for variable arrays.\nimport numpy as np\nimport discopt as do\nimport discopt.modeling as dm\n"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "# TODO\n"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## Exercise 2 \u2014 Cut a hole in the LP (15 pts)\n\nFor the same problem, plot the LP relaxation polytope and the integer points. Plot your Gomory cut on top. Visually confirm the cut separates $x_{LP}$ from the integer hull."
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "# TODO: matplotlib\n"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## Exercise 3 \u2014 MIR (15 pts)\n\nApply MIR rounding to one constraint of the multi-knapsack problem of your choice (say 5 items, 2 knapsacks). Add the MIR cut and re-solve. How many nodes does it save?"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "# TODO\n"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## Exercise 4 \u2014 Disable cuts (10 pts)\n\nSolve a hard MILP (e.g., random `n=30` knapsack with values = weights) twice \u2014 once with all cuts disabled, once with the default. Compare nodes and time. What's the speedup factor?"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "# TODO\n"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## Exercise 5 \u2014 Custom cut callback (15 pts)\n\nWrite a `discopt` cut callback that, at each node, generates a *cover cut* for any violated knapsack constraint. (A cover is a set $S$ with $\\sum_{i \\in S} w_i > W$; the cut is $\\sum_{i \\in S} x_i \\le |S| - 1$.) Apply on a hard knapsack."
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "# TODO\n"
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/python/discopt/course/intermediate/13_cutting_planes/reading.ipynb
+++ b/python/discopt/course/intermediate/13_cutting_planes/reading.ipynb
@@ -1,0 +1,56 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "# Lesson 13 \u2014 Cutting Planes\n\n## Learning objectives\n\n1. Derive a Gomory cut from a fractional simplex tableau {cite:p}`Gomory1958`.\n2. Recognize Chv\u00e1tal-Gomory, MIR, lift-and-project, and split cuts.\n3. Understand cut management in modern solvers (cut pool, separation, age).\n4. Use `discopt` cut callbacks."
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## 1. The cutting-plane idea\n\nIf the LP relaxation $z_{LP}$ is fractional, find a linear inequality $\\alpha^\\top x \\le \\beta$ that:\n\n- holds for every integer-feasible $x$ (valid),\n- is *violated* by the current LP optimum $x_{LP}$.\n\nAdd it; resolve. Repeat. Each iteration tightens the relaxation. {cite:p}`Wolsey1998,Conforti2014` are the textbook references.\n\n## 2. Gomory mixed-integer (GMI) cut\n\nTake a row of the optimal LP tableau in which the basic variable $x_i$ has fractional value, with fractional part $f_i = x_i - \\lfloor x_i \\rfloor \\in (0, 1)$. Let $f_{ij}$ be the fractional part of the row's coefficient on non-basic *integer* variable $j$, and $a_{ij}$ the row's coefficient on non-basic *continuous* variable $j$. The **Gomory mixed-integer cut** is\n\n$$\n\\sum_{\\substack{j \\in N_I \\\\ f_{ij} \\le f_i}} \\frac{f_{ij}}{f_i} x_j \\;+\\; \\sum_{\\substack{j \\in N_I \\\\ f_{ij} > f_i}} \\frac{1 - f_{ij}}{1 - f_i} x_j \\;+\\; \\sum_{\\substack{j \\in N_C \\\\ a_{ij} \\ge 0}} \\frac{a_{ij}}{f_i} x_j \\;-\\; \\sum_{\\substack{j \\in N_C \\\\ a_{ij} < 0}} \\frac{a_{ij}}{1 - f_i} x_j \\;\\ge\\; 1.\n$$\n\n(Pure-integer Gomory cuts {cite:p}`Gomory1958` are the special case with no continuous variables.) The cut separates the current $x^{LP}$ (where every non-basic variable is at zero, so the LHS is 0) from every integer-feasible point. See {cite:p}`Wolsey1998,Conforti2014,Cornuejols2008` for the derivation."
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## 3. Mixed-integer rounding (MIR)\n\nTake a valid inequality with an integer-valued LHS and a *mixed* RHS: integer variables $x_j \\in \\mathbb{Z}_+$ ($j \\in I$), continuous $y_j \\ge 0$ ($j \\in C$). Let $f_j = a_j - \\lfloor a_j \\rfloor$ and $f_b = b - \\lfloor b \\rfloor$. The MIR inequality is\n\n$$\\sum_{j \\in I} \\Big(\\lfloor a_j \\rfloor + \\frac{(f_j - f_b)^+}{1 - f_b}\\Big) x_j \\;-\\; \\sum_{\\substack{j \\in C \\\\ a_j < 0}} \\frac{a_j}{1 - f_b} y_j \\;\\le\\; \\lfloor b \\rfloor + \\frac{f_b}{1 - f_b}\\cdot 0$$\n\nwith $(z)^+ = \\max(z, 0)$. The continuous part is what distinguishes MIR from pure Chv\u00e1tal\u2013Gomory rounding (which is the integer-only special case). MIR is one of the most effective cut families in modern solvers {cite:p}`Cornuejols2008`.\n\n## 4. Lift-and-project\n\nFor 0/1 problems: form the disjunction $x_j = 0 \\vee x_j = 1$, take the convex hull of the two LP relaxations, and project onto $x$-space. Yields a polynomial-time procedure for generating cuts {cite:p}`Balas1993`."
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## 5. Cut management\n\nModern MILP solvers add hundreds of cuts per node. They:\n\n- **Pool** cuts that aren't currently violated.\n- **Age** them out if not used in N nodes.\n- Apply cuts globally (root) vs locally (single subtree).\n- Use **strong cuts** (deep, dense) sparingly and **weak cuts** (sparse, cheap) often.\n\nCut quality is measured by depth: distance from $x_{LP}$ to the cut hyperplane."
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "# Standard discopt course imports. The lessons target the real\n# `discopt.modeling.core.Model` API: `m.continuous(name, shape=..., lb=..., ub=...)`,\n# `m.binary(name, shape=...)`, `m.integer(name, shape=..., lb=..., ub=...)`,\n# `m.subject_to(...)`, `m.minimize(...) / .maximize(...)`, `m.solve(...)`.\n# Result attributes: `r.status`, `r.objective`, `r.gap`, `r.bound`,\n# `r.wall_time`, `r.node_count`, and `r.value(var)` for variable arrays.\nimport numpy as np\nimport discopt as do\nimport discopt.modeling as dm\n"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "import numpy as np, discopt as do\n\n# Toy MILP: max x1 + x2 s.t. 2x1 + x2 <= 5, x1 + 3x2 <= 6, x1,x2 in {0,1,...,5}.\n# discopt's stable solve() does not expose a cuts on/off toggle \u2014 cuts run\n# inside the solver. To *measure* their effect, build the same MILP twice:\n# once natively, once with a manually-added Chv\u00e1tal-Gomory cut, and compare\n# node counts.\ndef build(extra_cut: bool):\n    m = do.Model(\"cut_demo_cut\" if extra_cut else \"cut_demo\")\n    x = m.integer(\"x\", shape=(2,), lb=0, ub=5)\n    m.subject_to(2*x[0] + x[1] <= 5)\n    m.subject_to(x[0] + 3*x[1] <= 6)\n    if extra_cut:\n        m.subject_to(x[0] + x[1] <= 3)        # CG cut from u=(1/3,1/3)\n    m.maximize(x[0] + x[1])\n    return m\n\nfor label, ec in [(\"no manual cut\", False), (\"with CG cut\", True)]:\n    r = build(ec).solve()\n    print(f\"{label:14s}  nodes={r.node_count:3d}  z*={r.objective}\")\n"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## References\n{cite:p}`Gomory1958` (original), {cite:p}`Balas1993` (lift-and-project),\n{cite:p}`Cornuejols2008` (modern survey),\n{cite:p}`Wolsey1998,Conforti2014` (textbooks)."
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/python/discopt/course/intermediate/13_cutting_planes/rubric.md
+++ b/python/discopt/course/intermediate/13_cutting_planes/rubric.md
@@ -1,0 +1,25 @@
+# Rubric — Lesson 13
+
+## Exercises (70)
+- E1 (15): Cut verified — (a) $x_1 + x_2 \le 4$ holds at every integer point of $[0,5]^2$ that satisfies the original constraints (in particular at $(3,1)$ where $3+1=4$ ✓); (b) violated by LP optimum (LHS $\approx 4.6 > 4$); (c) re-solved LP with cut returns objective $\le 4$.
+- E2 (15) Plot shows separation visually.
+- E3 (15) MIR applied; node savings reported.
+- E4 (10) cuts vs no-cuts speedup measured.
+- E5 (15) cover cut callback works.
+
+## Writing (30)
+
+- **Concept coverage (10):** the response names ≥ 3 specific concepts from
+  this lesson with a one-line definition or formula each, AND references at
+  least one numerical result the student produced in the exercise notebook
+  (objective value, runtime, gap, plot point).
+- **Technical correctness (10):** every claim about complexity, an algorithm,
+  or a solver's behaviour is either a citation or a derivation; nothing
+  factually wrong per the assessor's checklist for this lesson.
+- **Citations (5):** ≥ 2 `{cite:p}` keys resolve in `docs/references.bib`,
+  at least one of which is a recommended reference for this lesson; no
+  invented or unverifiable keys.
+- **Engagement (5):** the response cites a specific surprise, equation,
+  measurement, or solver-log line the student personally observed — not a
+  generic platitude.
+

--- a/python/discopt/course/intermediate/13_cutting_planes/writing.md
+++ b/python/discopt/course/intermediate/13_cutting_planes/writing.md
@@ -1,0 +1,6 @@
+# Writing assignment — Lesson 13
+
+In ~600 words, give a tour of the cut zoo: Gomory, MIR, lift-and-project, and
+clique cuts. For each, state in one sentence the key idea, give the strongest
+cut family it relates to, and note one practical caveat. Cite
+{cite:p}`Gomory1958,Balas1993,Cornuejols2008`.

--- a/python/discopt/course/intermediate/14_branching_rules/exercises.ipynb
+++ b/python/discopt/course/intermediate/14_branching_rules/exercises.ipynb
@@ -1,0 +1,89 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "# Lesson 14 \u2014 Exercises"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## Exercise 1 \u2014 Implement strong branching in a toy B&B (20 pts)\n\n`discopt` does not yet expose a stable branching-callback hook. Implement your own minimal B&B in ~120 lines: at each node solve the LP relaxation with `scipy.optimize.linprog`, run **strong branching** on the top-5 most fractional candidates (each with a 50-iteration LP cap), and pick the best. Compare nodes vs most-fractional branching on a 50-item hard knapsack."
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "# Standard discopt course imports. The lessons target the real\n# `discopt.modeling.core.Model` API: `m.continuous(name, shape=..., lb=..., ub=...)`,\n# `m.binary(name, shape=...)`, `m.integer(name, shape=..., lb=..., ub=...)`,\n# `m.subject_to(...)`, `m.minimize(...) / .maximize(...)`, `m.solve(...)`.\n# Result attributes: `r.status`, `r.objective`, `r.gap`, `r.bound`,\n# `r.wall_time`, `r.node_count`, and `r.value(var)` for variable arrays.\nimport numpy as np\nimport discopt as do\nimport discopt.modeling as dm\n"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "# TODO\n"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## Exercise 2 \u2014 Pseudocost from scratch (15 pts)\n\nExtend the toy B&B from Ex. 1 with **pseudocost** branching. Track $\\Phi^+, \\Phi^-$ globally; update after each branching. Compare nodes to the most-fractional baseline."
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "# TODO\n"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## Exercise 3 \u2014 Reliability tuning (15 pts)\n\nIn the same toy B&B harness, implement **reliability branching** with a tunable threshold $K$ (number of branchings before pseudocost is 'reliable'; below $K$, fall back to strong branching for that variable). For $K \\in \\{1, 5, 25\\}$, report node counts on the same benchmark instance."
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "# TODO\n"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## Exercise 4 \u2014 When most-fractional wins (10 pts)\n\nConstruct (or find) an MILP where most-fractional branching beats strong branching. Possibly: a problem where strong branching's overhead per node dwarfs the savings."
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "# TODO\n"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## Exercise 5 \u2014 Direction matters (10 pts)\n\nUsing default branching, run two times: down-first and up-first. Does it matter for nodes? For time-to-first-incumbent? Why?"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "# TODO\n"
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/python/discopt/course/intermediate/14_branching_rules/reading.ipynb
+++ b/python/discopt/course/intermediate/14_branching_rules/reading.ipynb
@@ -1,0 +1,51 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "# Lesson 14 \u2014 Branching Rules\n\n## Learning objectives\n\n1. Understand pseudocost branching.\n2. Implement strong branching {cite:p}`Achterberg2005` inside a hand-rolled B&B harness.\n3. Recognize reliability branching as a hybrid.\n4. Recognize the cost-per-node vs branching-quality trade-off and articulate it from data."
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## 1. The branching problem\n\nAfter solving the LP relaxation, several variables may be fractional. *Which* one to branch on is the **branching rule**. A bad rule can blow up the tree by orders of magnitude {cite:p}`Achterberg2005`.\n\n## 2. Most fractional / Most infeasible\n\nPick the $x_j$ closest to half-integer. Cheap, but a poor predictor of *useful* branches.\n\n## 3. Pseudocost branching\n\nFor each variable $x_j$, track historical *per-unit* changes in LP value when branched up ($\\Phi_j^+$) and down ($\\Phi_j^-$). Up-branching pushes $x_j$ from its LP value $x_j^{LP}$ to $\\lceil x_j^{LP} \\rceil$, a step of $1 - f_j$ where $f_j = x_j^{LP} - \\lfloor x_j^{LP} \\rfloor$; down-branching takes a step of $f_j$. The expected LP-value gains are therefore $\\Phi_j^+(1 - f_j)$ on the up child and $\\Phi_j^-\\, f_j$ on the down child. Score:\n\n$$\\text{score}(j) = \\max(\\Phi_j^+ (1 - f_j), \\epsilon) \\cdot \\max(\\Phi_j^- f_j, \\epsilon)$$\n\nPick the variable with the largest score (product, so a *bad* child is heavily penalised). Cheap; uses information from the whole tree {cite:p}`Achterberg2005`."
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## 4. Strong branching\n\nFor each candidate $x_j$, *actually solve* both child LPs (limited iterations) and record the LP value gains. Pick the $j$ with the best (e.g., product of) gains.\n\nExpensive \u2014 solving 2 LPs per candidate per node. But on hard MILPs, the branching quality more than pays for itself {cite:p}`Achterberg2005`.\n\n## 5. Reliability branching\n\nHybrid: use pseudocosts, but switch to strong branching for variables whose pseudocost is \"unreliable\" (insufficient samples). The default in modern solvers {cite:p}`Achterberg2007`."
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "# Standard discopt course imports. The lessons target the real\n# `discopt.modeling.core.Model` API: `m.continuous(name, shape=..., lb=..., ub=...)`,\n# `m.binary(name, shape=...)`, `m.integer(name, shape=..., lb=..., ub=...)`,\n# `m.subject_to(...)`, `m.minimize(...) / .maximize(...)`, `m.solve(...)`.\n# Result attributes: `r.status`, `r.objective`, `r.gap`, `r.bound`,\n# `r.wall_time`, `r.node_count`, and `r.value(var)` for variable arrays.\nimport numpy as np\nimport discopt as do\nimport discopt.modeling as dm\n"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "import numpy as np, discopt as do\n\nm = do.Model(\"br_demo\")\nn = 30\nrng = np.random.default_rng(42)\nv = rng.integers(1, 30, size=n); w = rng.integers(1, 20, size=n)\nW = int(0.4 * w.sum())\n\nx = m.binary(\"x\", shape=(n,))\nm.subject_to(w @ x <= W); m.maximize(v @ x)\n\n# discopt's stable solve() exposes branching_policy=\"fractional\" or \"gnn\".\n# Pseudocost / strong / reliability are conceptual rules from the literature;\n# the exercises ask you to implement them as callbacks.\nr = m.solve(branching_policy=\"fractional\")\nprint(f\"fractional rule  nodes={r.node_count:5d}  time={r.wall_time:.3f}s  z*={r.objective}\")\n"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## 6. Branching directions\n\nFor each branching, we choose **down first** (explore $x_j \\le \\lfloor x_j^{LP} \\rfloor$ first) or **up first**. Default is to follow the LP relaxation's *rounding*: if $x_j^{LP} = 0.7$, try up first.\n\n## 7. Plunging\n\nA heuristic: after expanding a node, dive depth-first into one child until you hit infeasibility or integrality. Tends to find incumbents fast. Most modern solvers do this opportunistically.\n\n## References\n{cite:p}`Achterberg2005,Achterberg2007` are the canonical references for modern branching."
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/python/discopt/course/intermediate/14_branching_rules/rubric.md
+++ b/python/discopt/course/intermediate/14_branching_rules/rubric.md
@@ -1,0 +1,25 @@
+# Rubric — Lesson 14
+
+## Exercises (70)
+- E1 (20) Strong branching callback works; node savings reported.
+- E2 (15) Pseudocost callback correct; beats most-fractional.
+- E3 (15) Reliability with three K values; sensible curve.
+- E4 (10) Most-fractional advantage shown; explanation references overhead.
+- E5 (10) Direction discussion connects to incumbent timing.
+
+## Writing (30)
+
+- **Concept coverage (10):** the response names ≥ 3 specific concepts from
+  this lesson with a one-line definition or formula each, AND references at
+  least one numerical result the student produced in the exercise notebook
+  (objective value, runtime, gap, plot point).
+- **Technical correctness (10):** every claim about complexity, an algorithm,
+  or a solver's behaviour is either a citation or a derivation; nothing
+  factually wrong per the assessor's checklist for this lesson.
+- **Citations (5):** ≥ 2 `{cite:p}` keys resolve in `docs/references.bib`,
+  at least one of which is a recommended reference for this lesson; no
+  invented or unverifiable keys.
+- **Engagement (5):** the response cites a specific surprise, equation,
+  measurement, or solver-log line the student personally observed — not a
+  generic platitude.
+

--- a/python/discopt/course/intermediate/14_branching_rules/writing.md
+++ b/python/discopt/course/intermediate/14_branching_rules/writing.md
@@ -1,0 +1,9 @@
+# Writing assignment — Lesson 14
+
+In ~600 words, explain why **branching rule choice** is among the most
+important — and most under-discussed by non-experts — design choices in
+modern MILP solvers. Use {cite:p}`Achterberg2005` and {cite:p}`Achterberg2007`.
+Address: (i) the trade-off between cost-per-node and branching quality;
+(ii) how reliability branching emerged as the default; (iii) what an OR
+practitioner should do if they suspect the default rule is bad on their
+problem.

--- a/python/discopt/course/intermediate/15_presolve_and_fbbt/exercises.ipynb
+++ b/python/discopt/course/intermediate/15_presolve_and_fbbt/exercises.ipynb
@@ -1,0 +1,87 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "# Lesson 15 \u2014 Exercises"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## Exercise 1 \u2014 FBBT by hand (15 pts)\n\nFor the system $x_1 + x_2 \\le 5, 2 x_1 - x_2 \\ge 1, x_1, x_2 \\in [0, 10]$, derive tightened bounds via FBBT until fixed point. Show every step."
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "**Your bounds:** $x_1 \\in [\\,?\\,]$, $x_2 \\in [\\,?\\,]$"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## Exercise 2 \u2014 Implement FBBT (20 pts)\n\nImplement an FBBT pass for linear constraints in ~50 lines. Iterate to fixed point or 50 iterations. Test on a 20-variable, 50-constraint problem; report bound improvements."
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "# Standard discopt course imports. The lessons target the real\n# `discopt.modeling.core.Model` API: `m.continuous(name, shape=..., lb=..., ub=...)`,\n# `m.binary(name, shape=...)`, `m.integer(name, shape=..., lb=..., ub=...)`,\n# `m.subject_to(...)`, `m.minimize(...) / .maximize(...)`, `m.solve(...)`.\n# Result attributes: `r.status`, `r.objective`, `r.gap`, `r.bound`,\n# `r.wall_time`, `r.node_count`, and `r.value(var)` for variable arrays.\nimport numpy as np\nimport discopt as do\nimport discopt.modeling as dm\n"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "# TODO\n"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## Exercise 3 \u2014 Probing (15 pts)\n\nFor a 10-binary, 20-constraint MILP of your choice, implement probing that tries each binary at 0 and 1 and propagates. How many fixings did you achieve? How many cliques?"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "# TODO\n"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## Exercise 4 \u2014 OBBT vs FBBT (10 pts)\n\nFor a small bilinear NLP, implement *optimization-based* bound tightening: $\\min/\\max x_k$ s.t. all constraints + linearization of nonlinear pieces. Compare bounds to FBBT. How much tighter? At what cost?"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "# TODO\n"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## Exercise 5 \u2014 Disable presolve (10 pts)\n\nSolve a hard MILP with presolve enabled and disabled. Report time and node counts. What does the relative speedup tell you about the importance of presolve?"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "# TODO\n"
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/python/discopt/course/intermediate/15_presolve_and_fbbt/reading.ipynb
+++ b/python/discopt/course/intermediate/15_presolve_and_fbbt/reading.ipynb
@@ -1,0 +1,59 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "# Lesson 15 \u2014 Presolve and FBBT\n\n## Learning objectives\n\n1. Recognize the standard presolve transformations.\n2. Implement feasibility-based bound tightening (FBBT) by hand.\n3. Understand probing and its trade-offs.\n4. Use `discopt`'s presolve flags to debug bad models."
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## 1. Why presolve matters\n\nPresolve runs *before* B&B and aims to reduce problem size, tighten bounds, and detect infeasibility. On real MILPs, presolve commonly reduces variable count 30\u201360% and constraint count 20\u201350% {cite:p}`Savelsbergh1994,Achterberg2007`. Time spent in presolve is almost always recovered.\n\n## 2. Standard transformations\n\n| Transformation | Example |\n|----------------|---------|\n| Singleton row | $x_j \\ge 5$ from a single-variable constraint \u2192 tighten bound |\n| Empty column | Variable with 0 coefficients \u2192 fix to bound that helps objective |\n| Implied bound | $x_1 + x_2 + x_3 = 1, x_i \\in [0,1]$ \u2192 already tight |\n| Coefficient strengthening | Loose big-M \u2192 tighten via implied bounds |\n| Aggregation | $x_1 = 2 x_2 + 3$ \u2192 eliminate $x_1$ |\n| Probing | Set $x_j = 0$, propagate; if infeasible, fix $x_j = 1$ |\n\nSee {cite:p}`Savelsbergh1994` and {cite:p}`Belotti2009` for the systematic catalogue."
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## 3. Feasibility-based bound tightening (FBBT)\n\nGiven a constraint $\\sum_j a_j x_j \\le b$ with $x_j \\in [\\ell_j, u_j]$, the implied bound on each $x_k$ is\n\n$$x_k \\le \\frac{b - \\sum_{j \\ne k, a_j > 0} a_j \\ell_j - \\sum_{j \\ne k, a_j < 0} a_j u_j}{a_k} \\quad \\text{(if } a_k > 0\\text{)}.$$\n\n(Mirror for $a_k < 0$ and for $\\ge$ constraints.) Apply to every variable in every constraint; iterate to a fixed point. {cite:p}`Belotti2009` formalize this for the MINLP setting."
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## 4. Probing\n\nPick a binary $x_j$. Tentatively set $x_j = 0$, run FBBT. If infeasible, fix $x_j = 1$. Repeat for $x_j = 1$. Either reduces variables or generates *implied bounds* and *cliques* ($x_j = 1 \\Rightarrow x_k = 0$). Quadratic in the number of binaries; usually limited to a budget {cite:p}`Achterberg2007`."
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "### Presolve in `discopt`\n\nThere is no standalone `m.presolve()` entry point \u2014 presolve runs *inside*\n`m.solve()`. The orchestrator (in the Rust backend, `discopt-core/src/presolve/orchestrator.rs`)\ndrives ~20 named passes (FBBT, OBBT, aggregation, implied bounds,\ncoefficient strengthening, probing, clique detection, redundancy\nelimination, scaling, symmetry, polynomial factorable elimination, ...) to\na *fixed point* under a global time/work budget. The full pass catalogue\nlives under `crates/discopt-core/src/presolve/`; see also\n`crates/discopt-core/src/presolve/ROADMAP.md` for status.\n\nThe Python-visible knobs on `m.solve()` are:\n\n| Argument | Default | What it does |\n|---|---|---|\n| `presolve=True` | on | master switch for the root-presolve pipeline |\n| `presolve_polynomial=False` | off | enables the (slower) polynomial / factorable elimination passes |\n| `presolve_reverse_ad=False` | off | reverse-AD-based bound tightening on top of FBBT |\n| `in_tree_presolve_stride=0` | off | run light presolve every `k` B&B nodes (0 = root only) |\n\nThe headline effect of presolve is visible without any flag: a smaller\n`r.node_count` and faster `r.wall_time`. Exercises 2 and 5 below let you\nbuild FBBT yourself on a single constraint and *measure* the per-instance\nspeedup of toggling `presolve=False`."
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## 5. FBBT in MINLP\n\nFor nonlinear constraints, FBBT uses **interval arithmetic** {cite:p}`Moore1966,Neumaier1990`. Given $z = x \\cdot y$ with $x \\in [a, b], y \\in [c, d]$, the implied bound is $z \\in [\\min(ac, ad, bc, bd), \\max(...)]$.\n\nThis yields tight enclosures for many problems but can be loose for high-rank monomials. **Optimization-based BT (OBBT)** instead solves a small auxiliary LP/NLP to compute each bound \u2014 much tighter, much slower."
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## 6. Effects on B&B\n\nTighter bounds \u2192 tighter LP relaxation \u2192 more pruning \u2192 smaller tree. Plus tighter bounds \u2192 tighter big-M and McCormick relaxations \u2192 tighter convex envelopes.\n\nThis is why \"pre-modelling\" (giving good initial bounds in your formulation) is usually the highest-leverage thing you can do for solver performance.\n\n## References\n{cite:p}`Savelsbergh1994` (LP/MILP), {cite:p}`Belotti2009` (MINLP), {cite:p}`Achterberg2007`."
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "# Standard discopt course imports. The lessons target the real\n# `discopt.modeling.core.Model` API: `m.continuous(name, shape=..., lb=..., ub=...)`,\n# `m.binary(name, shape=...)`, `m.integer(name, shape=..., lb=..., ub=...)`,\n# `m.subject_to(...)`, `m.minimize(...) / .maximize(...)`, `m.solve(...)`.\n# Result attributes: `r.status`, `r.objective`, `r.gap`, `r.bound`,\n# `r.wall_time`, `r.node_count`, and `r.value(var)` for variable arrays.\nimport numpy as np\nimport discopt as do\nimport discopt.modeling as dm\n"
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/python/discopt/course/intermediate/15_presolve_and_fbbt/rubric.md
+++ b/python/discopt/course/intermediate/15_presolve_and_fbbt/rubric.md
@@ -1,0 +1,25 @@
+# Rubric — Lesson 15
+
+## Exercises (70)
+- E1 (15) FBBT trace correct; final bounds match.
+- E2 (20) FBBT implemented; bounds improve on test problem.
+- E3 (15) Probing fixings + cliques reported.
+- E4 (10) OBBT bounds tighter than FBBT; trade-off discussed.
+- E5 (10) Presolve speedup measured.
+
+## Writing (30)
+
+- **Concept coverage (10):** the response names ≥ 3 specific concepts from
+  this lesson with a one-line definition or formula each, AND references at
+  least one numerical result the student produced in the exercise notebook
+  (objective value, runtime, gap, plot point).
+- **Technical correctness (10):** every claim about complexity, an algorithm,
+  or a solver's behaviour is either a citation or a derivation; nothing
+  factually wrong per the assessor's checklist for this lesson.
+- **Citations (5):** ≥ 2 `{cite:p}` keys resolve in `docs/references.bib`,
+  at least one of which is a recommended reference for this lesson; no
+  invented or unverifiable keys.
+- **Engagement (5):** the response cites a specific surprise, equation,
+  measurement, or solver-log line the student personally observed — not a
+  generic platitude.
+

--- a/python/discopt/course/intermediate/15_presolve_and_fbbt/writing.md
+++ b/python/discopt/course/intermediate/15_presolve_and_fbbt/writing.md
@@ -1,0 +1,7 @@
+# Writing assignment — Lesson 15
+
+In ~600 words, argue that *presolve is the unsung hero* of modern MILP. Pull
+example numbers from {cite:p}`Achterberg2007` or your own experiments.
+Address: (i) which transformations have the most impact in practice;
+(ii) why FBBT is essentially free; (iii) when probing pays off and when it
+doesn't. Cite {cite:p}`Savelsbergh1994` and {cite:p}`Belotti2009`.

--- a/python/discopt/course/intermediate/16_convex_relaxations/exercises.ipynb
+++ b/python/discopt/course/intermediate/16_convex_relaxations/exercises.ipynb
@@ -1,0 +1,87 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "# Lesson 16 \u2014 Exercises"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## Exercise 1 \u2014 McCormick by hand (10 pts)\n\nFor $z = x y$ with $x \\in [1, 3], y \\in [-2, 4]$, write all four McCormick inequalities. Where on the box are they tight? Where are they loose?"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "**Your answer:** ..."
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## Exercise 2 \u2014 Plot envelopes (15 pts)\n\nPlot the surface $z = x y$ over $[0, 1]^2$ and the McCormick envelope on the same axes. Visualise the gap. Now refine: split $x$ at $0.5$ and plot the two narrower envelopes \u2014 show the gap closes."
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "# Standard discopt course imports. The lessons target the real\n# `discopt.modeling.core.Model` API: `m.continuous(name, shape=..., lb=..., ub=...)`,\n# `m.binary(name, shape=...)`, `m.integer(name, shape=..., lb=..., ub=...)`,\n# `m.subject_to(...)`, `m.minimize(...) / .maximize(...)`, `m.solve(...)`.\n# Result attributes: `r.status`, `r.objective`, `r.gap`, `r.bound`,\n# `r.wall_time`, `r.node_count`, and `r.value(var)` for variable arrays.\nimport numpy as np\nimport discopt as do\nimport discopt.modeling as dm\n"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "# TODO: matplotlib 3D\n"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## Exercise 3 \u2014 Build \u03b1BB (15 pts)\n\nFor $f(x) = -x^4$ on $[-1, 1]$, compute an $\\alpha$ that makes $\\check f(x) = -x^4 - \\alpha (1 - x)(x + 1)$ convex. Plot both. What's the gap at $x = 0$?"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "# TODO\n"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## Exercise 4 \u2014 Pooling problem (20 pts)\n\nThe Haverly pooling problem (Williams 2013, ch. 12) is a small bilinear program. Solve it (i) with `mode='local'` from random starts; (ii) with `mode='global'` and `relaxation='mccormick'`; (iii) with `relaxation='rlt'`. Report objectives and times."
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "# TODO\n"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## Exercise 5 \u2014 Tightness as bounds shrink (10 pts)\n\nFor $z = x y$ on $x, y \\in [0, b]$ with $b \\in \\{0.1, 0.5, 1, 5, 10\\}$, plot the McCormick gap at $(b/2, b/2)$. How does the gap scale with $b$?"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "# TODO\n"
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/python/discopt/course/intermediate/16_convex_relaxations/reading.ipynb
+++ b/python/discopt/course/intermediate/16_convex_relaxations/reading.ipynb
@@ -1,0 +1,73 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "# Lesson 16 \u2014 Convex Relaxations\n\n## Learning objectives\n\n1. Build the McCormick envelope of a bilinear term {cite:p}`McCormick1976`.\n2. Recognize secant relaxations of univariate concave functions.\n3. State the \u03b1BB convex underestimator {cite:p}`Adjiman1998,Adjiman1998a`.\n4. Use `discopt`'s convex-relaxation infrastructure on a small NLP."
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## 1. The McCormick envelope\n\nFor a bilinear term $z = x y$ with $x \\in [\\underline x, \\overline x], y \\in [\\underline y, \\overline y]$, the **convex hull** is the four McCormick inequalities:\n\n$$\n\\begin{aligned}\nz &\\ge \\underline x \\, y + x \\, \\underline y - \\underline x \\, \\underline y \\\\\nz &\\ge \\overline x \\, y + x \\, \\overline y - \\overline x \\, \\overline y \\\\\nz &\\le \\underline x \\, y + x \\, \\overline y - \\underline x \\, \\overline y \\\\\nz &\\le \\overline x \\, y + x \\, \\underline y - \\overline x \\, \\underline y\n\\end{aligned}\n$$\n\nThese give the *tightest* convex relaxation of the graph $\\{(x, y, z) : z = xy\\}$ over the box. Bound width determines tightness \u2014 narrower boxes \u2192 tighter envelopes."
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## 2. Secant relaxation for concave $f$\n\nFor univariate concave $f$ on $[a, b]$:\n\n- Tightest **convex underestimator**: the secant $f(a) + (f(b) - f(a))(x - a)/(b - a)$.\n- Tightest **concave overestimator**: $f$ itself.\n\nFor convex $f$, swap the roles. Combined with McCormick for products, this handles **factorable** nonconvex problems {cite:p}`McCormick1976,Smith1999`. A function is *factorable* if it can be expressed as a finite composition of unary operators (exp, log, sin, $\\cdot^k$) and binary operators ($+$, $\\times$, $/$) applied to the variables; intuitively, anything you would write down by hand. Most engineering objectives and constraints are factorable; the convex-relaxation construction works **term-by-term** on the operator DAG of such a function. We revisit factorability formally in Lesson 22."
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## 3. \u03b1BB underestimator for general C\u00b2 functions\n\nFor any $f \\in C^2$ on a box, the \u03b1BB underestimator is\n\n$$\\check f(x) = f(x) - \\sum_i \\alpha_i (\\overline x_i - x_i)(x_i - \\underline x_i)$$\n\nwith $\\alpha_i$ large enough to cancel any negative curvature of $f$. Explicit choices use eigenvalue bounds on $\\nabla^2 f$ {cite:p}`Adjiman1998`. Convex by construction; tightness depends on $\\alpha$.\n\nThis is the workhorse for global optimization of general factorable NLPs {cite:p}`Adjiman1998a,Tawarmalani2005`."
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "# Standard discopt course imports. The lessons target the real\n# `discopt.modeling.core.Model` API: `m.continuous(name, shape=..., lb=..., ub=...)`,\n# `m.binary(name, shape=...)`, `m.integer(name, shape=..., lb=..., ub=...)`,\n# `m.subject_to(...)`, `m.minimize(...) / .maximize(...)`, `m.solve(...)`.\n# Result attributes: `r.status`, `r.objective`, `r.gap`, `r.bound`,\n# `r.wall_time`, `r.node_count`, and `r.value(var)` for variable arrays.\nimport numpy as np\nimport discopt as do\nimport discopt.modeling as dm\n"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "# Bilinear: min x*y  s.t.  x + y >= 1, x,y in [0, 2].\n# discopt automatically applies McCormick relaxations to bilinear terms\n# inside its spatial-B&B; you don't construct them manually.\nimport numpy as np, discopt as do\nfrom discopt.modeling import Model\n\nm = Model(\"bilinear\")\nx = m.continuous(\"x\", lb=0, ub=2)\ny = m.continuous(\"y\", lb=0, ub=2)\nz = m.continuous(\"z\", lb=-10, ub=10)              # auxiliary for the bilinear\nm.subject_to(z == x * y)\nm.subject_to(x + y >= 1)\nm.minimize(z)\n\nr = m.solve()\nprint(f\"global z = {r.objective:.4f}; status: {r.status}; convex fast path: {r.convex_fast_path}\")\n# (m.relaxation_inequalities() \u2014 i.e., the McCormick LP at the root \u2014\n#  is not a stable public method; the relaxation lives in the Rust backend.)\n"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## 4. Tightness vs branching\n\nThe McCormick relaxation is exact at the box corners; loosest at the center. To tighten: **branch on $x$ (or $y$)** to split the box, recompute envelopes on each child. Spatial B&B (Lesson 21) is exactly this iterated.\n\nThe choice of which variable to branch on is the spatial branching rule; common heuristics are *most violating* and *largest box*."
+  },
+  {
+   "cell_type": "markdown",
+   "id": "inserted-20517",
+   "metadata": {},
+   "source": "## 5. Trilinear monomials\n\nFor products of *three* variables $z = x y w$ on a box, you can build a\nMcCormick envelope by nesting: pick a pair ($x y$), introduce an\nauxiliary $u = x y$ with McCormick on $u$, then McCormick on $u w$. The\ncatch is that the choice of which pair to nest first changes the envelope\n\u2014 there are three orderings and they don't agree.\n\nThe **permutation-symmetric** trilinear envelope takes the tightest of all\nthree nested orderings; it is the strongest McCormick-like trilinear\nrelaxation that depends only on the box {cite:p}`rikun-1997,meyer-floudas-2004`.\nA full convex-hull characterization for general box domains has only\nrecently been completed {cite:p}`makhoul-speakman-2025`.\n\n`discopt` ships both: see `discopt._jax.envelopes.relax_trilinear` (fast,\nfixed-order, fallback path) and `relax_trilinear_exact`\n(permutation-symmetric). Both run under `jax.vmap` so per-term\nrelaxations stay batched on the GPU."
+  },
+  {
+   "cell_type": "markdown",
+   "id": "inserted-93758",
+   "metadata": {},
+   "source": "## 6. \u03b1BB and eigenvalue bounds in `discopt`\n\nThe \u03b1BB construction needs $\\alpha_i$ at least as large as the most\nnegative eigenvalue of $\\nabla^2 f$ over the box. `discopt` computes\n*sound* interval-eigenvalue bounds in\n`discopt._jax.convexity.eigenvalue` and uses them both for the \u03b1BB\nunderestimator and for emitting a *convexity certificate* \u2014 when the\nlower eigenvalue bound is $\\ge 0$ on the box, the solver can take the\nconvex fast path (`r.convex_fast_path == True`) and skip spatial\nbranching entirely.\n\nThis is the \"M6\" piece of the convexification roadmap. The certificate\nmachinery lives in `discopt._jax.convexity.certificate`; the \u03b1BB\narithmetic in `eigenvalue_arith.py`."
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## 7. RLT (Reformulation-Linearization Technique)\n\nA more aggressive relaxation: multiply pairs of constraints together\n(linear \u00d7 linear \u2192 bilinear, then McCormick on each). Tightens the LP\nrelaxation at the cost of a quadratic blow-up in size {cite:p}`Sherali1990`.\n\n## References\n{cite:p}`McCormick1976,Adjiman1998,Adjiman1998a,Tawarmalani2005,Sherali1990,rikun-1997,meyer-floudas-2004,makhoul-speakman-2025`."
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/python/discopt/course/intermediate/16_convex_relaxations/rubric.md
+++ b/python/discopt/course/intermediate/16_convex_relaxations/rubric.md
@@ -1,0 +1,25 @@
+# Rubric — Lesson 16
+
+## Exercises (70)
+- E1 (10) Four inequalities; tightness analysis.
+- E2 (15) 3D plots show envelope and refined envelope.
+- E3 (15) αBB computation; plot.
+- E4 (20) Pooling solved three ways; numbers reported.
+- E5 (10) Quadratic gap scaling.
+
+## Writing (30)
+
+- **Concept coverage (10):** the response names ≥ 3 specific concepts from
+  this lesson with a one-line definition or formula each, AND references at
+  least one numerical result the student produced in the exercise notebook
+  (objective value, runtime, gap, plot point).
+- **Technical correctness (10):** every claim about complexity, an algorithm,
+  or a solver's behaviour is either a citation or a derivation; nothing
+  factually wrong per the assessor's checklist for this lesson.
+- **Citations (5):** ≥ 2 `{cite:p}` keys resolve in `docs/references.bib`,
+  at least one of which is a recommended reference for this lesson; no
+  invented or unverifiable keys.
+- **Engagement (5):** the response cites a specific surprise, equation,
+  measurement, or solver-log line the student personally observed — not a
+  generic platitude.
+

--- a/python/discopt/course/intermediate/16_convex_relaxations/writing.md
+++ b/python/discopt/course/intermediate/16_convex_relaxations/writing.md
@@ -1,0 +1,7 @@
+# Writing assignment — Lesson 16
+
+In ~600 words, explain why **McCormick relaxations** {cite:p}`McCormick1976`
+are foundational to spatial B&B. Address: (i) why they're the convex hull of
+a bilinear term (not just a relaxation); (ii) how branching tightens them;
+(iii) one example where αBB is needed because the term isn't bilinear.
+Cite {cite:p}`Adjiman1998,Tawarmalani2005`.

--- a/python/discopt/course/intermediate/17_conic_optimization/exercises.ipynb
+++ b/python/discopt/course/intermediate/17_conic_optimization/exercises.ipynb
@@ -1,0 +1,87 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "# Lesson 17 \u2014 Exercises"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## Exercise 1 \u2014 Norm to SOCP (15 pts)\n\nReformulate $\\min \\|Ax - b\\|_2 + \\lambda \\|x\\|_1$ (lasso) as an SOCP. List variables, constraints, cone memberships."
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "# Standard discopt course imports. The lessons target the real\n# `discopt.modeling.core.Model` API: `m.continuous(name, shape=..., lb=..., ub=...)`,\n# `m.binary(name, shape=...)`, `m.integer(name, shape=..., lb=..., ub=...)`,\n# `m.subject_to(...)`, `m.minimize(...) / .maximize(...)`, `m.solve(...)`.\n# Result attributes: `r.status`, `r.objective`, `r.gap`, `r.bound`,\n# `r.wall_time`, `r.node_count`, and `r.value(var)` for variable arrays.\nimport numpy as np\nimport discopt as do\nimport discopt.modeling as dm\n"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "# TODO\n"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## Exercise 2 \u2014 Markowitz with cardinality (15 pts)\n\nExtend the portfolio in the reading: at most 3 assets active. This becomes a *mixed-integer SOCP* (MISOCP). Solve and compare to the unconstrained optimum."
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "# TODO\n"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## Exercise 3 \u2014 Goemans-Williamson SDP (20 pts)\n\nFor a 5-vertex weighted graph of your choice, set up the max-cut SDP relaxation and solve it (use any SDP solver \u2014 `cvxpy` is fine). Round via the GW hyperplane and compare to true max cut."
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "# TODO\n"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## Exercise 4 \u2014 LMI (10 pts)\n\nFor a $3 \\times 3$ symmetric matrix $A$ with one free parameter $\\theta$, find the range of $\\theta$ for which $A \\succeq 0$. Set up the LMI feasibility problem; solve with an SDP solver."
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "# TODO\n"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## Exercise 5 \u2014 Robust LP (10 pts)\n\nGiven $\\min c^\\top x$ s.t. $a_i^\\top x \\ge b_i$ where $a_i$ lies in an ellipsoid $a_i \\in \\{\\bar a_i + P_i u : \\|u\\| \\le 1\\}$, write the robust counterpart as an SOCP {cite:p}`BenTal1999`."
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "**Your answer:** ..."
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/python/discopt/course/intermediate/17_conic_optimization/reading.ipynb
+++ b/python/discopt/course/intermediate/17_conic_optimization/reading.ipynb
@@ -1,0 +1,61 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "# Lesson 17 \u2014 Conic Optimization\n\n## Learning objectives\n\n1. State the standard form of LP, SOCP, SDP and the chain of inclusions.\n2. Recognize problems naturally formulated as SOCP (norm constraints, robust LP, portfolio).\n3. Recognize SDP applications (LMIs, max-cut, polynomial optimization).\n4. Use `discopt`'s SOCP backend (or any external SDP solver) on a small example."
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## 1. Cones\n\nA cone $K \\subseteq \\mathbb{R}^n$ is closed under non-negative scaling. The relevant cones for optimization {cite:p}`BenTal2001,Boyd2004`:\n\n- **Linear cone** $\\mathbb{R}^n_{\\ge 0}$ \u2014 the LP cone.\n- **Lorentz cone** (second-order cone) $\\{(t, x) : t \\ge \\|x\\|_2\\}$.\n- **PSD cone** $\\mathbb{S}_+^n = \\{X = X^\\top, X \\succeq 0\\}$.\n\nA *conic program*:\n\n$$\\min c^\\top x \\;\\;\\text{s.t.}\\;\\; Ax = b, \\; x \\in K.$$\n\nLP, SOCP, SDP are conic programs over their respective cones. All three are convex; all three are polynomial-time via interior-point methods."
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## 2. SOCP\n\n$$\\min c^\\top x \\;\\;\\text{s.t.}\\;\\; \\|A_i x + b_i\\|_2 \\le c_i^\\top x + d_i, \\; i = 1, \\dots, m.$$\n\nCommon applications {cite:p}`BenTal2001`:\n\n- **Robust LP** with ellipsoidal uncertainty becomes an SOCP (Lesson 25).\n- **Markowitz portfolio**: minimize $\\|L^\\top w\\|_2$ where $\\Sigma = LL^\\top$.\n- **Truss design**, antenna design, geometric medians.\n\nQP and convex QCQP are special cases of SOCP."
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## 3. SDP\n\n$$\\min \\langle C, X \\rangle \\;\\;\\text{s.t.}\\;\\; \\langle A_i, X \\rangle = b_i, \\; X \\succeq 0.$$\n\nGeneralizes both LP (diagonal $X$) and SOCP (block structure). Applications:\n\n- **Max-cut relaxation** (Goemans-Williamson): cut value $\\le$ SDP value $\\le$ trivial UB.\n- **LMI control problems**: stability, $H_\\infty$ control.\n- **Polynomial optimization**: via sum-of-squares (Lasserre hierarchy).\n\nSDPs are polynomial-time, but constants are large; solvers (Mosek, SDPT3, SeDuMi, COSMO) are slower than LP solvers."
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "# Standard discopt course imports. The lessons target the real\n# `discopt.modeling.core.Model` API: `m.continuous(name, shape=..., lb=..., ub=...)`,\n# `m.binary(name, shape=...)`, `m.integer(name, shape=..., lb=..., ub=...)`,\n# `m.subject_to(...)`, `m.minimize(...) / .maximize(...)`, `m.solve(...)`.\n# Result attributes: `r.status`, `r.objective`, `r.gap`, `r.bound`,\n# `r.wall_time`, `r.node_count`, and `r.value(var)` for variable arrays.\nimport numpy as np\nimport discopt as do\nimport discopt.modeling as dm\n"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "import numpy as np, discopt as do\nfrom discopt.modeling import Model, sqrt\n# (For sum-of-squares write `dm.sum(x**2)` \u2014 there is no separate `sum_squares` in discopt.)\n\n# Markowitz: min sigma^2  s.t.  mu' w >= r_min, sum(w)=1, w>=0\nn = 6\nrng = np.random.default_rng(0)\nmu = 0.05 + 0.1 * rng.random(n)              # expected returns\nL  = rng.normal(scale=0.05, size=(n, n))     # covariance factor\nSigma = L @ L.T + 1e-3 * np.eye(n)\n\nm = Model(\"portfolio\")\nw = m.continuous(\"w\", shape=(n,), lb=0)\nm.subject_to(dm.sum(w) == 1)\nm.subject_to(mu @ w >= 0.08)\nm.minimize(w @ Sigma @ w)                    # convex QP / SOCP\nr = m.solve()\nprint(\"portfolio:\", r.value(w).round(3), \"  variance:\", r.objective)\n"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## 4. The conic chain\n\n$$\\text{LP} \\subset \\text{QP} \\subset \\text{SOCP} \\subset \\text{SDP}.$$\n\nChoosing the *smallest* cone that fits your problem is best \u2014 solvers exploit structure. A QP solved as an SDP is far slower than as an SOCP {cite:p}`BenTal2001`.\n\n## 5. Strong duality and slater\n\nConic strong duality requires Slater (strict feasibility). If primal-dual values disagree at infinity (Slater fails), special handling is needed."
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## References\n{cite:p}`BenTal2001,Boyd2004` are the textbooks; {cite:p}`Wright1997` for IPM theory."
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/python/discopt/course/intermediate/17_conic_optimization/rubric.md
+++ b/python/discopt/course/intermediate/17_conic_optimization/rubric.md
@@ -1,0 +1,25 @@
+# Rubric — Lesson 17
+
+## Exercises (70)
+- E1 (15) Lasso → SOCP correctly.
+- E2 (15) MISOCP solved; cardinality respected.
+- E3 (20) GW SDP set up + rounded; compared to optimum.
+- E4 (10) LMI feasibility solved.
+- E5 (10) Robust LP → SOCP.
+
+## Writing (30)
+
+- **Concept coverage (10):** the response names ≥ 3 specific concepts from
+  this lesson with a one-line definition or formula each, AND references at
+  least one numerical result the student produced in the exercise notebook
+  (objective value, runtime, gap, plot point).
+- **Technical correctness (10):** every claim about complexity, an algorithm,
+  or a solver's behaviour is either a citation or a derivation; nothing
+  factually wrong per the assessor's checklist for this lesson.
+- **Citations (5):** ≥ 2 `{cite:p}` keys resolve in `docs/references.bib`,
+  at least one of which is a recommended reference for this lesson; no
+  invented or unverifiable keys.
+- **Engagement (5):** the response cites a specific surprise, equation,
+  measurement, or solver-log line the student personally observed — not a
+  generic platitude.
+

--- a/python/discopt/course/intermediate/17_conic_optimization/writing.md
+++ b/python/discopt/course/intermediate/17_conic_optimization/writing.md
@@ -1,0 +1,8 @@
+# Writing assignment — Lesson 17
+
+In ~600 words, explain why an OR practitioner who has only seen LP should
+care about conic optimization. Use {cite:p}`BenTal2001`. Address:
+(i) the conic chain LP ⊂ QP ⊂ SOCP ⊂ SDP and what each adds; (ii) one
+problem each from your domain that fits naturally in SOCP and SDP;
+(iii) why "everything is a conic program" is true but unhelpful — solver
+specialization matters.

--- a/python/discopt/course/intermediate/18_decomposition/exercises.ipynb
+++ b/python/discopt/course/intermediate/18_decomposition/exercises.ipynb
@@ -1,0 +1,85 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "# Lesson 18 \u2014 Exercises"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## Exercise 1 \u2014 Equivalent / Benders (20 pts)\n\nFor the toy 2-stage problem in the reading, implement Benders decomposition by hand (master / subproblem / cut). Run for 10 iterations max; compare final objective to the equivalent (extensive) form."
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "# Standard discopt course imports. The lessons target the real\n# `discopt.modeling.core.Model` API: `m.continuous(name, shape=..., lb=..., ub=...)`,\n# `m.binary(name, shape=...)`, `m.integer(name, shape=..., lb=..., ub=...)`,\n# `m.subject_to(...)`, `m.minimize(...) / .maximize(...)`, `m.solve(...)`.\n# Result attributes: `r.status`, `r.objective`, `r.gap`, `r.bound`,\n# `r.wall_time`, `r.node_count`, and `r.value(var)` for variable arrays.\nimport numpy as np\nimport discopt as do\nimport discopt.modeling as dm\n"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "# TODO\n"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## Exercise 2 \u2014 Cutting stock via column generation (20 pts)\n\nImplement column generation for cutting stock: produce 100 units of length 12, 80 units of 9, 60 units of 7 from rolls of length 25. The master is an LP over patterns; the pricing problem is a knapsack. Iterate until reduced cost \u2265 0."
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "# TODO\n"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## Exercise 3 \u2014 Lagrangian for assignment (15 pts)\n\nFor a $5 \\times 5$ assignment problem (each task to exactly one machine; multiple tasks per machine OK), relax the per-task constraint via Lagrangian and run subgradient updates on $\\lambda$. Plot the Lagrangian bound across iterations vs the LP optimum."
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "# TODO\n"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## Exercise 4 \u2014 When decomposition helps (10 pts)\n\nDescribe one problem from your domain whose structure suggests Benders, one for Dantzig-Wolfe, and one for Lagrangian. Justify each choice in 2-3 sentences."
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "**Your answer:** ..."
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## Exercise 5 \u2014 Convergence of subgradients (5 pts)\n\nSubgradient methods for the Lagrangian dual converge slowly. Why? What's the trade-off vs bundle methods?"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "**Your answer:** ..."
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/python/discopt/course/intermediate/18_decomposition/reading.ipynb
+++ b/python/discopt/course/intermediate/18_decomposition/reading.ipynb
@@ -1,0 +1,61 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "# Lesson 18 \u2014 Decomposition Methods\n\n## Learning objectives\n\n1. Explain the structure that makes a problem decomposable.\n2. Implement Benders decomposition for a 2-stage stochastic LP.\n3. Recognize Dantzig-Wolfe decomposition and column generation.\n4. Recognize Lagrangian relaxation and the link to dual decomposition."
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## 1. Block-angular structure\n\nMany large LPs / MILPs have the structure\n\n$$\n\\begin{aligned}\n\\min \\quad & c^\\top x + \\sum_{s} d_s^\\top y_s \\\\\n\\text{s.t.} \\quad & A_s x + B_s y_s = b_s, \\quad s = 1, \\dots, S \\\\\n& T x = h \\quad \\text{(complicating constraint on } x\\text{ alone)}.\n\\end{aligned}\n$$\n\nIf we fix $x$, the problem decouples across $s$. Decomposition methods exploit this \u2014 solve smaller subproblems, coordinate via a *master*."
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## 2. Benders decomposition\n\nFor 2-stage stochastic LPs / mixed-integer first stage:\n\n- **Master:** $\\min c^\\top x + \\eta$ s.t. (cuts so far), $x \\in \\mathcal{X}$.\n- **Subproblem (per scenario):** given $\\hat x$, solve $\\min d_s^\\top y_s$ s.t. $B_s y_s = b_s - A_s \\hat x, y_s \\ge 0$.\n- **Cuts:** if subproblem feasible with dual $\\pi_s$, add *optimality cut* $\\eta \\ge \\pi_s^\\top (b_s - A_s x)$. If infeasible with dual ray $\\rho_s$, add *feasibility cut* $\\rho_s^\\top (b_s - A_s x) \\le 0$.\n\nIterate until master and sum-of-subproblem objectives match. {cite:t}`Benders1962` is the original; {cite:p}`Birge2011` is the modern stochastic-programming treatment."
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## 3. Dantzig-Wolfe / column generation\n\nFor block-angular *with linking constraints*, Dantzig-Wolfe expresses each block's feasible polytope as a convex combination of extreme points (a Minkowski sum). The master selects which combinations to use; subproblems generate new extreme points (columns) only when needed (pricing). {cite:p}`DantzigWolfe1960`.\n\nCutting stock and crew scheduling are textbook examples."
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## 4. Lagrangian relaxation\n\nMove the complicating *equality* constraint $Tx = h$ into the objective with multipliers $\\mu$ (free, since the constraint is an equality \u2014 we follow the convention from Lesson 9: $\\lambda$ for inequalities, $\\mu$ for equalities):\n\n$$L(\\mu) = \\min_x c^\\top x + \\mu^\\top (Tx - h).$$\n\nFor each fixed $\\mu$ this is decomposable (or simpler). The Lagrangian dual $\\max_\\mu L(\\mu)$ provides a lower bound on the primal optimum. Subgradient methods or bundle methods solve the outer maximization. (For an *inequality* complicating constraint $Tx \\le h$, use $\\lambda \\ge 0$ instead.)\n\nOften used as a *bound* inside B&B for hard MILPs (e.g., generalized assignment). {cite:p}`Wolsey1998` Ch 10."
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "# Standard discopt course imports. The lessons target the real\n# `discopt.modeling.core.Model` API: `m.continuous(name, shape=..., lb=..., ub=...)`,\n# `m.binary(name, shape=...)`, `m.integer(name, shape=..., lb=..., ub=...)`,\n# `m.subject_to(...)`, `m.minimize(...) / .maximize(...)`, `m.solve(...)`.\n# Result attributes: `r.status`, `r.objective`, `r.gap`, `r.bound`,\n# `r.wall_time`, `r.node_count`, and `r.value(var)` for variable arrays.\nimport numpy as np\nimport discopt as do\nimport discopt.modeling as dm\n"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "import numpy as np, discopt as do\nfrom discopt.modeling import Model\n\n# Toy 2-stage stochastic LP, 3 scenarios (production w/ uncertain demand)\nS = 3\ndemand = np.array([80, 100, 120])  # scenarios\nprob   = np.array([0.3, 0.4, 0.3])\n\n# First stage: x = production capacity (cost 5/unit)\n# Second stage (per scenario): y = sales (revenue 9/unit), with y <= x and y <= demand_s\ndef deterministic_eq():\n    m = Model()\n    x = m.continuous(\"x\", lb=0)\n    y = [m.continuous(f\"y{s}\", lb=0) for s in range(S)]\n    m.minimize(5 * x - sum(prob[s] * 9 * y[s] for s in range(S)))\n    for s in range(S):\n        m.subject_to(y[s] <= x); m.subject_to(y[s] <= demand[s])\n    return m.solve()\n\nprint(\"EQ form:\", deterministic_eq().objective)\n# A Benders implementation would split this into a master(x, eta) and S subproblems(y_s).\n"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## References\n{cite:p}`Benders1962,DantzigWolfe1960,Birge2011,Wolsey1998`. For a modern algorithmic perspective, {cite:p}`Achterberg2007` discusses how solvers integrate decomposition with B&B."
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/python/discopt/course/intermediate/18_decomposition/rubric.md
+++ b/python/discopt/course/intermediate/18_decomposition/rubric.md
@@ -1,0 +1,25 @@
+# Rubric — Lesson 18
+
+## Exercises (70)
+- E1 (20) Benders implemented; cut history; matches EQ.
+- E2 (20) Column generation works; converges in modest iterations.
+- E3 (15) Lagrangian + subgradient; bound vs LP value plotted.
+- E4 (10) Three sensible domain examples.
+- E5 (5) Convergence rationale articulated.
+
+## Writing (30)
+
+- **Concept coverage (10):** the response names ≥ 3 specific concepts from
+  this lesson with a one-line definition or formula each, AND references at
+  least one numerical result the student produced in the exercise notebook
+  (objective value, runtime, gap, plot point).
+- **Technical correctness (10):** every claim about complexity, an algorithm,
+  or a solver's behaviour is either a citation or a derivation; nothing
+  factually wrong per the assessor's checklist for this lesson.
+- **Citations (5):** ≥ 2 `{cite:p}` keys resolve in `docs/references.bib`,
+  at least one of which is a recommended reference for this lesson; no
+  invented or unverifiable keys.
+- **Engagement (5):** the response cites a specific surprise, equation,
+  measurement, or solver-log line the student personally observed — not a
+  generic platitude.
+

--- a/python/discopt/course/intermediate/18_decomposition/writing.md
+++ b/python/discopt/course/intermediate/18_decomposition/writing.md
@@ -1,0 +1,7 @@
+# Writing assignment — Lesson 18
+
+In ~600 words, explain to a colleague who's never decomposed a problem the
+*three big patterns*: Benders, Dantzig-Wolfe, Lagrangian. For each, give a
+one-paragraph capsule with: the problem structure it exploits, the master /
+subproblem split, and a citation.
+{cite:p}`Benders1962,DantzigWolfe1960,Birge2011,Wolsey1998`.

--- a/python/discopt/course/intermediate/19_stochastic_programming/exercises.ipynb
+++ b/python/discopt/course/intermediate/19_stochastic_programming/exercises.ipynb
@@ -1,0 +1,89 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "# Lesson 19 \u2014 Exercises"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## Exercise 1 \u2014 SAA convergence (15 pts)\n\nFor the newsvendor in the reading, solve SAA with $N \\in \\{10, 50, 200, 1000\\}$. Plot the optimal $x^\\star$ vs $N$. How quickly does it converge to the **analytical critical-fractile answer**?\n\nWith over-cost $c_o = c - s = 2 - 1 = 1$, under-cost $c_u = p - c = 5 - 2 = 3$, and $D \\sim \\text{Uniform}(50, 150)$, the optimal order is $x^\\star = F^{-1}(c_u/(c_o+c_u)) = F^{-1}(3/4)$. For uniform demand on $[50, 150]$ that is $50 + 100 \\cdot 0.75 = \\mathbf{125}$."
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "# Standard discopt course imports. The lessons target the real\n# `discopt.modeling.core.Model` API: `m.continuous(name, shape=..., lb=..., ub=...)`,\n# `m.binary(name, shape=...)`, `m.integer(name, shape=..., lb=..., ub=...)`,\n# `m.subject_to(...)`, `m.minimize(...) / .maximize(...)`, `m.solve(...)`.\n# Result attributes: `r.status`, `r.objective`, `r.gap`, `r.bound`,\n# `r.wall_time`, `r.node_count`, and `r.value(var)` for variable arrays.\nimport numpy as np\nimport discopt as do\nimport discopt.modeling as dm\n"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "# TODO\n"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## Exercise 2 \u2014 Chance-constrained portfolio (15 pts)\n\nReturns $r \\sim \\mathcal{N}(\\mu, \\Sigma)$. Find weights $w$ that minimize variance subject to $\\Pr(\\mu^\\top w \\ge 0.05) \\ge 0.95$. Use the SOCP reformulation."
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "# TODO\n"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## Exercise 3 \u2014 CVaR optimization (15 pts)\n\nFor the same portfolio, minimize $\\text{CVaR}_{0.05}$ of the loss using the Rockafellar-Uryasev LP reformulation. Compare to mean-variance."
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "# TODO\n"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## Exercise 4 \u2014 Multi-stage warm-up (15 pts)\n\nImplement a 3-stage SP with 5 scenarios per stage (tree size 125): inventory replenishment with random demand. Solve the extensive form. What's the value of perfect information?"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "# TODO\n"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## Exercise 5 \u2014 VSS / EVPI (10 pts)\n\nDefine and compute (i) the *value of stochastic solution* (VSS) and (ii) the *expected value of perfect information* (EVPI) for the newsvendor problem. {cite:p}`Birge2011`"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "# TODO\n"
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/python/discopt/course/intermediate/19_stochastic_programming/reading.ipynb
+++ b/python/discopt/course/intermediate/19_stochastic_programming/reading.ipynb
@@ -1,0 +1,56 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "# Lesson 19 \u2014 Stochastic Programming\n\n## Learning objectives\n\n1. Distinguish 2-stage from multi-stage SP.\n2. Use sample average approximation (SAA) for SP.\n3. Recognize chance constraints and CVaR.\n4. Connect to robust optimization (Lesson 25)."
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## 1. The two-stage SP\n\n$$\\min_x c^\\top x + \\mathbb{E}_\\xi[Q(x, \\xi)] \\quad \\text{s.t.} \\quad x \\in \\mathcal{X}$$\n\nwhere $Q(x, \\xi) = \\min_y \\{q^\\top y : Wy = h - Tx, y \\ge 0\\}$ is the second-stage value under realization $\\xi = (q, h, T, W)$.\n\nIf $\\xi$ has finitely many scenarios $s = 1, \\dots, S$ with probabilities $p_s$, the **extensive form** is one big LP. With many scenarios, decomposition (Benders, Lesson 18) is essential. {cite:p}`Birge2011` is the standard reference."
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## 2. Sample average approximation (SAA)\n\nFor continuous $\\xi$, sample $N$ realizations and solve the *deterministic* SP with these $N$ scenarios. As $N \\to \\infty$, the optimal value converges (SAA consistency). {cite:p}`Shapiro2009` Ch 5.\n\nIn practice: sample 100, 500, 1000 scenarios; solve; compare optimal values to gauge stability."
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## 3. Chance constraints\n\n$$\\Pr_\\xi(\\xi^\\top x \\le b) \\ge 1 - \\epsilon.$$\n\nFor Gaussian $\\xi$, equivalent to a deterministic constraint:\n\n$$\\bar \\xi^\\top x + \\Phi^{-1}(1 - \\epsilon) \\sqrt{x^\\top \\Sigma x} \\le b,$$\n\nan SOCP! For non-Gaussian, harder; SAA + integer indicators is one way. {cite:p}`Birge2011`.\n\n## 4. CVaR\n\n$$\\text{CVaR}_\\alpha(L) = \\mathbb{E}[L \\mid L \\ge \\text{VaR}_\\alpha(L)].$$\n\nFor a random loss $L(x, \\xi)$, minimizing CVaR is convex in $x$ when $L$ is convex. Replaces the non-convex VaR; widely used in risk-aware optimization."
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "# Standard discopt course imports. The lessons target the real\n# `discopt.modeling.core.Model` API: `m.continuous(name, shape=..., lb=..., ub=...)`,\n# `m.binary(name, shape=...)`, `m.integer(name, shape=..., lb=..., ub=...)`,\n# `m.subject_to(...)`, `m.minimize(...) / .maximize(...)`, `m.solve(...)`.\n# Result attributes: `r.status`, `r.objective`, `r.gap`, `r.bound`,\n# `r.wall_time`, `r.node_count`, and `r.value(var)` for variable arrays.\nimport numpy as np\nimport discopt as do\nimport discopt.modeling as dm\n"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "import numpy as np, discopt as do\n\n# Newsvendor: order x today, demand D ~ uniform(50, 150)\n# Cost: 2*x today, revenue 5*min(x, D), salvage 1*max(0, x - D)\nnp.random.seed(0)\nN = 200\nD = np.random.uniform(50, 150, size=N)\n\nm = do.Model(\"newsvendor\")\nx = m.continuous(\"x\", lb=0, ub=200)\ny = m.continuous(\"y\", shape=(N,), lb=0)             # sold\nz = m.continuous(\"z\", shape=(N,), lb=0)             # salvage\nfor s in range(N):\n    m.subject_to(y[s] <= x)\n    m.subject_to(y[s] <= D[s])\n    m.subject_to(z[s] == x - y[s])      # equality! z = unsold = salvage quantity\n# Salvage z is recovered revenue (1 per unit), NOT a cost \u2014 both 5*y and 1*z carry the same sign.\nm.minimize(2 * x - sum(5 * y[s] + 1 * z[s] for s in range(N)) / N)\nr = m.solve()\nprint(f\"order quantity: {r.value(x):.2f}, expected profit: {-r.objective:.2f}\")\n"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## 5. Multi-stage SP\n\nFor $T$ stages, decisions are recourse functions $x_t(\\xi_{1:t})$. Number of scenarios grows exponentially in $T$. Approximation strategies:\n\n- **Scenario tree** (small finite tree).\n- **SDDP** (stochastic dual dynamic programming) \u2014 Benders cuts in time {cite:p}`Birge2011`.\n\nMulti-stage SP is the bread and butter of energy and finance applications.\n\n## References\n{cite:p}`Birge2011,Shapiro2009,Wolsey1998`."
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/python/discopt/course/intermediate/19_stochastic_programming/rubric.md
+++ b/python/discopt/course/intermediate/19_stochastic_programming/rubric.md
@@ -1,0 +1,25 @@
+# Rubric — Lesson 19
+
+## Exercises (70)
+- E1 (15) SAA convergence plot; converges to $x^\star = 125$ (critical fractile $3/4$).
+- E2 (15) Chance-constrained portfolio via SOCP.
+- E3 (15) CVaR LP works; comparison done.
+- E4 (15) 3-stage tree; EV solved.
+- E5 (10) VSS, EVPI defined and computed correctly.
+
+## Writing (30)
+
+- **Concept coverage (10):** the response names ≥ 3 specific concepts from
+  this lesson with a one-line definition or formula each, AND references at
+  least one numerical result the student produced in the exercise notebook
+  (objective value, runtime, gap, plot point).
+- **Technical correctness (10):** every claim about complexity, an algorithm,
+  or a solver's behaviour is either a citation or a derivation; nothing
+  factually wrong per the assessor's checklist for this lesson.
+- **Citations (5):** ≥ 2 `{cite:p}` keys resolve in `docs/references.bib`,
+  at least one of which is a recommended reference for this lesson; no
+  invented or unverifiable keys.
+- **Engagement (5):** the response cites a specific surprise, equation,
+  measurement, or solver-log line the student personally observed — not a
+  generic platitude.
+

--- a/python/discopt/course/intermediate/19_stochastic_programming/writing.md
+++ b/python/discopt/course/intermediate/19_stochastic_programming/writing.md
@@ -1,0 +1,6 @@
+# Writing assignment — Lesson 19
+
+In ~600 words, explain why **deterministic optimization with mean values is
+often wrong** in stochastic settings — Jensen's inequality, the asymmetry
+between costs of over- and under-provisioning, etc. Use the newsvendor as a
+running example. Cite {cite:p}`Birge2011,Shapiro2009`.

--- a/python/discopt/course/intermediate/20_capstone_intermediate/exercises.ipynb
+++ b/python/discopt/course/intermediate/20_capstone_intermediate/exercises.ipynb
@@ -1,0 +1,36 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "# Capstone deliverable \u2014 single notebook with code + benchmarks."
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "# Standard discopt course imports. The lessons target the real\n# `discopt.modeling.core.Model` API: `m.continuous(name, shape=..., lb=..., ub=...)`,\n# `m.binary(name, shape=...)`, `m.integer(name, shape=..., lb=..., ub=...)`,\n# `m.subject_to(...)`, `m.minimize(...) / .maximize(...)`, `m.solve(...)`.\n# Result attributes: `r.status`, `r.objective`, `r.gap`, `r.bound`,\n# `r.wall_time`, `r.node_count`, and `r.value(var)` for variable arrays.\nimport numpy as np\nimport discopt as do\nimport discopt.modeling as dm\n"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "# TODO: implement your chosen extension; run benchmarks; tabulate.\n"
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/python/discopt/course/intermediate/20_capstone_intermediate/reading.ipynb
+++ b/python/discopt/course/intermediate/20_capstone_intermediate/reading.ipynb
@@ -1,0 +1,34 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "# Lesson 20 \u2014 Capstone (Intermediate)\n\n## Goal\n\nImplement a **piece of an optimization solver**, plug it into `discopt`, and\nbenchmark against the default. Three options:\n\n### A) A new branching rule (research-style)\n\nImplement strong branching (Lesson 14) with a custom score function \u2014 e.g.,\n*hybrid* (max $f_j (1-f_j)$ \u00d7 pseudocost). `discopt`'s stable solve API\nexposes `branching_policy=\"fractional\" | \"gnn\"`; a public callback hook is\nnot yet stable, so a real plug-in either (a) requires a fork of the Rust\nbackend, or (b) you can fall back to *post-hoc analysis*: drive the solver\nto specific node-orderings via warm starts and `time_limit`, and infer\nwhat a custom rule would do. Either route counts; document which you took.\nBenchmark against the default on \u2265 5 medium MILPs from\n`discopt_benchmarks/instances/`.\n\nDeliverables: rule code, results table (nodes, time, gap), and discussion.\n\n### B) A new cut family (research-style)\n\nImplement *zero-half cuts* (a special case of MIR, generated via parity\narguments). A stable cut-callback API is also not exposed; route (a) above\napplies. Alternatively, generate cuts *offline* and add them as constraints\non a per-instance basis, then re-solve \u2014 the speedup vs the cut-free\nformulation is the headline number. Benchmark.\n\nDeliverables: cut code, separation routine, results table.\n\n### C) A new decomposition\n\nPick one structured problem (network design, multi-commodity flow,\nstochastic LP) and implement Benders or column generation from scratch.\nCompare runtime and gap to monolithic solve."
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## What to deliver\n\n- `writing_response.ipynb` with code, plots, and result tables.\n- `writing_response.md` (~2,000 words) describing your design,\n  experiments, and conclusions.\n\n## Scope and benchmarking protocol\n\nAim for **15\u201320 hours**. Document each design decision; cite at least 5\nreferences; include 95 % bootstrap CIs on timing comparisons (see\n`discopt_benchmarks/utils/statistics.py`).\n\n**Benchmarking protocol** \u2014 apply this to every numerical comparison:\n\n- **Instances:** at least 5 instances drawn from\n  `discopt_benchmarks/instances/<problem-class>/`, where `<problem-class>` is\n  whichever subfolder matches your project (e.g., `knapsack/`,\n  `facility-location/`, `stochastic/`). All instances must come from the same\n  subfolder for like-for-like comparison.\n- **Repetitions:** 5 runs per (instance, configuration) pair with different\n  random seeds (use `--seed` if your callback uses randomness).\n- **Effect-size threshold:** \"method A beats method B\" requires a\n  Wilcoxon signed-rank test ($p < 0.05$) on per-instance log-runtime *and*\n  a median speedup of $\\ge 1.2\\times$. Anything weaker than that is\n  reported as \"no significant difference.\"\n- **Failure handling:** any instance that hits the time limit counts as the\n  time limit *plus* the optimality gap reported at termination; don't drop\n  unsolved instances from the average.\n\n## References\nPick from {cite:p}`Achterberg2005,Achterberg2007,Cornuejols2008,Benders1962,DantzigWolfe1960,Wolsey1998` based on your project."
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "# Standard discopt course imports. The lessons target the real\n# `discopt.modeling.core.Model` API: `m.continuous(name, shape=..., lb=..., ub=...)`,\n# `m.binary(name, shape=...)`, `m.integer(name, shape=..., lb=..., ub=...)`,\n# `m.subject_to(...)`, `m.minimize(...) / .maximize(...)`, `m.solve(...)`.\n# Result attributes: `r.status`, `r.objective`, `r.gap`, `r.bound`,\n# `r.wall_time`, `r.node_count`, and `r.value(var)` for variable arrays.\nimport numpy as np\nimport discopt as do\nimport discopt.modeling as dm\n"
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/python/discopt/course/intermediate/20_capstone_intermediate/rubric.md
+++ b/python/discopt/course/intermediate/20_capstone_intermediate/rubric.md
@@ -1,0 +1,16 @@
+# Rubric — Lesson 20
+
+**Total: 100**
+
+## Computational deliverable (60)
+- (15) Project well-specified; design justified.
+- (20) Implementation correct: runs end-to-end via the chosen route (fork / post-hoc / offline), no crashes.
+- (15) Benchmarks: ≥ 5 instances, timings + gaps, CIs.
+- (10) Code quality, reproducibility (seed, instance versions).
+
+## Writeup (40)
+- (10) Clear structure following the prompt.
+- (10) Honest discussion (no cherry-picking; failure cases acknowledged).
+- (10) Quantitative — numbers, not vague claims.
+- (5) ≥ 5 citations resolving in `references.bib`.
+- (5) Reflection forward-looking.

--- a/python/discopt/course/intermediate/20_capstone_intermediate/writing.md
+++ b/python/discopt/course/intermediate/20_capstone_intermediate/writing.md
@@ -1,0 +1,15 @@
+# Capstone writeup — Lesson 20
+
+~2,000 words. Structure:
+
+1. **Pick your project** (A, B, C above) and justify (~200 words).
+2. **Design** (~500 words): math, algorithm, implementation choices.
+3. **Implementation** (~300 words): which route you took to inject your
+   method (forked Rust backend, post-hoc analysis with warm starts, or
+   offline cut generation), why, and the pitfalls you hit.
+4. **Benchmarks** (~600 words): instances, settings, timings, gaps,
+   confidence intervals. At least 5 instances.
+5. **Discussion** (~400 words): when does your method help? When does it
+   hurt? What would you do next?
+
+Cite ≥ 5 references from `docs/references.bib`.

--- a/python/discopt/course/progress.template.yaml
+++ b/python/discopt/course/progress.template.yaml
@@ -1,0 +1,22 @@
+# Student progress file. Copy to course/progress.yaml on first /course:progress.
+# Claude reads/writes this file when grading lessons.
+
+student:
+  name: ""
+  started: null  # ISO date set on first lesson
+
+# Per-lesson scores. Append entries under this key as `<track>/<id>:`.
+# Example:
+#   basic/01_intro_to_optimization:
+#     exercises: 60
+#     writing: 24
+#     total: 84
+#     attempts: 1
+#     hints_used: 0
+#     last_assessed: 2026-04-26
+scores: null  # set to {} on first write; do NOT use inline {} here
+
+current_lesson: basic/01_intro_to_optimization
+
+notes: |
+  # Free-text notes the student writes (or Claude appends after a session).

--- a/python/discopt/modeling/core.py
+++ b/python/discopt/modeling/core.py
@@ -1906,27 +1906,33 @@ class Model:
                 time_limit=time_limit, gap_tolerance=gap_tolerance, **kwargs
             )
 
+        from discopt._jax.deadline import deadline_scope
         from discopt.solver import solve_model
 
         if solver is not None:
             kwargs["solver"] = solver
 
-        result = solve_model(
-            self,
-            time_limit=time_limit,
-            gap_tolerance=gap_tolerance,
-            threads=threads,
-            deterministic=deterministic,
-            partitions=partitions,
-            branching_policy=branching_policy,
-            initial_point=_x0_flat,
-            skip_convex_check=skip_convex_check,
-            nlp_bb=nlp_bb,
-            lazy_constraints=lazy_constraints,
-            incumbent_callback=incumbent_callback,
-            node_callback=node_callback,
-            **kwargs,
-        )
+        # Install a process-global wall-clock deadline that JAX-compiled
+        # while_loops (LP/QP/NLP IPM) can poll via host callback so they
+        # self-terminate within ``time_limit + ε`` instead of running to
+        # XLA convergence after Python's budget is gone (issue #80).
+        with deadline_scope(time_limit):
+            result = solve_model(
+                self,
+                time_limit=time_limit,
+                gap_tolerance=gap_tolerance,
+                threads=threads,
+                deterministic=deterministic,
+                partitions=partitions,
+                branching_policy=branching_policy,
+                initial_point=_x0_flat,
+                skip_convex_check=skip_convex_check,
+                nlp_bb=nlp_bb,
+                lazy_constraints=lazy_constraints,
+                incumbent_callback=incumbent_callback,
+                node_callback=node_callback,
+                **kwargs,
+            )
 
         # Attach model reference and auto-generate LLM explanation
         result._model = self

--- a/python/discopt/modeling/core.py
+++ b/python/discopt/modeling/core.py
@@ -883,6 +883,9 @@ class SolveResult:
     nlp_bb: bool = False
     gap_certified: bool = True
 
+    # Examiner-style validation report (populated if validate=True).
+    validation_report: Optional[object] = None
+
     # LLM explanation (populated if llm=True)
     _explanation: Optional[str] = None
     _model: Optional["Model"] = None
@@ -1804,6 +1807,7 @@ class Model:
         incumbent_callback: Optional[Callable] = None,
         node_callback: Optional[Callable] = None,
         solver: Optional[str] = None,
+        validate: bool = False,
         **kwargs,
     ) -> Union[SolveResult, Iterator["SolveUpdate"]]:
         r"""
@@ -1864,6 +1868,11 @@ class Model:
         node_callback : callable, optional
             Node callback. Called after each batch of nodes is processed.
             Should accept ``(ctx, model)`` and return ``None``.
+        validate : bool, default False
+            If True, run Examiner-style KKT validation on the returned
+            point and attach the :class:`~discopt.validation.ExaminerReport`
+            to ``result.validation_report``. Errors during validation are
+            swallowed and leave ``validation_report`` as ``None``.
         \*\*kwargs
             Additional keyword arguments passed to the solver backend.
 
@@ -1941,6 +1950,14 @@ class Model:
                 result._explanation = result._explain_with_llm()
             except Exception:
                 pass
+
+        if validate and result.x is not None:
+            try:
+                from discopt.validation.examiner import examine
+
+                result.validation_report = examine(result, self)
+            except Exception:
+                result.validation_report = None
 
         return result
 

--- a/python/discopt/solver.py
+++ b/python/discopt/solver.py
@@ -3165,9 +3165,57 @@ def _solve_nlp_bb(
         if obj_val >= _SENTINEL_THRESHOLD:
             incumbent = None
 
+    constraint_duals = None
+    bound_duals_lower = None
+    bound_duals_upper = None
+
     if incumbent is not None:
         sol_flat = np.array(sol_array)
         x_dict = _unpack_solution(model, sol_flat)
+
+        # Recover relaxation duals at the incumbent by re-solving the NLP with
+        # integer variables fixed. Best-effort — failures leave duals as None
+        # and the examiner falls back to its LSQ recovery.
+        try:
+            fix_lb = lb.copy()
+            fix_ub = ub.copy()
+            for off, sz in zip(int_offsets, int_sizes):
+                for k in range(int(sz)):
+                    val = float(round(float(sol_flat[off + k])))
+                    fix_lb[off + k] = val
+                    fix_ub[off + k] = val
+            recover_opts = dict(opts)
+            recover_opts["max_wall_time"] = max(
+                0.1, min(5.0, time_limit - (time.perf_counter() - t_start))
+            )
+            recover_opts.setdefault("print_level", 0)
+            nlp_recovered = _solve_node_nlp_ipopt(
+                evaluator, sol_flat, fix_lb, fix_ub, constraint_bounds, recover_opts
+            )
+            if nlp_recovered.status in (
+                SolveStatus.OPTIMAL,
+                SolveStatus.ITERATION_LIMIT,
+            ):
+                constraint_duals = _unpack_constraint_duals(evaluator, nlp_recovered.multipliers)
+                bound_duals_lower = _unpack_bound_duals(
+                    model, nlp_recovered.bound_multipliers_lower
+                )
+                bound_duals_upper = _unpack_bound_duals(
+                    model, nlp_recovered.bound_multipliers_upper
+                )
+                # Zero bound multipliers on integer columns: they reflect the
+                # cost of fixing the integer, not bound activity in the
+                # original model. The examiner already drops integer columns
+                # from stationarity, so zeros are safe here.
+                if bound_duals_lower is not None or bound_duals_upper is not None:
+                    for v in model._variables:
+                        if v.var_type in (VarType.BINARY, VarType.INTEGER):
+                            if bound_duals_lower is not None and v.name in bound_duals_lower:
+                                bound_duals_lower[v.name] = np.zeros_like(bound_duals_lower[v.name])
+                            if bound_duals_upper is not None and v.name in bound_duals_upper:
+                                bound_duals_upper[v.name] = np.zeros_like(bound_duals_upper[v.name])
+        except Exception as _exc:
+            logger.debug("NLP-BB dual recovery failed: %s", _exc)
 
         assert model._objective is not None
         if model._objective.sense == ObjectiveSense.MAXIMIZE:
@@ -3206,6 +3254,9 @@ def _solve_nlp_bb(
         python_time=python_time,
         nlp_bb=True,
         gap_certified=_gap_certified,
+        constraint_duals=constraint_duals,
+        bound_duals_lower=bound_duals_lower,
+        bound_duals_upper=bound_duals_upper,
     )
 
 
@@ -3747,16 +3798,259 @@ def _solve_node_nlp_ipopt(
     status_code = info["status"]
     status = _IPOPT_STATUS_MAP.get(status_code, SolveStatus.ERROR)
 
+    mult_g = info.get("mult_g")
+    mult_x_L = info.get("mult_x_L")
+    mult_x_U = info.get("mult_x_U")
+
     return NLPResult(
         status=status,
         x=np.asarray(x),
         objective=float(info["obj_val"]),
+        multipliers=np.asarray(mult_g) if mult_g is not None else None,
+        bound_multipliers_lower=np.asarray(mult_x_L) if mult_x_L is not None else None,
+        bound_multipliers_upper=np.asarray(mult_x_U) if mult_x_U is not None else None,
     )
 
 
 # ---------------------------------------------------------------------------
 # Specialized LP/QP solvers
 # ---------------------------------------------------------------------------
+
+
+def _scalar_constraint_layout(
+    model: Model,
+) -> Optional[tuple[list[str], list[tuple[str, str]]]]:
+    """Return per-row identity for the LP/QP fast paths, when all constraints
+    are scalar.
+
+    The algebraic and repr-based extractors used by ``extract_lp_data`` /
+    ``extract_qp_data`` partition rows into ``[equalities..., inequalities...]``
+    in the order constraints appear in ``model._constraints``. This helper
+    returns parallel lists ``(eq_names, ub_info)``:
+
+      - ``eq_names[i]`` is the constraint name for the ``i``-th equality row.
+      - ``ub_info[j] = (name, original_sense)`` for the ``j``-th inequality
+        row, where ``original_sense`` is ``"<="`` or ``">="`` (used to flip
+        the dual sign for ``">="`` constraints that the extractor negated).
+
+    Returns ``None`` if any constraint body is non-scalar — vector-bodied
+    constraints don't have a one-row-per-constraint mapping the LP path can
+    rely on, and the LP fast path's algebraic/repr extractors don't handle
+    them either.
+    """
+    eq_names: list[str] = []
+    ub_info: list[tuple[str, str]] = []
+    for idx, con in enumerate(model._constraints):
+        if not isinstance(con, Constraint):
+            continue
+        body_shape = getattr(con.body, "shape", ())
+        if body_shape not in ((), (1,)):
+            return None
+        name = con.name if con.name else f"c{idx}"
+        if con.sense == "==":
+            eq_names.append(name)
+        elif con.sense in ("<=", ">="):
+            ub_info.append((name, con.sense))
+        else:
+            return None
+    return eq_names, ub_info
+
+
+def _lp_qp_unpack_duals(
+    model: Model,
+    *,
+    row_dual: Optional[np.ndarray],
+    col_dual: Optional[np.ndarray],
+    n_eq: int,
+    n_ub: int,
+    n_orig: int,
+) -> tuple[
+    Optional[dict[str, np.ndarray]],
+    Optional[dict[str, np.ndarray]],
+    Optional[dict[str, np.ndarray]],
+]:
+    """Translate HiGHS row duals + reduced costs into discopt's named-dual
+    convention.
+
+    HiGHS row dual layout matches the constraint matrix the wrapper assembles:
+    ``A_ub`` rows first (multipliers ≥ 0), then ``A_eq`` rows (free).
+    ``_decompose_eq_slack_form`` emits inequalities to ``A_ub`` in declared
+    order, flipping the row sign for ``">="`` so HiGHS sees ``-body ≤ 0``;
+    we flip the multiplier back so the returned dual reflects the original
+    ``">="`` body (giving ``μ ≤ 0`` in the examiner convention).
+
+    Reduced costs are split into lower- and upper-bound multipliers using the
+    examiner's convention ``λ_lb = max(rc, 0)``, ``λ_ub = max(-rc, 0)``.
+
+    Returns ``(constraint_duals, bound_duals_lower, bound_duals_upper)``;
+    any entry may be ``None`` if the underlying solver did not return that
+    family of multipliers, or the row layout cannot be mapped (vector body,
+    extractor mismatch, etc.).
+    """
+    layout = _scalar_constraint_layout(model)
+    if layout is None:
+        return None, None, None
+    eq_names, ub_info = layout
+    if len(eq_names) != n_eq or len(ub_info) != n_ub:
+        return None, None, None
+
+    constraint_duals: Optional[dict[str, np.ndarray]] = None
+    if row_dual is not None and row_dual.size == n_ub + n_eq:
+        # HiGHS reports row duals as ∂obj/∂b. The examiner uses the Lagrangian
+        # convention μ s.t. ∇f + ∇body·μ = 0, with μ ≥ 0 for "<=" and μ ≤ 0
+        # for ">=", so we negate for "<=" and "==" rows. For ">=" the
+        # extractor already flipped the row to "-body ≤ const", which (after
+        # composing the two negations) leaves the HiGHS row_dual unflipped.
+        out: dict[str, np.ndarray] = {}
+        for j, (name, original_sense) in enumerate(ub_info):
+            rd = float(row_dual[j])
+            mu = rd if original_sense == ">=" else -rd
+            out[name] = np.asarray(mu, dtype=float).reshape(())
+        for i, name in enumerate(eq_names):
+            mu = -float(row_dual[n_ub + i])
+            out[name] = np.asarray(mu, dtype=float).reshape(())
+        constraint_duals = out
+
+    bound_duals_lower: Optional[dict[str, np.ndarray]] = None
+    bound_duals_upper: Optional[dict[str, np.ndarray]] = None
+    if col_dual is not None and col_dual.size >= n_orig:
+        rc = np.asarray(col_dual[:n_orig], dtype=float)
+        lam_lb = np.maximum(rc, 0.0)
+        lam_ub = np.maximum(-rc, 0.0)
+        lo: dict[str, np.ndarray] = {}
+        up: dict[str, np.ndarray] = {}
+        offset = 0
+        for v in model._variables:
+            sz = int(v.size)
+            chunk_lo = lam_lb[offset : offset + sz]
+            chunk_up = lam_ub[offset : offset + sz]
+            if v.shape == () or v.shape == (1,):
+                lo[v.name] = chunk_lo.reshape(v.shape) if v.shape == (1,) else chunk_lo.reshape(())
+                up[v.name] = chunk_up.reshape(v.shape) if v.shape == (1,) else chunk_up.reshape(())
+            else:
+                lo[v.name] = chunk_lo.reshape(v.shape)
+                up[v.name] = chunk_up.reshape(v.shape)
+            offset += sz
+        bound_duals_lower = lo
+        bound_duals_upper = up
+
+    return constraint_duals, bound_duals_lower, bound_duals_upper
+
+
+def _mip_recover_relaxation_duals(
+    model: Model,
+    *,
+    lp_data,
+    x_flat: np.ndarray,
+    n_orig: int,
+    A_ub: Optional[np.ndarray],
+    b_ub: Optional[np.ndarray],
+    A_eq: Optional[np.ndarray],
+    b_eq: Optional[np.ndarray],
+    time_limit: Optional[float] = None,
+    Q_orig: Optional[np.ndarray] = None,
+) -> tuple[
+    Optional[dict[str, np.ndarray]],
+    Optional[dict[str, np.ndarray]],
+    Optional[dict[str, np.ndarray]],
+]:
+    """Re-solve the relaxation with integer variables fixed at their MIP
+    incumbent so HiGHS returns row duals + reduced costs we can map back to
+    discopt's named-dual convention.
+
+    Pass ``Q_orig`` for QP-style relaxations; omit it for LP-style. Returns
+    ``(None, None, None)`` if recovery is unavailable (HiGHS missing, the
+    fix-and-resolve LP/QP itself fails, or layout mismatch).
+
+    Bound multipliers on the fixing bounds for integer columns are zeroed in
+    the returned dicts — they reflect the act of fixing, not feasibility of
+    the original integer-feasible point.
+    """
+    try:
+        if Q_orig is None:
+            from discopt.solvers.lp_highs import solve_lp as _highs_solve_lp
+        else:
+            from discopt.solvers.qp_highs import solve_qp as _highs_solve_qp
+    except ImportError:
+        return None, None, None
+
+    from discopt.solvers import SolveStatus
+
+    bounds_fixed: list[tuple[float, float]] = []
+    is_integer_col = np.zeros(n_orig, dtype=bool)
+    offset = 0
+    for v in model._variables:
+        sz = int(v.size)
+        is_int = v.var_type in (VarType.BINARY, VarType.INTEGER)
+        for k in range(sz):
+            if is_int:
+                val = float(round(float(x_flat[offset + k])))
+                bounds_fixed.append((val, val))
+                is_integer_col[offset + k] = True
+            else:
+                lb_k = float(np.asarray(lp_data.x_l[offset + k]))
+                ub_k = float(np.asarray(lp_data.x_u[offset + k]))
+                bounds_fixed.append((lb_k, ub_k))
+        offset += sz
+
+    c_orig = np.asarray(lp_data.c[:n_orig])
+
+    try:
+        relax: Any
+        if Q_orig is None:
+            relax = _highs_solve_lp(
+                c=c_orig,
+                A_ub=A_ub,
+                b_ub=b_ub,
+                A_eq=A_eq,
+                b_eq=b_eq,
+                bounds=bounds_fixed,
+                time_limit=time_limit,
+            )
+        else:
+            relax = _highs_solve_qp(
+                Q=Q_orig,
+                c=c_orig,
+                A_ub=A_ub,
+                b_ub=b_ub,
+                A_eq=A_eq,
+                b_eq=b_eq,
+                bounds=bounds_fixed,
+                integrality=None,
+                time_limit=time_limit,
+            )
+    except Exception as exc:
+        logger.debug("MIP-relaxation dual recovery failed: %s", exc)
+        return None, None, None
+
+    if relax.status != SolveStatus.OPTIMAL:
+        return None, None, None
+
+    n_eq_rows = A_eq.shape[0] if A_eq is not None else 0
+    n_ub_rows = A_ub.shape[0] if A_ub is not None else 0
+    cd, bdl, bdu = _lp_qp_unpack_duals(
+        model,
+        row_dual=relax.dual_values,
+        col_dual=relax.reduced_costs,
+        n_eq=n_eq_rows,
+        n_ub=n_ub_rows,
+        n_orig=n_orig,
+    )
+
+    # Zero out bound multipliers on the fix-bounds of integer columns; they
+    # quantify the cost of fixing, not bound activity in the original model.
+    if (bdl is not None or bdu is not None) and is_integer_col.any():
+        offset = 0
+        for v in model._variables:
+            sz = int(v.size)
+            if v.var_type in (VarType.BINARY, VarType.INTEGER):
+                if bdl is not None and v.name in bdl:
+                    bdl[v.name] = np.zeros_like(bdl[v.name])
+                if bdu is not None and v.name in bdu:
+                    bdu[v.name] = np.zeros_like(bdu[v.name])
+            offset += sz
+
+    return cd, bdl, bdu
 
 
 def _decompose_eq_slack_form(
@@ -3923,6 +4217,17 @@ def _solve_lp_highs(
         if model._objective.sense == ObjectiveSense.MAXIMIZE:
             obj_val = -obj_val
 
+        n_eq_rows = A_eq.shape[0] if A_eq is not None else 0
+        n_ub_rows = A_ub.shape[0] if A_ub is not None else 0
+        cd, bdl, bdu = _lp_qp_unpack_duals(
+            model,
+            row_dual=result.dual_values,
+            col_dual=result.reduced_costs,
+            n_eq=n_eq_rows,
+            n_ub=n_ub_rows,
+            n_orig=n_orig,
+        )
+
         sr = SolveResult(
             status="optimal",
             objective=obj_val,
@@ -3934,6 +4239,9 @@ def _solve_lp_highs(
             rust_time=0.0,
             jax_time=0.0,
             python_time=wall_time,
+            constraint_duals=cd,
+            bound_duals_lower=bdl,
+            bound_duals_upper=bdu,
         )
         sr.convex_fast_path = True
         return sr
@@ -4029,6 +4337,33 @@ def _solve_qp_highs(
         if model._objective.sense == ObjectiveSense.MAXIMIZE:
             obj_val = -obj_val
 
+        n_eq_rows = A_eq.shape[0] if A_eq is not None else 0
+        n_ub_rows = A_ub.shape[0] if A_ub is not None else 0
+        if integrality is None:
+            cd, bdl, bdu = _lp_qp_unpack_duals(
+                model,
+                row_dual=result.dual_values,
+                col_dual=result.reduced_costs,
+                n_eq=n_eq_rows,
+                n_ub=n_ub_rows,
+                n_orig=n_orig,
+            )
+        else:
+            # MIQP: HiGHS doesn't expose MIP duals. Recover by re-solving the
+            # QP relaxation with integers fixed at the MIP incumbent.
+            cd, bdl, bdu = _mip_recover_relaxation_duals(
+                model,
+                lp_data=qp_data,
+                x_flat=np.asarray(x_flat, dtype=float),
+                n_orig=n_orig,
+                A_ub=A_ub,
+                b_ub=b_ub,
+                A_eq=A_eq,
+                b_eq=b_eq,
+                time_limit=time_limit,
+                Q_orig=Q_orig,
+            )
+
         sr = SolveResult(
             status="optimal",
             objective=obj_val,
@@ -4040,6 +4375,9 @@ def _solve_qp_highs(
             rust_time=0.0,
             jax_time=0.0,
             python_time=wall_time,
+            constraint_duals=cd,
+            bound_duals_lower=bdl,
+            bound_duals_upper=bdu,
         )
         # A detected QP with PSD Q is a convex problem solved directly without
         # B&B -- semantically the same as the convex NLP fast path.
@@ -4122,6 +4460,17 @@ def _solve_milp_highs(
         obj_val = result.objective + lp_data.obj_const
         if sense == ObjectiveSense.MAXIMIZE:
             obj_val = -obj_val
+        cd, bdl, bdu = _mip_recover_relaxation_duals(
+            model,
+            lp_data=lp_data,
+            x_flat=np.asarray(x_flat, dtype=float),
+            n_orig=n_orig,
+            A_ub=A_ub,
+            b_ub=b_ub,
+            A_eq=A_eq,
+            b_eq=b_eq,
+            time_limit=time_limit,
+        )
         return SolveResult(
             status="optimal",
             objective=obj_val,
@@ -4133,6 +4482,9 @@ def _solve_milp_highs(
             rust_time=0.0,
             jax_time=0.0,
             python_time=wall_time,
+            constraint_duals=cd,
+            bound_duals_lower=bdl,
+            bound_duals_upper=bdu,
         )
     elif result.status == SolveStatus.INFEASIBLE:
         return SolveResult(status="infeasible", wall_time=wall_time, node_count=result.node_count)
@@ -4357,9 +4709,37 @@ def _solve_milp_bb(
         if obj_val >= _SENTINEL_THRESHOLD:
             incumbent = None
 
+    constraint_duals = None
+    bound_duals_lower = None
+    bound_duals_upper = None
+
     if incumbent is not None:
         sol_flat = np.array(sol_array)
         x_dict = _unpack_solution(model, sol_flat)
+
+        # Recover relaxation duals at the integer-feasible incumbent by
+        # re-solving the LP relaxation with integer variables fixed.
+        try:
+            n_total = lp_data.A_eq.shape[1] if lp_data.A_eq.shape[0] > 0 else n_orig
+            n_slack = n_total - n_orig
+            A_eq_full = np.asarray(lp_data.A_eq)
+            b_eq_full = np.asarray(lp_data.b_eq)
+            A_ub, b_ub_, A_eq, b_eq = _decompose_eq_slack_form(
+                A_eq_full, b_eq_full, n_orig, n_slack
+            )
+            constraint_duals, bound_duals_lower, bound_duals_upper = _mip_recover_relaxation_duals(
+                model,
+                lp_data=lp_data,
+                x_flat=np.asarray(sol_flat[:n_orig], dtype=float),
+                n_orig=n_orig,
+                A_ub=A_ub,
+                b_ub=b_ub_,
+                A_eq=A_eq,
+                b_eq=b_eq,
+                time_limit=max(0.1, time_limit - (time.perf_counter() - t_start)),
+            )
+        except Exception as _exc:
+            logger.debug("MILP-BB dual recovery failed: %s", _exc)
 
         # Negate objective back for maximization (B&B tree tracks minimization)
         from discopt.modeling.core import ObjectiveSense
@@ -4401,6 +4781,9 @@ def _solve_milp_bb(
         rust_time=rust_time,
         jax_time=jax_time,
         python_time=python_time,
+        constraint_duals=constraint_duals,
+        bound_duals_lower=bound_duals_lower,
+        bound_duals_upper=bound_duals_upper,
     )
 
 
@@ -4579,9 +4962,39 @@ def _solve_miqp_bb(
         if obj_val >= _SENTINEL_THRESHOLD:
             incumbent = None
 
+    constraint_duals = None
+    bound_duals_lower = None
+    bound_duals_upper = None
+
     if incumbent is not None:
         sol_flat = np.array(sol_array)
         x_dict = _unpack_solution(model, sol_flat)
+
+        # Recover relaxation duals at the integer-feasible incumbent by
+        # re-solving the QP relaxation with integer variables fixed.
+        try:
+            n_total = qp_data.A_eq.shape[1] if qp_data.A_eq.shape[0] > 0 else n_orig
+            n_slack_local = n_total - n_orig
+            A_eq_full = np.asarray(qp_data.A_eq)
+            b_eq_full = np.asarray(qp_data.b_eq)
+            A_ub_, b_ub_, A_eq_, b_eq_ = _decompose_eq_slack_form(
+                A_eq_full, b_eq_full, n_orig, n_slack_local
+            )
+            Q_orig = np.asarray(qp_data.Q[:n_orig, :n_orig])
+            constraint_duals, bound_duals_lower, bound_duals_upper = _mip_recover_relaxation_duals(
+                model,
+                lp_data=qp_data,
+                x_flat=np.asarray(sol_flat[:n_orig], dtype=float),
+                n_orig=n_orig,
+                A_ub=A_ub_,
+                b_ub=b_ub_,
+                A_eq=A_eq_,
+                b_eq=b_eq_,
+                time_limit=max(0.1, time_limit - (time.perf_counter() - t_start)),
+                Q_orig=Q_orig,
+            )
+        except Exception as _exc:
+            logger.debug("MIQP-BB dual recovery failed: %s", _exc)
 
         # Negate objective back for maximization (B&B tree tracks minimization)
         from discopt.modeling.core import ObjectiveSense
@@ -4623,4 +5036,7 @@ def _solve_miqp_bb(
         rust_time=rust_time,
         jax_time=jax_time,
         python_time=python_time,
+        constraint_duals=constraint_duals,
+        bound_duals_lower=bound_duals_lower,
+        bound_duals_upper=bound_duals_upper,
     )

--- a/python/discopt/solvers/__init__.py
+++ b/python/discopt/solvers/__init__.py
@@ -57,6 +57,7 @@ class QPResult:
     x: Optional[np.ndarray] = None
     objective: Optional[float] = None
     dual_values: Optional[np.ndarray] = None
+    reduced_costs: Optional[np.ndarray] = None
     node_count: int = 0
     iterations: int = 0
     wall_time: float = 0.0

--- a/python/discopt/solvers/qp_highs.py
+++ b/python/discopt/solvers/qp_highs.py
@@ -214,10 +214,21 @@ def solve_qp(
             _, node_count_f = h.getInfoValue("mip_node_count")
             node_count = int(node_count_f)
 
+        # HiGHS does not produce duals for MIP problems, only for continuous QP.
+        dual_values: Optional[np.ndarray] = None
+        reduced_costs: Optional[np.ndarray] = None
+        if integrality is None:
+            row_dual_raw = np.array(getattr(sol, "row_dual", []), dtype=np.float64)
+            col_dual_raw = np.array(getattr(sol, "col_dual", []), dtype=np.float64)
+            dual_values = row_dual_raw if row_dual_raw.size else None
+            reduced_costs = col_dual_raw if col_dual_raw.size else None
+
         return QPResult(
             status=status,
             x=x,
             objective=obj,
+            dual_values=dual_values,
+            reduced_costs=reduced_costs,
             node_count=node_count,
             wall_time=float(wall_time),
         )

--- a/python/discopt/tutor.py
+++ b/python/discopt/tutor.py
@@ -1,0 +1,493 @@
+"""``discopt tutor`` — entry point for the Claude-Code-driven course.
+
+Thin CLI sugar that locates the ``course/`` tree, resolves a lesson id,
+and shells out to ``claude`` with the matching ``/course:`` slash
+command (lesson, hint, assess, progress). The lesson library, grading
+rubrics, and progress tracking all live under ``course/``; this module
+adds no separate state.
+
+The course content ships as package data under ``discopt.course`` so a
+pip install includes it. ``discopt tutor install`` materializes a
+writable copy of the tree into the user's working directory and drops
+the ``/course:`` slash commands into ``./.claude/``.
+
+Subcommands:
+
+* ``discopt tutor``                       — dashboard (counts + next lesson)
+* ``discopt tutor list``                  — every lesson with completion status
+* ``discopt tutor start <lesson>``        — launch ``claude /course:lesson <lesson>``
+* ``discopt tutor resume``                — start whatever ``current_lesson`` is
+* ``discopt tutor next``                  — start the next-numbered lesson after ``current_lesson``
+* ``discopt tutor reset [<lesson>]``      — drop one entry from progress.yaml (or all)
+* ``discopt tutor install [--force]``     — copy the ``/course:`` slash commands
+                                            into ``./.claude/``
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+_TRACKS = ("basic", "intermediate", "advanced")
+
+
+def _packaged_course_dir() -> Path | None:
+    """Return the read-only course/ tree shipped inside the wheel."""
+    try:
+        from discopt.course import package_root
+    except Exception:
+        return None
+    p = package_root()
+    return p if (p / "SYLLABUS.md").exists() else None
+
+
+def _find_course_dir() -> Path | None:
+    """Locate the ``course/`` tree.
+
+    Resolution order:
+    1. ``$DISCOPT_COURSE_DIR``
+    2. Walk upward from cwd looking for ``course/SYLLABUS.md``
+       (so a writable copy in the user's project always wins).
+    3. The packaged copy shipped with the wheel (read-only).
+    """
+    env = os.environ.get("DISCOPT_COURSE_DIR")
+    if env:
+        p = Path(env).expanduser().resolve()
+        if (p / "SYLLABUS.md").exists():
+            return p
+        return None
+    cwd = Path.cwd().resolve()
+    for cand in [cwd, *cwd.parents]:
+        if (cand / "course" / "SYLLABUS.md").exists():
+            return cand / "course"
+    return _packaged_course_dir()
+
+
+def _is_read_only(course_dir: Path) -> bool:
+    """Heuristic: True when ``course_dir`` is the packaged copy in site-packages."""
+    pkg = _packaged_course_dir()
+    if pkg is None:
+        return False
+    try:
+        return course_dir.resolve() == pkg.resolve()
+    except OSError:
+        return False
+
+
+def _list_lessons(course_dir: Path) -> list[str]:
+    """Return ``<track>/<id>`` strings in syllabus order."""
+    out: list[str] = []
+    for track in _TRACKS:
+        td = course_dir / track
+        if not td.is_dir():
+            continue
+        for sub in sorted(td.iterdir()):
+            if sub.is_dir() and (sub / "reading.ipynb").exists():
+                out.append(f"{track}/{sub.name}")
+    return out
+
+
+def _resolve_lesson(course_dir: Path, name: str) -> str | None:
+    """Map a user-supplied lesson name to a canonical ``<track>/<id>``.
+
+    Accepts:
+    * ``"basic/02_lp_fundamentals"`` — already canonical
+    * ``"02"`` or ``"02_lp_fundamentals"`` — looked up across tracks
+    """
+    all_lessons = _list_lessons(course_dir)
+    if name in all_lessons:
+        return name
+    # Strip leading track if present but unknown
+    short = name.split("/", 1)[-1]
+    matches = [le for le in all_lessons if le.split("/", 1)[1].startswith(short)]
+    if not matches and re.fullmatch(r"\d+", short):
+        # bare lesson number, e.g. "16"
+        matches = [le for le in all_lessons if le.split("/", 1)[1].startswith(short + "_")]
+    if len(matches) == 1:
+        return matches[0]
+    return None
+
+
+def _progress_path(course_dir: Path) -> Path:
+    return course_dir / "progress.yaml"
+
+
+def _load_progress(course_dir: Path) -> dict | None:
+    """Best-effort load of ``course/progress.yaml``.
+
+    Returns ``None`` if the file is missing or PyYAML is unavailable.
+    """
+    path = _progress_path(course_dir)
+    if not path.exists():
+        return None
+    try:
+        import yaml  # type: ignore[import-not-found]
+    except ImportError:
+        return None
+    try:
+        return yaml.safe_load(path.read_text()) or {}
+    except Exception:
+        return None
+
+
+def _scores_for(progress: dict | None) -> dict:
+    if not progress:
+        return {}
+    scores = progress.get("scores") or {}
+    return scores if isinstance(scores, dict) else {}
+
+
+def _current_lesson(progress: dict | None) -> str | None:
+    if not progress:
+        return None
+    cl = progress.get("current_lesson")
+    return cl if isinstance(cl, str) else None
+
+
+def _claude_binary() -> str | None:
+    return shutil.which("claude")
+
+
+def _print_no_claude() -> None:
+    print(
+        "claude binary not found on PATH. Install Claude Code "
+        "(https://claude.com/claude-code) and re-run.",
+        file=sys.stderr,
+    )
+
+
+def _launch_slash(slash_command: str, *extra_args: str) -> int:
+    """Spawn ``claude "<slash_command> <extra_args>"`` and inherit its TTY."""
+    claude = _claude_binary()
+    if claude is None:
+        _print_no_claude()
+        return 1
+    initial = " ".join((slash_command, *extra_args)).strip()
+    # Inherit stdin/stdout/stderr so the user gets a real interactive session.
+    return subprocess.call([claude, initial])
+
+
+# ---------------------------------------------------------------------------
+# Subcommand handlers
+# ---------------------------------------------------------------------------
+
+
+def _cmd_dashboard(_args, course_dir: Path) -> int:
+    lessons = _list_lessons(course_dir)
+    progress = _load_progress(course_dir)
+    scores = _scores_for(progress)
+    current = _current_lesson(progress)
+
+    print(f"discopt tutor  ({course_dir})")
+    if _is_read_only(course_dir):
+        print(
+            "  (read-only packaged copy; run `discopt tutor install` to "
+            "materialize a writable course/ in cwd)"
+        )
+    print()
+    for track in _TRACKS:
+        track_lessons = [le for le in lessons if le.startswith(track + "/")]
+        done = [le for le in track_lessons if _is_passed(scores.get(le))]
+        avg = _avg([scores[le].get("total") for le in track_lessons if le in scores])
+        avg_s = f"{avg:.0f}" if avg is not None else "-"
+        print(f"  {track:12s}  {len(done):>2d} / {len(track_lessons):<2d} complete   avg {avg_s}")
+    print()
+    if current:
+        print(f"  current lesson:  {current}")
+    next_id = _next_lesson(lessons, scores, current)
+    if next_id:
+        print(f"  next lesson:     {next_id}")
+    print()
+    print("  discopt tutor list             show every lesson")
+    print("  discopt tutor start <lesson>   launch a lesson in claude")
+    print("  discopt tutor resume           continue current_lesson")
+    return 0
+
+
+def _is_passed(entry: object) -> bool:
+    if not isinstance(entry, dict):
+        return False
+    total = entry.get("total")
+    return isinstance(total, (int, float)) and total >= 70
+
+
+def _avg(values: list) -> float | None:
+    nums = [v for v in values if isinstance(v, (int, float))]
+    if not nums:
+        return None
+    return sum(nums) / len(nums)
+
+
+def _next_lesson(lessons: list[str], scores: dict, current: str | None) -> str | None:
+    if current and current in lessons:
+        idx = lessons.index(current)
+        # If current is already passed, jump to the one after it.
+        if _is_passed(scores.get(current)):
+            return lessons[idx + 1] if idx + 1 < len(lessons) else None
+        return current
+    # No current lesson: first unpassed lesson.
+    for le in lessons:
+        if not _is_passed(scores.get(le)):
+            return le
+    return None
+
+
+def _cmd_list(_args, course_dir: Path) -> int:
+    lessons = _list_lessons(course_dir)
+    progress = _load_progress(course_dir)
+    scores = _scores_for(progress)
+    current = _current_lesson(progress)
+
+    if progress is None and not _progress_path(course_dir).exists():
+        print("(no progress.yaml yet — run /course:progress in claude to initialize)\n")
+
+    for le in lessons:
+        entry = scores.get(le) or {}
+        total = entry.get("total")
+        if isinstance(total, (int, float)):
+            tag = f"{int(total):3d}"
+        else:
+            tag = " - "
+        marker = "*" if le == current else " "
+        print(f"  {marker} {tag}   {le}")
+    return 0
+
+
+def _cmd_start(args, course_dir: Path) -> int:
+    lesson = _resolve_lesson(course_dir, args.lesson)
+    if lesson is None:
+        print(f"unknown lesson: {args.lesson!r}", file=sys.stderr)
+        print("run `discopt tutor list` to see available lessons.", file=sys.stderr)
+        return 1
+    return _launch_slash(f"/course:lesson {lesson}")
+
+
+def _cmd_resume(_args, course_dir: Path) -> int:
+    progress = _load_progress(course_dir)
+    current = _current_lesson(progress)
+    if current is None:
+        if progress is None and not _progress_path(course_dir).exists():
+            print(
+                "no progress.yaml yet. Start your first lesson with "
+                "`discopt tutor start basic/01_intro_to_optimization`.",
+                file=sys.stderr,
+            )
+        else:
+            print(
+                "no current_lesson recorded in progress.yaml. "
+                "Use `discopt tutor start <lesson>` to pick one.",
+                file=sys.stderr,
+            )
+        return 1
+    return _launch_slash(f"/course:lesson {current}")
+
+
+def _cmd_next(_args, course_dir: Path) -> int:
+    lessons = _list_lessons(course_dir)
+    progress = _load_progress(course_dir)
+    scores = _scores_for(progress)
+    current = _current_lesson(progress)
+    nxt = _next_lesson(lessons, scores, current)
+    if nxt is None:
+        print("you've completed every lesson — nothing left to start.")
+        return 0
+    return _launch_slash(f"/course:lesson {nxt}")
+
+
+def _cmd_reset(args, course_dir: Path) -> int:
+    if _is_read_only(course_dir):
+        print(
+            "course/ is the read-only packaged copy. Run "
+            "`discopt tutor install` first to make it writable.",
+            file=sys.stderr,
+        )
+        return 1
+    path = _progress_path(course_dir)
+    if not path.exists():
+        print("no progress.yaml to reset.")
+        return 0
+    if args.lesson is None:
+        # Wipe the whole file: restore from template.
+        tmpl = course_dir / "progress.template.yaml"
+        if not tmpl.exists():
+            print("progress.template.yaml is missing; refusing to delete progress.yaml.")
+            return 1
+        confirm = input(f"reset all progress at {path}? [y/N] ").strip().lower()
+        if confirm != "y":
+            print("aborted.")
+            return 0
+        shutil.copy2(tmpl, path)
+        print(f"reset {path} from template.")
+        return 0
+    # Drop a single entry.
+    lesson = _resolve_lesson(course_dir, args.lesson)
+    if lesson is None:
+        print(f"unknown lesson: {args.lesson!r}", file=sys.stderr)
+        return 1
+    try:
+        import yaml  # type: ignore[import-not-found]
+    except ImportError:
+        print(
+            "per-lesson reset needs PyYAML. Install it or edit progress.yaml by hand.",
+            file=sys.stderr,
+        )
+        return 1
+    data = yaml.safe_load(path.read_text()) or {}
+    scores = data.get("scores") or {}
+    if lesson in scores:
+        del scores[lesson]
+        data["scores"] = scores or None
+        path.write_text(yaml.safe_dump(data, sort_keys=False))
+        print(f"dropped progress entry for {lesson}.")
+    else:
+        print(f"no progress entry for {lesson}; nothing to do.")
+    return 0
+
+
+_PY_ARTIFACT_SUFFIXES = (".pyc", ".pyo")
+
+
+def _is_py_artifact(rel: Path) -> bool:
+    """Reject Python build artifacts that leak through editable installs."""
+    if "__pycache__" in rel.parts:
+        return True
+    if rel.name == "__init__.py" and len(rel.parts) == 1:
+        # The course/__init__.py we added to make it a package — student
+        # shouldn't see it in their materialized copy.
+        return True
+    return rel.suffix in _PY_ARTIFACT_SUFFIXES
+
+
+def _copy_tree(src_root: Path, dest_root: Path, *, force: bool, skip: set[str]) -> tuple[int, int]:
+    """Copy ``src_root`` recursively into ``dest_root``.
+
+    Skips any top-level entry whose name is in *skip* (so the course copy
+    can exclude ``_claude_assets`` while still pulling lessons across) and
+    Python build artifacts (``__pycache__``, ``*.pyc``, the package's own
+    ``__init__.py``). Returns ``(copied, skipped)`` file counts.
+    """
+    copied = 0
+    skipped = 0
+    for src in src_root.rglob("*"):
+        if not src.is_file():
+            continue
+        rel = src.relative_to(src_root)
+        if rel.parts and rel.parts[0] in skip:
+            continue
+        if _is_py_artifact(rel):
+            continue
+        dest = dest_root / rel
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        if dest.exists() and not force:
+            print(f"  skip  {rel} (exists; pass --force to overwrite)")
+            skipped += 1
+            continue
+        shutil.copy2(src, dest)
+        print(f"  copy  {rel}")
+        copied += 1
+    return copied, skipped
+
+
+def _cmd_install(args, course_dir: Path) -> int:
+    """Materialize a writable course/ tree + Claude assets into cwd.
+
+    Copies:
+    * ``course/_claude_assets/`` -> ``./.claude/``
+    * everything else under ``course/`` -> ``./course/``
+
+    Idempotent: existing files are preserved unless ``--force`` is passed.
+    """
+    src_assets = course_dir / "_claude_assets"
+    if not src_assets.is_dir():
+        print(f"missing {src_assets}; can't install.", file=sys.stderr)
+        return 1
+    cwd = Path.cwd()
+    claude_dest = cwd / ".claude"
+    course_dest = cwd / "course"
+
+    print(f"installing Claude assets into {claude_dest}")
+    n_claude, n_claude_skip = _copy_tree(src_assets, claude_dest, force=args.force, skip=set())
+
+    course_copied = course_skipped = 0
+    if course_dest.resolve() != course_dir.resolve():
+        print(f"\ninstalling course content into {course_dest}")
+        course_copied, course_skipped = _copy_tree(
+            course_dir,
+            course_dest,
+            force=args.force,
+            skip={"_claude_assets"},
+        )
+    else:
+        print(f"\nskipping course content copy: already at {course_dest}")
+
+    total = n_claude + course_copied
+    total_skipped = n_claude_skip + course_skipped
+    print(f"\ninstalled {total} file(s); {total_skipped} skipped.")
+    if total_skipped:
+        print("  pass --force to overwrite existing files.")
+    return 0
+
+
+# ---------------------------------------------------------------------------
+# argparse entry point
+# ---------------------------------------------------------------------------
+
+
+def add_subparser(subparsers) -> None:
+    """Register the ``tutor`` subcommand on the top-level ``discopt`` parser."""
+    p = subparsers.add_parser(
+        "tutor",
+        help="Interactive Claude-Code-driven discopt course.",
+        description=(
+            "Entry point for the discopt course. Locates the course/ tree, "
+            "resolves a lesson id, and launches a claude session running the "
+            "matching /course: slash command."
+        ),
+    )
+    tutor_sub = p.add_subparsers(dest="tutor_cmd", metavar="<subcommand>")
+
+    p_list = tutor_sub.add_parser("list", help="list every lesson with status")
+    p_list.set_defaults(tutor_func=_cmd_list)
+
+    p_start = tutor_sub.add_parser("start", help="launch a specific lesson")
+    p_start.add_argument("lesson", help="lesson id, e.g. basic/02_lp_fundamentals or just 02")
+    p_start.set_defaults(tutor_func=_cmd_start)
+
+    p_resume = tutor_sub.add_parser("resume", help="continue current_lesson")
+    p_resume.set_defaults(tutor_func=_cmd_resume)
+
+    p_next = tutor_sub.add_parser("next", help="start the next-numbered lesson")
+    p_next.set_defaults(tutor_func=_cmd_next)
+
+    p_reset = tutor_sub.add_parser("reset", help="reset progress (one lesson, or all)")
+    p_reset.add_argument("lesson", nargs="?", help="lesson id; omit to reset all")
+    p_reset.set_defaults(tutor_func=_cmd_reset)
+
+    p_install = tutor_sub.add_parser(
+        "install", help="install /course: slash commands into ./.claude/"
+    )
+    p_install.add_argument("--force", action="store_true", help="overwrite existing files")
+    p_install.set_defaults(tutor_func=_cmd_install)
+
+    # Bare `discopt tutor` (no subcommand) shows the dashboard.
+    p.set_defaults(tutor_func=_cmd_dashboard, tutor_cmd=None)
+
+
+def run(args) -> int:
+    """Dispatch ``discopt tutor ...`` after argparse parsing."""
+    course_dir = _find_course_dir()
+    # ``install`` is the only command that legitimately runs against a course
+    # tree the user might still need help finding; all others require it.
+    if course_dir is None:
+        print(
+            "course/ directory not found. Run from a discopt checkout that "
+            "contains course/SYLLABUS.md, or set DISCOPT_COURSE_DIR.",
+            file=sys.stderr,
+        )
+        return 1
+    rc: int = args.tutor_func(args, course_dir)
+    return rc

--- a/python/tests/test_cli_tutor.py
+++ b/python/tests/test_cli_tutor.py
@@ -1,0 +1,511 @@
+"""Tests for the ``discopt tutor`` CLI subcommand."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+import pytest
+from discopt import tutor
+
+# ──────────────────────────────────────────────────────────
+# Fixtures: synthetic course tree
+# ──────────────────────────────────────────────────────────
+
+
+def _make_course(root: Path) -> Path:
+    """Create a minimal in-memory ``course/`` tree under *root*.
+
+    Mimics the real layout: basic/01..03, intermediate/11, advanced/21.
+    """
+    course = root / "course"
+    (course / "basic" / "01_intro_to_optimization").mkdir(parents=True)
+    (course / "basic" / "02_lp_fundamentals").mkdir(parents=True)
+    (course / "basic" / "03_modeling_in_discopt").mkdir(parents=True)
+    (course / "intermediate" / "11_milp_modeling").mkdir(parents=True)
+    (course / "advanced" / "21_spatial_branch_and_bound").mkdir(parents=True)
+    for sub in (
+        "basic/01_intro_to_optimization",
+        "basic/02_lp_fundamentals",
+        "basic/03_modeling_in_discopt",
+        "intermediate/11_milp_modeling",
+        "advanced/21_spatial_branch_and_bound",
+    ):
+        (course / sub / "reading.ipynb").write_text("{}")
+    (course / "SYLLABUS.md").write_text("# syllabus\n")
+    (course / "progress.template.yaml").write_text(
+        "scores: null\ncurrent_lesson: basic/01_intro_to_optimization\n"
+    )
+    return course
+
+
+@pytest.fixture
+def fake_course(tmp_path, monkeypatch):
+    course = _make_course(tmp_path)
+    monkeypatch.setenv("DISCOPT_COURSE_DIR", str(course))
+    return course
+
+
+# ──────────────────────────────────────────────────────────
+# _find_course_dir
+# ──────────────────────────────────────────────────────────
+
+
+class TestFindCourseDir:
+    def test_env_var(self, tmp_path, monkeypatch):
+        course = _make_course(tmp_path)
+        monkeypatch.setenv("DISCOPT_COURSE_DIR", str(course))
+        assert tutor._find_course_dir() == course.resolve()
+
+    def test_env_var_invalid_falls_back_to_package(self, tmp_path, monkeypatch):
+        # An invalid env-var short-circuits to None (doesn't fall back).
+        monkeypatch.setenv("DISCOPT_COURSE_DIR", str(tmp_path / "nope"))
+        monkeypatch.chdir(tmp_path)
+        assert tutor._find_course_dir() is None
+
+    def test_walk_up_from_cwd(self, tmp_path, monkeypatch):
+        course = _make_course(tmp_path)
+        deep = tmp_path / "a" / "b" / "c"
+        deep.mkdir(parents=True)
+        monkeypatch.delenv("DISCOPT_COURSE_DIR", raising=False)
+        monkeypatch.chdir(deep)
+        assert tutor._find_course_dir() == course
+
+    def test_packaged_fallback(self, tmp_path, monkeypatch):
+        # Outside any checkout, the packaged course/ is the fallback.
+        monkeypatch.delenv("DISCOPT_COURSE_DIR", raising=False)
+        monkeypatch.chdir(tmp_path)
+        found = tutor._find_course_dir()
+        assert found is not None
+        assert (found / "SYLLABUS.md").exists()
+        assert found == tutor._packaged_course_dir()
+
+    def test_no_packaged_fallback(self, tmp_path, monkeypatch):
+        # If the packaged copy is somehow missing, fallback returns None.
+        monkeypatch.delenv("DISCOPT_COURSE_DIR", raising=False)
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.setattr(tutor, "_packaged_course_dir", lambda: None)
+        assert tutor._find_course_dir() is None
+
+
+# ──────────────────────────────────────────────────────────
+# _list_lessons / _resolve_lesson
+# ──────────────────────────────────────────────────────────
+
+
+class TestListLessons:
+    def test_orders_by_track_then_id(self, fake_course):
+        lessons = tutor._list_lessons(fake_course)
+        assert lessons == [
+            "basic/01_intro_to_optimization",
+            "basic/02_lp_fundamentals",
+            "basic/03_modeling_in_discopt",
+            "intermediate/11_milp_modeling",
+            "advanced/21_spatial_branch_and_bound",
+        ]
+
+    def test_skips_dirs_without_reading_ipynb(self, fake_course):
+        (fake_course / "basic" / "99_drafty").mkdir()
+        assert "basic/99_drafty" not in tutor._list_lessons(fake_course)
+
+
+class TestResolveLesson:
+    def test_canonical(self, fake_course):
+        assert (
+            tutor._resolve_lesson(fake_course, "basic/02_lp_fundamentals")
+            == "basic/02_lp_fundamentals"
+        )
+
+    def test_shorthand_number(self, fake_course):
+        assert tutor._resolve_lesson(fake_course, "02") == "basic/02_lp_fundamentals"
+
+    def test_shorthand_full_id(self, fake_course):
+        assert (
+            tutor._resolve_lesson(fake_course, "02_lp_fundamentals") == "basic/02_lp_fundamentals"
+        )
+
+    def test_unknown(self, fake_course):
+        assert tutor._resolve_lesson(fake_course, "nonsense") is None
+
+    def test_ambiguous_returns_none(self, fake_course):
+        # Add a colliding lesson under another track.
+        (fake_course / "intermediate" / "02_dup").mkdir()
+        (fake_course / "intermediate" / "02_dup" / "reading.ipynb").write_text("{}")
+        assert tutor._resolve_lesson(fake_course, "02") is None
+
+
+# ──────────────────────────────────────────────────────────
+# Progress parsing
+# ──────────────────────────────────────────────────────────
+
+
+class TestProgress:
+    def test_missing_file_returns_none(self, fake_course):
+        assert tutor._load_progress(fake_course) is None
+
+    def test_yaml_load(self, fake_course):
+        pytest.importorskip("yaml")
+        (fake_course / "progress.yaml").write_text(
+            "current_lesson: basic/02_lp_fundamentals\n"
+            "scores:\n"
+            "  basic/01_intro_to_optimization:\n"
+            "    total: 88\n"
+            "  basic/02_lp_fundamentals:\n"
+            "    total: 65\n"
+        )
+        data = tutor._load_progress(fake_course)
+        assert data is not None
+        assert data["current_lesson"] == "basic/02_lp_fundamentals"
+        assert tutor._scores_for(data)["basic/01_intro_to_optimization"]["total"] == 88
+        assert tutor._current_lesson(data) == "basic/02_lp_fundamentals"
+
+    def test_is_passed_threshold(self):
+        assert tutor._is_passed({"total": 70})
+        assert tutor._is_passed({"total": 99})
+        assert not tutor._is_passed({"total": 69})
+        assert not tutor._is_passed({})
+        assert not tutor._is_passed(None)
+
+
+# ──────────────────────────────────────────────────────────
+# _next_lesson
+# ──────────────────────────────────────────────────────────
+
+
+class TestNextLesson:
+    def test_no_progress_returns_first(self, fake_course):
+        lessons = tutor._list_lessons(fake_course)
+        assert tutor._next_lesson(lessons, {}, None) == "basic/01_intro_to_optimization"
+
+    def test_current_unpassed_returns_current(self, fake_course):
+        lessons = tutor._list_lessons(fake_course)
+        nxt = tutor._next_lesson(lessons, {}, "basic/02_lp_fundamentals")
+        assert nxt == "basic/02_lp_fundamentals"
+
+    def test_current_passed_advances(self, fake_course):
+        lessons = tutor._list_lessons(fake_course)
+        scores = {"basic/02_lp_fundamentals": {"total": 90}}
+        nxt = tutor._next_lesson(lessons, scores, "basic/02_lp_fundamentals")
+        assert nxt == "basic/03_modeling_in_discopt"
+
+    def test_all_passed(self, fake_course):
+        lessons = tutor._list_lessons(fake_course)
+        scores = {le: {"total": 100} for le in lessons}
+        assert tutor._next_lesson(lessons, scores, lessons[-1]) is None
+
+
+# ──────────────────────────────────────────────────────────
+# Subcommand handlers (without launching claude)
+# ──────────────────────────────────────────────────────────
+
+
+def _ns(**kw):
+    return argparse.Namespace(**kw)
+
+
+class TestDashboard:
+    def test_no_progress(self, fake_course, capsys):
+        rc = tutor._cmd_dashboard(_ns(), fake_course)
+        out = capsys.readouterr().out
+        assert rc == 0
+        assert "basic" in out
+        assert "0 / 3" in out
+        assert "next lesson:" in out
+        assert "basic/01_intro_to_optimization" in out
+
+    def test_with_progress(self, fake_course, capsys):
+        pytest.importorskip("yaml")
+        (fake_course / "progress.yaml").write_text(
+            "current_lesson: basic/02_lp_fundamentals\n"
+            "scores:\n"
+            "  basic/01_intro_to_optimization:\n"
+            "    total: 80\n"
+        )
+        tutor._cmd_dashboard(_ns(), fake_course)
+        out = capsys.readouterr().out
+        assert "1 / 3" in out
+        assert "current lesson:  basic/02_lp_fundamentals" in out
+
+
+class TestList:
+    def test_no_progress_hint(self, fake_course, capsys):
+        rc = tutor._cmd_list(_ns(), fake_course)
+        out = capsys.readouterr().out
+        assert rc == 0
+        assert "no progress.yaml yet" in out
+        assert "basic/01_intro_to_optimization" in out
+        # Unscored lessons show " - "
+        assert " - " in out
+
+    def test_with_scores(self, fake_course, capsys):
+        pytest.importorskip("yaml")
+        (fake_course / "progress.yaml").write_text(
+            "current_lesson: basic/02_lp_fundamentals\n"
+            "scores:\n"
+            "  basic/01_intro_to_optimization:\n"
+            "    total: 88\n"
+        )
+        tutor._cmd_list(_ns(), fake_course)
+        out = capsys.readouterr().out
+        assert " 88   basic/01_intro_to_optimization" in out
+        # Current lesson is marked with an asterisk.
+        assert "* " in out
+
+
+class TestStart:
+    def test_unknown_lesson(self, fake_course, capsys):
+        rc = tutor._cmd_start(_ns(lesson="nonsense"), fake_course)
+        assert rc == 1
+        err = capsys.readouterr().err
+        assert "unknown lesson" in err
+
+    def test_resolves_and_launches(self, fake_course, monkeypatch):
+        calls = []
+        monkeypatch.setattr(
+            tutor,
+            "_launch_slash",
+            lambda cmd, *args: calls.append((cmd, args)) or 0,
+        )
+        rc = tutor._cmd_start(_ns(lesson="02"), fake_course)
+        assert rc == 0
+        assert calls == [("/course:lesson basic/02_lp_fundamentals", ())]
+
+
+class TestResume:
+    def test_no_progress(self, fake_course, capsys):
+        rc = tutor._cmd_resume(_ns(), fake_course)
+        assert rc == 1
+        assert "no progress.yaml yet" in capsys.readouterr().err
+
+    def test_current_lesson(self, fake_course, monkeypatch):
+        pytest.importorskip("yaml")
+        (fake_course / "progress.yaml").write_text(
+            "current_lesson: basic/03_modeling_in_discopt\nscores: null\n"
+        )
+        calls = []
+        monkeypatch.setattr(tutor, "_launch_slash", lambda cmd, *args: calls.append(cmd) or 0)
+        rc = tutor._cmd_resume(_ns(), fake_course)
+        assert rc == 0
+        assert calls == ["/course:lesson basic/03_modeling_in_discopt"]
+
+
+class TestNextCmd:
+    def test_launches_first_when_no_progress(self, fake_course, monkeypatch):
+        calls = []
+        monkeypatch.setattr(tutor, "_launch_slash", lambda cmd, *args: calls.append(cmd) or 0)
+        rc = tutor._cmd_next(_ns(), fake_course)
+        assert rc == 0
+        assert calls == ["/course:lesson basic/01_intro_to_optimization"]
+
+    def test_done_with_everything(self, fake_course, capsys):
+        pytest.importorskip("yaml")
+        (fake_course / "progress.yaml").write_text(
+            "current_lesson: advanced/21_spatial_branch_and_bound\n"
+            "scores:\n"
+            "  basic/01_intro_to_optimization: {total: 100}\n"
+            "  basic/02_lp_fundamentals: {total: 100}\n"
+            "  basic/03_modeling_in_discopt: {total: 100}\n"
+            "  intermediate/11_milp_modeling: {total: 100}\n"
+            "  advanced/21_spatial_branch_and_bound: {total: 100}\n"
+        )
+        rc = tutor._cmd_next(_ns(), fake_course)
+        assert rc == 0
+        assert "completed every lesson" in capsys.readouterr().out
+
+
+class TestReset:
+    def test_no_progress_file(self, fake_course, capsys):
+        rc = tutor._cmd_reset(_ns(lesson=None), fake_course)
+        assert rc == 0
+        assert "no progress.yaml to reset" in capsys.readouterr().out
+
+    def test_drop_single_lesson(self, fake_course):
+        pytest.importorskip("yaml")
+        import yaml
+
+        (fake_course / "progress.yaml").write_text(
+            "scores:\n"
+            "  basic/01_intro_to_optimization: {total: 80}\n"
+            "  basic/02_lp_fundamentals: {total: 90}\n"
+        )
+        rc = tutor._cmd_reset(_ns(lesson="01"), fake_course)
+        assert rc == 0
+        data = yaml.safe_load((fake_course / "progress.yaml").read_text())
+        assert "basic/01_intro_to_optimization" not in (data["scores"] or {})
+        assert "basic/02_lp_fundamentals" in data["scores"]
+
+    def test_unknown_lesson(self, fake_course, capsys):
+        (fake_course / "progress.yaml").write_text("scores: null\n")
+        rc = tutor._cmd_reset(_ns(lesson="nonsense"), fake_course)
+        assert rc == 1
+        assert "unknown lesson" in capsys.readouterr().err
+
+    def test_refuses_on_packaged_copy(self, monkeypatch, capsys):
+        pkg = tutor._packaged_course_dir()
+        assert pkg is not None
+        rc = tutor._cmd_reset(_ns(lesson=None), pkg)
+        assert rc == 1
+        assert "read-only packaged copy" in capsys.readouterr().err
+
+
+class TestInstall:
+    def test_missing_assets(self, fake_course, tmp_path, monkeypatch, capsys):
+        # fake_course has no _claude_assets/
+        monkeypatch.chdir(tmp_path)
+        rc = tutor._cmd_install(_ns(force=False), fake_course)
+        assert rc == 1
+        assert "missing" in capsys.readouterr().err
+
+    def test_copies_claude_assets_and_course_content(self, fake_course, tmp_path, monkeypatch):
+        # Build a tiny _claude_assets tree.
+        assets = fake_course / "_claude_assets"
+        (assets / "commands" / "course").mkdir(parents=True)
+        (assets / "commands" / "course" / "lesson.md").write_text("LESSON SLASH\n")
+        (assets / "agents").mkdir()
+        (assets / "agents" / "tutor.md").write_text("AGENT\n")
+
+        # Install into a separate writable directory.
+        work = tmp_path / "workspace"
+        work.mkdir()
+        monkeypatch.chdir(work)
+        rc = tutor._cmd_install(_ns(force=False), fake_course)
+        assert rc == 0
+        # Claude assets land in .claude/, course/ gets the lesson tree.
+        assert (work / ".claude" / "commands" / "course" / "lesson.md").read_text() == (
+            "LESSON SLASH\n"
+        )
+        assert (work / ".claude" / "agents" / "tutor.md").read_text() == "AGENT\n"
+        assert (work / "course" / "SYLLABUS.md").exists()
+        assert (work / "course" / "basic" / "01_intro_to_optimization" / "reading.ipynb").exists()
+        # _claude_assets must NOT be duplicated under course/.
+        assert not (work / "course" / "_claude_assets").exists()
+
+    def test_skip_without_force(self, fake_course, tmp_path, monkeypatch, capsys):
+        assets = fake_course / "_claude_assets"
+        (assets / "commands").mkdir(parents=True)
+        (assets / "commands" / "x.md").write_text("from package\n")
+        work = tmp_path / "workspace"
+        work.mkdir()
+        monkeypatch.chdir(work)
+
+        (work / ".claude" / "commands").mkdir(parents=True)
+        (work / ".claude" / "commands" / "x.md").write_text("preexisting\n")
+
+        tutor._cmd_install(_ns(force=False), fake_course)
+        assert (work / ".claude" / "commands" / "x.md").read_text() == "preexisting\n"
+        assert "skip" in capsys.readouterr().out
+
+        tutor._cmd_install(_ns(force=True), fake_course)
+        assert (work / ".claude" / "commands" / "x.md").read_text() == "from package\n"
+
+    def test_skips_python_artifacts(self, fake_course, tmp_path, monkeypatch):
+        (fake_course / "_claude_assets").mkdir()
+        (fake_course / "_claude_assets" / "ok.md").write_text("k\n")
+        # Pollute the source with editable-install artifacts.
+        (fake_course / "__init__.py").write_text("")
+        (fake_course / "basic" / "__pycache__").mkdir()
+        (fake_course / "basic" / "__pycache__" / "x.cpython.pyc").write_bytes(b"")
+        (fake_course / "basic" / "01_intro_to_optimization" / "stale.pyc").write_bytes(b"")
+
+        work = tmp_path / "workspace"
+        work.mkdir()
+        monkeypatch.chdir(work)
+        tutor._cmd_install(_ns(force=False), fake_course)
+
+        assert not (work / "course" / "__init__.py").exists()
+        assert not (work / "course" / "basic" / "__pycache__").exists()
+        assert not (work / "course" / "basic" / "01_intro_to_optimization" / "stale.pyc").exists()
+        # But real content still copies.
+        assert (work / "course" / "SYLLABUS.md").exists()
+
+    def test_no_self_copy_when_install_in_course_dir(
+        self, fake_course, tmp_path, monkeypatch, capsys
+    ):
+        # Running install from inside the course dir itself: don't copy onto self.
+        (fake_course / "_claude_assets").mkdir(exist_ok=True)
+        (fake_course / "_claude_assets" / "x.md").write_text("hi\n")
+        # Install with cwd as the *parent* of fake_course so cwd/course == fake_course.
+        monkeypatch.chdir(fake_course.parent)
+        rc = tutor._cmd_install(_ns(force=False), fake_course)
+        assert rc == 0
+        assert "skipping course content copy" in capsys.readouterr().out
+
+
+# ──────────────────────────────────────────────────────────
+# run() dispatcher and argparse wiring
+# ──────────────────────────────────────────────────────────
+
+
+class TestRun:
+    def test_missing_course_dir(self, tmp_path, monkeypatch, capsys):
+        # Suppress the packaged-fallback so we exercise the not-found branch.
+        monkeypatch.delenv("DISCOPT_COURSE_DIR", raising=False)
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.setattr(tutor, "_packaged_course_dir", lambda: None)
+        rc = tutor.run(_ns(tutor_cmd=None, tutor_func=tutor._cmd_dashboard))
+        assert rc == 1
+        assert "course/ directory not found" in capsys.readouterr().err
+
+    def test_dispatches_to_tutor_func(self, fake_course):
+        called = {}
+
+        def fake_func(args, course_dir):
+            called["course_dir"] = course_dir
+            return 7
+
+        rc = tutor.run(_ns(tutor_cmd=None, tutor_func=fake_func))
+        assert rc == 7
+        assert called["course_dir"] == fake_course
+
+
+class TestArgparseWiring:
+    def test_tutor_help(self):
+        import sys
+
+        from discopt.cli import main
+
+        with pytest.raises(SystemExit):
+            old = sys.argv[:]
+            sys.argv = ["discopt", "tutor", "--help"]
+            try:
+                main()
+            finally:
+                sys.argv = old
+
+    def test_tutor_list_runs(self, fake_course, monkeypatch, capsys):
+        import sys
+
+        from discopt.cli import main
+
+        monkeypatch.setattr(sys, "argv", ["discopt", "tutor", "list"])
+        with pytest.raises(SystemExit) as excinfo:
+            main()
+        # tutor.run returns 0; main calls sys.exit(...)
+        assert (excinfo.value.code or 0) == 0
+        assert "basic/01_intro_to_optimization" in capsys.readouterr().out
+
+
+# ──────────────────────────────────────────────────────────
+# _launch_slash claude-missing branch
+# ──────────────────────────────────────────────────────────
+
+
+class TestLaunchSlash:
+    def test_no_claude_binary(self, monkeypatch, capsys):
+        monkeypatch.setattr(tutor, "_claude_binary", lambda: None)
+        rc = tutor._launch_slash("/course:lesson basic/01_intro_to_optimization")
+        assert rc == 1
+        assert "claude binary not found" in capsys.readouterr().err
+
+    def test_invokes_subprocess(self, monkeypatch):
+        captured = {}
+
+        def fake_call(argv):
+            captured["argv"] = argv
+            return 0
+
+        monkeypatch.setattr(tutor, "_claude_binary", lambda: "/fake/claude")
+        monkeypatch.setattr(tutor.subprocess, "call", fake_call)
+        rc = tutor._launch_slash("/course:lesson basic/02_lp_fundamentals")
+        assert rc == 0
+        assert captured["argv"] == ["/fake/claude", "/course:lesson basic/02_lp_fundamentals"]

--- a/python/tests/test_deadline.py
+++ b/python/tests/test_deadline.py
@@ -1,0 +1,151 @@
+"""Tests for the JAX-side wall-clock deadline plumbing (issue #80).
+
+These verify that ``deadline_scope`` actually interrupts a JAX-compiled
+``while_loop`` mid-execution, that an unset deadline leaves convergence
+behavior unchanged, and that the host-callback predicate behaves on the
+process-global state.
+"""
+
+from __future__ import annotations
+
+import time
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+import pytest
+from discopt._jax.deadline import (
+    clear_deadline,
+    deadline_exceeded,
+    deadline_exceeded_jax,
+    deadline_scope,
+    set_deadline,
+)
+
+
+@pytest.fixture(autouse=True)
+def _reset_deadline():
+    """Ensure no leaked deadline from a previous test."""
+    clear_deadline()
+    yield
+    clear_deadline()
+
+
+def test_deadline_unset_returns_false():
+    assert deadline_exceeded() is False
+
+
+def test_deadline_scope_set_and_clear():
+    with deadline_scope(60.0):
+        assert deadline_exceeded() is False  # 60s in the future
+    assert deadline_exceeded() is False  # cleared on exit
+
+
+def test_deadline_scope_trips_after_sleep():
+    with deadline_scope(0.05):
+        assert deadline_exceeded() is False
+        time.sleep(0.1)
+        assert deadline_exceeded() is True
+
+
+def test_set_deadline_none_clears():
+    set_deadline(60.0)
+    set_deadline(None)
+    assert deadline_exceeded() is False
+
+
+def test_deadline_exceeded_jax_in_while_loop_terminates_loop():
+    """A jax.lax.while_loop guarded by deadline_exceeded_jax() must exit
+    promptly once the deadline trips, instead of running to its bound."""
+
+    @jax.jit
+    def run(n_max):
+        def cond(c):
+            return jnp.logical_and(c < n_max, jnp.logical_not(deadline_exceeded_jax()))
+
+        def body(c):
+            return c + 1
+
+        return jax.lax.while_loop(cond, body, jnp.int32(0))
+
+    # Warm-compile under a wide deadline.
+    with deadline_scope(60.0):
+        _ = int(run(jnp.int32(1_000)))
+
+    # Now trip the deadline mid-loop.
+    with deadline_scope(0.1):
+        t0 = time.perf_counter()
+        iters = int(run(jnp.int32(10_000_000)))
+        elapsed = time.perf_counter() - t0
+
+    assert iters < 10_000_000, "while_loop ran to its bound; deadline was not honored"
+    assert elapsed < 2.0, f"deadline trip took {elapsed:.2f}s — should be ≲ 1s"
+
+
+def test_lp_ipm_honors_deadline():
+    """LP IPM (lp_ipm.py main solve) must self-terminate on deadline."""
+    from discopt._jax.lp_ipm import LPIPMOptions, lp_ipm_solve
+
+    # Small, well-conditioned LP so without a deadline the solver converges
+    # quickly; we then re-run with a tight deadline and verify the wall is
+    # bounded.
+    rng = np.random.default_rng(0)
+    n, m = 20, 5
+    A = rng.standard_normal((m, n))
+    x_star = np.abs(rng.standard_normal(n))
+    b = A @ x_star
+    c = rng.standard_normal(n)
+    x_l = jnp.zeros(n)
+    x_u = jnp.full(n, 1e6)
+
+    # Warm-compile.
+    state_ok = lp_ipm_solve(
+        jnp.asarray(c),
+        jnp.asarray(A),
+        jnp.asarray(b),
+        x_l,
+        x_u,
+        options=LPIPMOptions(max_iter=200),
+    )
+    assert int(state_ok.converged) in (1, 2, 3)
+
+    # Trip the deadline before calling.
+    set_deadline(-1.0)  # already past
+    t0 = time.perf_counter()
+    _ = lp_ipm_solve(
+        jnp.asarray(c),
+        jnp.asarray(A),
+        jnp.asarray(b),
+        x_l,
+        x_u,
+        options=LPIPMOptions(max_iter=10_000),  # would otherwise iterate long
+    )
+    elapsed = time.perf_counter() - t0
+    clear_deadline()
+
+    # The loop should exit immediately. converged stays at 0 (running) when
+    # the deadline trips before the first iteration completes — that's the
+    # expected signal to callers that the solve was preempted.
+    assert elapsed < 1.0, f"deadline-tripped LP IPM took {elapsed:.2f}s"
+
+
+def test_lp_ipm_unchanged_when_no_deadline():
+    """A normal solve (no deadline) must still converge to optimal."""
+    from discopt._jax.lp_ipm import LPIPMOptions, lp_ipm_solve
+
+    rng = np.random.default_rng(1)
+    n, m = 15, 4
+    A = rng.standard_normal((m, n))
+    x_star = np.abs(rng.standard_normal(n))
+    b = A @ x_star
+    c = rng.standard_normal(n)
+
+    state = lp_ipm_solve(
+        jnp.asarray(c),
+        jnp.asarray(A),
+        jnp.asarray(b),
+        jnp.zeros(n),
+        jnp.full(n, 1e6),
+        options=LPIPMOptions(max_iter=200),
+    )
+    assert int(state.converged) in (1, 2)

--- a/python/tests/test_deadline.py
+++ b/python/tests/test_deadline.py
@@ -98,14 +98,16 @@ def test_lp_ipm_honors_deadline():
     x_l = jnp.zeros(n)
     x_u = jnp.full(n, 1e6)
 
-    # Warm-compile.
+    # Warm-compile with the SAME options used in the timed call below.
+    # max_iter is a static_argnum for _lp_ipm_solve_jit, so a different value
+    # triggers a recompile that can dominate the wall-clock measurement on CI.
     state_ok = lp_ipm_solve(
         jnp.asarray(c),
         jnp.asarray(A),
         jnp.asarray(b),
         x_l,
         x_u,
-        options=LPIPMOptions(max_iter=200),
+        options=LPIPMOptions(max_iter=10_000),
     )
     assert int(state_ok.converged) in (1, 2, 3)
 

--- a/python/tests/test_solver_duals.py
+++ b/python/tests/test_solver_duals.py
@@ -1,0 +1,181 @@
+"""End-to-end tests for solver-supplied duals on the LP / QP / B&B paths.
+
+Each test runs a real solve and asserts that ``constraint_duals`` /
+``bound_duals_lower`` / ``bound_duals_upper`` are populated with the
+expected sign and magnitude, then optionally re-runs through the
+Examiner to confirm the duals satisfy KKT.
+"""
+
+from __future__ import annotations
+
+import discopt.modeling as dm
+import numpy as np
+import pytest
+
+
+def _scalar(name: str, vec: dict[str, np.ndarray]) -> float:
+    return float(np.asarray(vec[name]).ravel()[0])
+
+
+# ── LP fast path ────────────────────────────────────────────────────────
+
+
+def test_lp_path_returns_constraint_and_bound_duals():
+    """min x + 2y s.t. x + y >= 4, 0<=x,y<=10 → x*=4, y*=0."""
+    m = dm.Model("lp")
+    x = m.continuous("x", lb=0.0, ub=10.0)
+    y = m.continuous("y", lb=0.0, ub=10.0)
+    m.minimize(x + 2 * y)
+    m.subject_to(x + y >= 4, name="c1")
+
+    res = m.solve()
+
+    assert res.status == "optimal"
+    assert res.constraint_duals is not None
+    assert res.bound_duals_lower is not None
+    assert res.bound_duals_upper is not None
+
+    assert _scalar("x", res.x) == pytest.approx(4.0, abs=1e-6)
+    assert _scalar("y", res.x) == pytest.approx(0.0, abs=1e-6)
+
+    # ">=" row binding from below → μ ≥ 0 in the discopt convention.
+    mu = _scalar("c1", res.constraint_duals)
+    assert mu == pytest.approx(1.0, abs=1e-6)
+
+    # Bound on y at lb=0 is active; reduced cost is 2 - mu = 1 (>= 0).
+    lam_lb_y = _scalar("y", res.bound_duals_lower)
+    assert lam_lb_y == pytest.approx(1.0, abs=1e-6)
+
+    # Bound on x is inactive; multiplier ≈ 0.
+    assert _scalar("x", res.bound_duals_lower) == pytest.approx(0.0, abs=1e-6)
+    assert _scalar("x", res.bound_duals_upper) == pytest.approx(0.0, abs=1e-6)
+
+
+def test_lp_equality_constraint_dual_sign():
+    """Equality row dual is free; verify magnitude matches reduced LP."""
+    m = dm.Model("lp_eq")
+    x = m.continuous("x", lb=0.0, ub=10.0)
+    y = m.continuous("y", lb=0.0, ub=10.0)
+    m.minimize(x + 3 * y)
+    m.subject_to(x + y == 4, name="ceq")
+
+    res = m.solve()
+    assert res.status == "optimal"
+    assert res.constraint_duals is not None
+    # x*=4, y*=0; ∇f = [1, 3]; KKT (Examiner convention ∇f + ∇body·μ = 0)
+    # gives 1 + 1·μ = 0 → μ = -1 (equality multipliers are free in sign).
+    mu = _scalar("ceq", res.constraint_duals)
+    assert mu == pytest.approx(-1.0, abs=1e-6)
+
+
+# ── QP fast path ────────────────────────────────────────────────────────
+
+
+def test_qp_path_returns_duals_at_active_constraint():
+    """min (x-0.5)^2 + (y-0.5)^2 s.t. x+y >= 5, 0<=x,y<=10."""
+    m = dm.Model("qp_active")
+    x = m.continuous("x", lb=0.0, ub=10.0)
+    y = m.continuous("y", lb=0.0, ub=10.0)
+    m.minimize((x - 0.5) ** 2 + (y - 0.5) ** 2)
+    m.subject_to(x + y >= 5, name="c1")
+
+    res = m.solve()
+    assert res.status == "optimal"
+    assert res.constraint_duals is not None
+    assert res.bound_duals_lower is not None
+
+    # Symmetric → x* = y* = 2.5; ∇f = [2(x-0.5), 2(y-0.5)] = [4, 4].
+    # ">=" with μ ≥ 0 gives 4 - μ = 0 → μ = 4.
+    mu = _scalar("c1", res.constraint_duals)
+    assert mu == pytest.approx(4.0, abs=1e-4)
+
+
+# ── MILP B&B path ───────────────────────────────────────────────────────
+
+
+def test_milp_returns_relaxation_duals_at_incumbent():
+    """min x + 2y, integer, s.t. x+y >= 5. Optimum x=5,y=0 with all-integer
+    fix-and-resolve degenerating to zero free continuous columns; the
+    recovery should still attach a dict (possibly all zeros) without
+    raising."""
+    m = dm.Model("milp")
+    x = m.integer("x", lb=0, ub=10)
+    y = m.integer("y", lb=0, ub=10)
+    m.minimize(x + 2 * y)
+    m.subject_to(x + y >= 5, name="c1")
+
+    res = m.solve()
+    assert res.status == "optimal"
+    assert _scalar("x", res.x) == pytest.approx(5.0, abs=1e-6)
+    assert _scalar("y", res.x) == pytest.approx(0.0, abs=1e-6)
+    # Recovery returns dicts (even if all zero — fully integer fix gives
+    # no free columns; what matters is the plumbing wires through).
+    assert res.constraint_duals is not None
+    assert "c1" in res.constraint_duals
+    assert res.bound_duals_lower is not None
+    assert "x" in res.bound_duals_lower
+    assert "y" in res.bound_duals_lower
+
+
+def test_miqp_returns_relaxation_duals_at_incumbent():
+    """min (x-0.5)^2 + (y-0.5)^2 s.t. x+y >= 5, x cont, y int.
+
+    With y fixed at incumbent (=3), the LP relaxation is min (x-0.5)^2
+    s.t. x >= 2, x in [0,10] → x*=2, μ=3 on the ">=" row.
+    """
+    m = dm.Model("miqp")
+    x = m.continuous("x", lb=0.0, ub=10.0)
+    y = m.integer("y", lb=0, ub=10)
+    m.minimize((x - 0.5) ** 2 + (y - 0.5) ** 2)
+    m.subject_to(x + y >= 5, name="c1")
+
+    res = m.solve()
+    assert res.status == "optimal"
+    assert res.constraint_duals is not None
+    mu = _scalar("c1", res.constraint_duals)
+    assert mu == pytest.approx(3.0, abs=1e-3)
+
+
+# ── validate=True hook ──────────────────────────────────────────────────
+
+
+def test_solve_with_validate_attaches_examiner_report():
+    m = dm.Model("lp_validate")
+    x = m.continuous("x", lb=0.0, ub=10.0)
+    y = m.continuous("y", lb=0.0, ub=10.0)
+    m.minimize(x + 2 * y)
+    m.subject_to(x + y >= 4, name="c1")
+
+    res = m.solve(validate=True)
+    assert res.validation_report is not None
+    rep = res.validation_report
+    assert rep.passed, rep.summary(verbose=True)
+    # The solver-duals branch should have run, since the LP fast path
+    # populated constraint_duals.
+    assert rep.solver_duals_used
+
+
+def test_solve_without_validate_leaves_report_none():
+    m = dm.Model("lp_no_validate")
+    x = m.continuous("x", lb=0.0, ub=10.0)
+    m.minimize(x)
+    m.subject_to(x >= 1, name="c1")
+    res = m.solve()
+    assert res.validation_report is None
+
+
+def test_validate_true_on_milp_attaches_report():
+    m = dm.Model("milp_validate")
+    x = m.integer("x", lb=0, ub=10)
+    y = m.integer("y", lb=0, ub=10)
+    m.minimize(x + 2 * y)
+    m.subject_to(x + y >= 5, name="c1")
+
+    res = m.solve(validate=True)
+    assert res.validation_report is not None
+    # We don't assert .passed — pure-integer fix-and-resolve degenerates;
+    # the contract is that the report exists and primal checks pass.
+    rep = res.validation_report
+    primal = [c for c in rep.checks if c.name.startswith("primal_")]
+    assert primal, "expected at least one primal check"
+    assert all(c.passed for c in primal), rep.summary(verbose=True)


### PR DESCRIPTION
Summary:
- Merge current `upstream/main` into the fork `amp` branch.
- Bring in upstream deadline handling, solver dual plumbing, benchmark runner updates, and the course/tutor materials.
- Resolve conflicts in CI triggers, PR-fast Makefile flags, dev dependencies, and `Model.solve` by preserving `amp` branch behavior while adding upstream changes.

Conflict notes:
- CI now still runs for `main` and `amp` branches and also keeps upstream's nightly schedule.
- PR-fast Makefile flags keep the `amp` branch exclusions and add upstream xdist `loadgroup` parallelism using the existing bounded `PYTEST_XDIST_WORKERS` setting.
- `dev` extras keep both `pytest-xdist` and `pre-commit`.
- `Model.solve` keeps the `solver=` forwarding used by `amp` and wraps the dispatch in upstream's `deadline_scope`.

Tests run:
- `/tmp/discopt-issue91/.venv/bin/python -m ruff check python/` -> passed.
- `/tmp/discopt-issue91/.venv/bin/python -m ruff format --check python/` -> passed, 283 files already formatted.
- `cargo test -p discopt-core` -> passed, 250 unit tests, 4 integration tests, 1 doc test.
- `/tmp/discopt-issue91/.venv/bin/python -m mypy python/discopt/` -> passed, no issues found in 173 source files.
- `PYTHONPATH=python /tmp/discopt-issue91/.venv/bin/python -m pytest python/tests/test_solver_duals.py python/tests/test_deadline.py python/tests/test_cli_tutor.py -q --tb=short` -> 53 passed, 6 skipped.

Notes:
- The broad PR-fast `make test` was not run locally for this large upstream sync; CI should run it on the PR.
- `git diff --check --cached` reports blank-line-at-EOF warnings in upstream-added course rubric markdown files. I left those unchanged to avoid adding cleanup noise to the upstream sync merge.
