### PR TITLE
Add Gurobi LP/MILP backend

### DIFF
--- a/python/discopt/modeling/core.py
+++ b/python/discopt/modeling/core.py
@@ -2782,6 +2782,12 @@ class Model:
             ``convhull_ebd_encoding``, ``use_start_as_incumbent``,
             ``obbt_at_root``, ``obbt_with_cutoff``, ``alphabb_cutoff_obbt``,
             and ``obbt_time_limit``.
+            Use ``solver="gurobi"`` to select the optional Gurobi backend for
+            LP and MILP models. Stage-1 Gurobi support is intentionally limited
+            to linear continuous and mixed-integer models; unsupported model
+            classes raise ``NotImplementedError`` instead of silently falling
+            back to another backend. Pass Gurobi parameters through
+            ``gurobi_options={...}``.
         validate : bool, default False
             If True, run Examiner-style KKT validation on the returned
             point and attach the :class:`~discopt.validation.ExaminerReport`

--- a/python/discopt/solver.py
+++ b/python/discopt/solver.py
@@ -7962,14 +7962,16 @@ def _solve_milp_gurobi(
         if sense == ObjectiveSense.MAXIMIZE:
             objective = -objective
 
-    # For a maximization solved as internal minimization, a non-optimal Gurobi
-    # ObjBound is an upper bound in the user's original sense, not discopt's
-    # lower-bound field. Keep it only for proven optima.
+    # ``result.bound`` is a valid lower bound for the internal minimization.
+    # Map it back to the original sense: lower bound for minimize, upper bound
+    # for maximize (matching discopt's existing SolveResult convention).
     bound = None
     if result.status == SolveStatus.OPTIMAL and objective is not None:
         bound = objective
-    elif sense == ObjectiveSense.MINIMIZE and result.bound is not None:
+    elif result.bound is not None:
         bound = float(result.bound) + float(lp_data.obj_const)
+        if sense == ObjectiveSense.MAXIMIZE:
+            bound = -bound
 
     if result.status == SolveStatus.OPTIMAL:
         assert result.x is not None and objective is not None

--- a/python/discopt/solver.py
+++ b/python/discopt/solver.py
@@ -2131,6 +2131,10 @@ def solve_model(
     solver : str or None, default None
         Optional global-solver selector. Use ``"amp"`` to dispatch to
         Adaptive Multivariate Partitioning instead of branch-and-bound.
+        Use ``"gurobi"`` to dispatch LP/MILP models to the optional Gurobi
+        backend. Stage-1 Gurobi support is intentionally limited to linear
+        continuous and mixed-integer models; unsupported classes raise a clear
+        ``NotImplementedError`` instead of falling back silently.
         Use ``"gp"`` to dispatch to the geometric-programming fast path:
         the model is checked for GP structure (posynomial/monomial
         objective and constraints over strictly-positive continuous
@@ -2264,12 +2268,15 @@ def solve_model(
     # --- AMP (Adaptive Multivariate Partitioning) global solver ---
     _solver = solver if solver is not None else kwargs.pop("solver", None)
     # Recognised global-solver selectors: ``None`` (default branch-and-bound,
-    # with the automatic GP fast path below), ``"amp"``, ``"gp"`` (force the GP
-    # log-space path), and ``"bb"`` (force classic branch-and-bound, opting out
-    # of the automatic GP fast path). Reject anything else rather than silently
-    # falling through to B&B.
-    if _solver not in (None, "amp", "gp", "bb"):
-        raise ValueError(f"Unknown solver={_solver!r}. Choose one of None, 'amp', 'gp', 'bb'.")
+    # with the automatic GP fast path below), ``"amp"``, ``"gurobi"``,
+    # ``"gp"`` (force the GP log-space path), and ``"bb"`` (force classic
+    # branch-and-bound, opting out of the automatic GP fast path). Reject
+    # anything else rather than silently falling through to B&B.
+    if _solver not in (None, "amp", "gurobi", "gp", "bb"):
+        raise ValueError(
+            f"Unknown solver={_solver!r}. Choose one of None, 'amp', 'gurobi', 'gp', 'bb'."
+        )
+    gurobi_options = kwargs.pop("gurobi_options", None) if _solver == "gurobi" else None
     if _solver == "amp":
         import warnings
 
@@ -2956,6 +2963,23 @@ def solve_model(
     except Exception as e:
         logger.debug("Problem classification failed: %s", e)
         problem_class = None
+
+    if _solver == "gurobi":
+        if problem_class is None:
+            raise NotImplementedError(
+                "solver='gurobi' requires problem classification and currently "
+                "supports LP and MILP models only."
+            )
+        if problem_class == ProblemClass.LP:
+            return _solve_lp_gurobi(model, t_start, time_limit, threads, gurobi_options)
+        if problem_class == ProblemClass.MILP:
+            return _solve_milp_gurobi(
+                model, t_start, time_limit, gap_tolerance, threads, gurobi_options
+            )
+        raise NotImplementedError(
+            f"solver='gurobi' stage 1 supports LP and MILP models only; "
+            f"classified this model as {problem_class.value!r}."
+        )
 
     _pure_continuous_force_spatial = False
     if problem_class is not None:
@@ -7424,12 +7448,39 @@ def _solve_lp_pounce(
     return _solve_lp_matrix(model, t_start, time_limit, solve_fn, "POUNCE")
 
 
+def _solve_lp_gurobi(
+    model: Model,
+    t_start: float,
+    time_limit: float | None = None,
+    threads: int | None = None,
+    options: Optional[dict] = None,
+) -> SolveResult:
+    """Solve an LP using the explicit Gurobi backend."""
+    import functools
+
+    from discopt.solvers.gurobi import solve_lp as _gurobi_solve_lp
+
+    solve_fn = functools.partial(_gurobi_solve_lp, threads=threads, options=options)
+    result = _solve_lp_matrix(
+        model,
+        t_start,
+        time_limit,
+        solve_fn,
+        "Gurobi",
+        strict=True,
+    )
+    if result is None:  # pragma: no cover - strict mode raises before this
+        raise RuntimeError("Gurobi LP solve failed without returning a result.")
+    return result
+
+
 def _solve_lp_matrix(
     model: Model,
     t_start: float,
     time_limit: float | None,
     solve_lp_fn,
     engine: str,
+    strict: bool = False,
 ) -> SolveResult | None:
     """Solve a pure LP through a matrix-form ``solve_lp`` backend.
 
@@ -7467,6 +7518,8 @@ def _solve_lp_matrix(
             time_limit=time_limit,
         )
     except Exception as e:
+        if strict:
+            raise
         logger.debug("%s LP solve failed: %s", engine, e)
         return None
 
@@ -7846,6 +7899,132 @@ def _solve_milp_highs(
         return SolveResult(status="time_limit", wall_time=wall_time, node_count=result.node_count)
 
     return None
+
+
+def _solve_milp_gurobi(
+    model: Model,
+    t_start: float,
+    time_limit: float | None = None,
+    gap_tolerance: float = 1e-4,
+    threads: int | None = None,
+    options: Optional[dict] = None,
+) -> SolveResult:
+    """Solve a MILP using the explicit Gurobi backend."""
+    from discopt._jax.problem_classifier import extract_lp_data
+    from discopt.modeling.core import ObjectiveSense
+    from discopt.solvers import SolveStatus
+    from discopt.solvers.gurobi import solve_milp as _gurobi_solve_milp
+
+    lp_data = extract_lp_data(model)
+    n_orig = sum(v.size for v in model._variables)
+
+    bounds = list(
+        zip(
+            np.asarray(lp_data.x_l[:n_orig]).tolist(),
+            np.asarray(lp_data.x_u[:n_orig]).tolist(),
+        )
+    )
+
+    n_total = lp_data.A_eq.shape[1] if lp_data.A_eq.shape[0] > 0 else n_orig
+    n_slack = n_total - n_orig
+    A_eq_full = np.asarray(lp_data.A_eq)
+    b_eq_full = np.asarray(lp_data.b_eq)
+    A_ub, b_ub, A_eq, b_eq = _decompose_eq_slack_form(A_eq_full, b_eq_full, n_orig, n_slack)
+
+    int_arr = np.zeros(n_orig, dtype=np.int32)
+    offset = 0
+    for v in model._variables:
+        if v.var_type in (VarType.BINARY, VarType.INTEGER):
+            int_arr[offset : offset + v.size] = 1
+        offset += v.size
+
+    result = _gurobi_solve_milp(
+        c=np.asarray(lp_data.c[:n_orig]),
+        A_ub=A_ub,
+        b_ub=b_ub,
+        A_eq=A_eq,
+        b_eq=b_eq,
+        bounds=bounds,
+        integrality=int_arr,
+        time_limit=time_limit,
+        gap_tolerance=gap_tolerance,
+        threads=threads,
+        options=options,
+    )
+
+    wall_time = time.perf_counter() - t_start
+    assert model._objective is not None
+    sense = model._objective.sense
+
+    objective = None
+    if result.objective is not None:
+        objective = float(result.objective) + float(lp_data.obj_const)
+        if sense == ObjectiveSense.MAXIMIZE:
+            objective = -objective
+
+    # For a maximization solved as internal minimization, a non-optimal Gurobi
+    # ObjBound is an upper bound in the user's original sense, not discopt's
+    # lower-bound field. Keep it only for proven optima.
+    bound = None
+    if result.status == SolveStatus.OPTIMAL and objective is not None:
+        bound = objective
+    elif sense == ObjectiveSense.MINIMIZE and result.bound is not None:
+        bound = float(result.bound) + float(lp_data.obj_const)
+
+    if result.status == SolveStatus.OPTIMAL:
+        assert result.x is not None and objective is not None
+        cd, bdl, bdu = _mip_recover_relaxation_duals(
+            model,
+            lp_data=lp_data,
+            x_flat=np.asarray(result.x[:n_orig], dtype=float),
+            n_orig=n_orig,
+            A_ub=A_ub,
+            b_ub=b_ub,
+            A_eq=A_eq,
+            b_eq=b_eq,
+            time_limit=time_limit,
+        )
+        return SolveResult(
+            status="optimal",
+            objective=objective,
+            bound=bound,
+            gap=result.gap if result.gap is not None else 0.0,
+            x=_unpack_solution(model, result.x[:n_orig]),
+            wall_time=wall_time,
+            node_count=result.node_count,
+            rust_time=0.0,
+            jax_time=0.0,
+            python_time=wall_time,
+            constraint_duals=cd,
+            bound_duals_lower=bdl,
+            bound_duals_upper=bdu,
+        )
+
+    if result.status == SolveStatus.INFEASIBLE:
+        return SolveResult(status="infeasible", wall_time=wall_time, node_count=result.node_count)
+    if result.status == SolveStatus.UNBOUNDED:
+        return SolveResult(status="unbounded", wall_time=wall_time, node_count=result.node_count)
+    if result.status == SolveStatus.TIME_LIMIT:
+        return SolveResult(
+            status="time_limit",
+            objective=objective,
+            bound=bound,
+            gap=result.gap,
+            x=_unpack_solution(model, result.x[:n_orig]) if result.x is not None else None,
+            wall_time=wall_time,
+            node_count=result.node_count,
+        )
+    if result.status == SolveStatus.ITERATION_LIMIT:
+        return SolveResult(
+            status="iteration_limit",
+            objective=objective,
+            bound=bound,
+            gap=result.gap,
+            x=_unpack_solution(model, result.x[:n_orig]) if result.x is not None else None,
+            wall_time=wall_time,
+            node_count=result.node_count,
+        )
+    return SolveResult(status="error", wall_time=wall_time, node_count=result.node_count)
 
 
 def _solve_qp_jax(model: Model, t_start: float) -> SolveResult:

--- a/python/discopt/solvers/gurobi.py
+++ b/python/discopt/solvers/gurobi.py
@@ -1,0 +1,342 @@
+"""Gurobi LP/MILP solver wrappers.
+
+This module mirrors the matrix-form HiGHS wrappers: callers pass extracted
+standard-form arrays and receive discopt result dataclasses. ``gurobipy`` stays
+optional and is imported only inside the solver path.
+"""
+
+from __future__ import annotations
+
+from typing import Optional, Union
+
+import numpy as np
+import scipy.sparse as sp
+
+from discopt.solvers import LPResult, MILPResult, SolveStatus
+
+_FINITE_BOUND_THRESHOLD = 1e15
+
+
+def _load_gurobi():
+    try:
+        import gurobipy as gp
+        from gurobipy import GRB
+    except ImportError as exc:
+        raise ImportError(
+            "gurobipy is required for solver='gurobi'. Install gurobipy and "
+            "configure a working Gurobi license."
+        ) from exc
+    return gp, GRB
+
+
+def _to_csr(A: Union[np.ndarray, sp.spmatrix]) -> sp.csr_matrix:
+    if sp.issparse(A):
+        return sp.csr_matrix(A, dtype=np.float64)
+    return sp.csr_matrix(np.asarray(A, dtype=np.float64))
+
+
+def _validate_linear_data(
+    c: np.ndarray,
+    A_ub: Optional[Union[np.ndarray, sp.spmatrix]],
+    b_ub: Optional[np.ndarray],
+    A_eq: Optional[Union[np.ndarray, sp.spmatrix]],
+    b_eq: Optional[np.ndarray],
+    bounds: Optional[list[tuple[float, float]]],
+) -> tuple[np.ndarray, int]:
+    c_arr = np.asarray(c, dtype=np.float64).ravel()
+    n = len(c_arr)
+
+    if A_ub is not None:
+        shape = A_ub.shape if sp.issparse(A_ub) else np.asarray(A_ub).shape
+        if len(shape) != 2 or shape[1] != n:
+            raise ValueError(f"A_ub has {shape[1]} columns but c has {n} elements")
+        if b_ub is None:
+            raise ValueError("b_ub is required when A_ub is provided")
+        if np.asarray(b_ub).ravel().shape[0] != shape[0]:
+            raise ValueError(f"A_ub has {shape[0]} rows but b_ub has wrong length")
+
+    if A_eq is not None:
+        shape = A_eq.shape if sp.issparse(A_eq) else np.asarray(A_eq).shape
+        if len(shape) != 2 or shape[1] != n:
+            raise ValueError(f"A_eq has {shape[1]} columns but c has {n} elements")
+        if b_eq is None:
+            raise ValueError("b_eq is required when A_eq is provided")
+        if np.asarray(b_eq).ravel().shape[0] != shape[0]:
+            raise ValueError(f"A_eq has {shape[0]} rows but b_eq has wrong length")
+
+    if bounds is not None and len(bounds) != n:
+        raise ValueError(f"bounds has {len(bounds)} entries but c has {n} elements")
+
+    return c_arr, n
+
+
+def _normalise_bounds(
+    bounds: Optional[list[tuple[float, float]]],
+    n: int,
+    inf: float,
+) -> tuple[np.ndarray, np.ndarray]:
+    if bounds is None:
+        lb = np.zeros(n, dtype=np.float64)
+        ub = np.full(n, inf, dtype=np.float64)
+    else:
+        lb = np.array([lo for lo, _ in bounds], dtype=np.float64)
+        ub = np.array([hi for _, hi in bounds], dtype=np.float64)
+
+    lb = np.where(lb <= -_FINITE_BOUND_THRESHOLD, -inf, lb)
+    ub = np.where(ub >= _FINITE_BOUND_THRESHOLD, inf, ub)
+    return lb, ub
+
+
+def _status_map(GRB) -> dict[int, SolveStatus]:
+    mapping = {
+        GRB.OPTIMAL: SolveStatus.OPTIMAL,
+        GRB.INFEASIBLE: SolveStatus.INFEASIBLE,
+        GRB.UNBOUNDED: SolveStatus.UNBOUNDED,
+        GRB.ITERATION_LIMIT: SolveStatus.ITERATION_LIMIT,
+        GRB.TIME_LIMIT: SolveStatus.TIME_LIMIT,
+    }
+    for name in ("NODE_LIMIT", "SOLUTION_LIMIT"):
+        code = getattr(GRB, name, None)
+        if code is not None:
+            mapping[code] = SolveStatus.ITERATION_LIMIT
+    return mapping
+
+
+def _optimize(model, GRB) -> int:
+    model.optimize()
+    status = int(model.Status)
+    if status == GRB.INF_OR_UNBD:
+        model.setParam("DualReductions", 0)
+        model.optimize()
+        status = int(model.Status)
+    return status
+
+
+def _set_common_params(model, time_limit, threads, options) -> None:
+    model.setParam("OutputFlag", 0)
+    if time_limit is not None:
+        model.setParam("TimeLimit", float(time_limit))
+    if threads is not None:
+        model.setParam("Threads", int(threads))
+    if options:
+        for key, value in options.items():
+            model.setParam(str(key), value)
+
+
+def _safe_attr(obj, name: str):
+    try:
+        return getattr(obj, name)
+    except Exception:
+        return None
+
+
+def _build_model(
+    gp,
+    GRB,
+    *,
+    name: str,
+    c: np.ndarray,
+    A_ub,
+    b_ub,
+    A_eq,
+    b_eq,
+    bounds,
+    integrality,
+    time_limit,
+    gap_tolerance,
+    threads,
+    options,
+):
+    env = gp.Env(empty=True)
+    try:
+        env.setParam("OutputFlag", 0)
+        env.start()
+        model = gp.Model(name, env=env)
+    except Exception:
+        env.dispose()
+        raise
+
+    _set_common_params(model, time_limit, threads, options)
+    if gap_tolerance is not None:
+        model.setParam("MIPGap", float(gap_tolerance))
+
+    lb, ub = _normalise_bounds(bounds, len(c), GRB.INFINITY)
+
+    vtype = GRB.CONTINUOUS
+    if integrality is not None:
+        int_arr = np.asarray(integrality, dtype=np.int32).ravel()
+        if int_arr.shape[0] != len(c):
+            model.dispose()
+            env.dispose()
+            raise ValueError(f"integrality has {int_arr.shape[0]} entries but c has {len(c)}")
+        vtype = []
+        for is_int, lo, hi in zip(int_arr == 1, lb, ub):
+            if not is_int:
+                vtype.append(GRB.CONTINUOUS)
+            elif lo == 0 and hi == 1:
+                vtype.append(GRB.BINARY)
+            else:
+                vtype.append(GRB.INTEGER)
+
+    x = model.addMVar(shape=len(c), lb=lb, ub=ub, vtype=vtype, name="x")
+    model.setObjective(c @ x, GRB.MINIMIZE)
+
+    ub_con = None
+    eq_con = None
+    if A_ub is not None and b_ub is not None:
+        A_ub_csr = _to_csr(A_ub)
+        b_ub_arr = np.asarray(b_ub, dtype=np.float64).ravel()
+        if b_ub_arr.size:
+            ub_con = model.addConstr(A_ub_csr @ x <= b_ub_arr, name="ub")
+    if A_eq is not None and b_eq is not None:
+        A_eq_csr = _to_csr(A_eq)
+        b_eq_arr = np.asarray(b_eq, dtype=np.float64).ravel()
+        if b_eq_arr.size:
+            eq_con = model.addConstr(A_eq_csr @ x == b_eq_arr, name="eq")
+
+    return env, model, x, ub_con, eq_con
+
+
+def solve_lp(
+    c: np.ndarray,
+    A_ub: Optional[Union[np.ndarray, sp.spmatrix]] = None,
+    b_ub: Optional[np.ndarray] = None,
+    A_eq: Optional[Union[np.ndarray, sp.spmatrix]] = None,
+    b_eq: Optional[np.ndarray] = None,
+    bounds: Optional[list[tuple[float, float]]] = None,
+    warm_basis: Optional[object] = None,
+    time_limit: Optional[float] = None,
+    threads: Optional[int] = None,
+    options: Optional[dict] = None,
+) -> LPResult:
+    """Solve a linear program using Gurobi."""
+    if warm_basis is not None:
+        raise NotImplementedError("Gurobi LP warm-start basis support is not implemented yet.")
+
+    c_arr, _n = _validate_linear_data(c, A_ub, b_ub, A_eq, b_eq, bounds)
+    gp, GRB = _load_gurobi()
+
+    env, model, x, ub_con, eq_con = _build_model(
+        gp,
+        GRB,
+        name="discopt_lp",
+        c=c_arr,
+        A_ub=A_ub,
+        b_ub=b_ub,
+        A_eq=A_eq,
+        b_eq=b_eq,
+        bounds=bounds,
+        integrality=None,
+        time_limit=time_limit,
+        gap_tolerance=None,
+        threads=threads,
+        options=options,
+    )
+    try:
+        status_code = _optimize(model, GRB)
+        status = _status_map(GRB).get(status_code, SolveStatus.ERROR)
+        iters = int(_safe_attr(model, "IterCount") or 0)
+        wall_time = float(_safe_attr(model, "Runtime") or 0.0)
+
+        if status == SolveStatus.OPTIMAL:
+            row_duals = []
+            if ub_con is not None:
+                pi = _safe_attr(ub_con, "Pi")
+                if pi is not None:
+                    row_duals.extend(np.asarray(pi, dtype=np.float64).ravel().tolist())
+            if eq_con is not None:
+                pi = _safe_attr(eq_con, "Pi")
+                if pi is not None:
+                    row_duals.extend(np.asarray(pi, dtype=np.float64).ravel().tolist())
+            rc = _safe_attr(x, "RC")
+            reduced_costs = np.asarray(rc, dtype=np.float64).ravel() if rc is not None else None
+            return LPResult(
+                status=status,
+                x=np.asarray(x.X, dtype=np.float64).ravel(),
+                objective=float(model.ObjVal),
+                dual_values=np.asarray(row_duals, dtype=np.float64) if row_duals else None,
+                reduced_costs=reduced_costs,
+                iterations=iters,
+                wall_time=wall_time,
+            )
+
+        return LPResult(status=status, iterations=iters, wall_time=wall_time)
+    finally:
+        model.dispose()
+        env.dispose()
+
+
+def solve_milp(
+    c: np.ndarray,
+    A_ub: Optional[Union[np.ndarray, sp.spmatrix]] = None,
+    b_ub: Optional[np.ndarray] = None,
+    A_eq: Optional[Union[np.ndarray, sp.spmatrix]] = None,
+    b_eq: Optional[np.ndarray] = None,
+    bounds: Optional[list[tuple[float, float]]] = None,
+    integrality: Optional[np.ndarray] = None,
+    time_limit: Optional[float] = None,
+    gap_tolerance: float = 1e-4,
+    threads: Optional[int] = None,
+    options: Optional[dict] = None,
+) -> MILPResult:
+    """Solve a mixed-integer linear program using Gurobi."""
+    c_arr, _n = _validate_linear_data(c, A_ub, b_ub, A_eq, b_eq, bounds)
+    gp, GRB = _load_gurobi()
+
+    env, model, x, _ub_con, _eq_con = _build_model(
+        gp,
+        GRB,
+        name="discopt_milp",
+        c=c_arr,
+        A_ub=A_ub,
+        b_ub=b_ub,
+        A_eq=A_eq,
+        b_eq=b_eq,
+        bounds=bounds,
+        integrality=integrality,
+        time_limit=time_limit,
+        gap_tolerance=gap_tolerance,
+        threads=threads,
+        options=options,
+    )
+    try:
+        status_code = _optimize(model, GRB)
+        status = _status_map(GRB).get(status_code, SolveStatus.ERROR)
+        node_count = int(_safe_attr(model, "NodeCount") or 0)
+        wall_time = float(_safe_attr(model, "Runtime") or 0.0)
+
+        objective = None
+        x_val = None
+        if int(_safe_attr(model, "SolCount") or 0) > 0:
+            objective = float(model.ObjVal)
+            x_val = np.asarray(x.X, dtype=np.float64).ravel()
+
+        bound = _safe_attr(model, "ObjBound")
+        bound = float(bound) if bound is not None and np.isfinite(bound) else None
+        gap = _safe_attr(model, "MIPGap")
+        gap = float(gap) if gap is not None and np.isfinite(gap) else None
+
+        if status == SolveStatus.OPTIMAL:
+            assert objective is not None and x_val is not None
+            return MILPResult(
+                status=status,
+                x=x_val,
+                objective=objective,
+                bound=objective if bound is None else bound,
+                gap=0.0 if gap is None else gap,
+                node_count=node_count,
+                wall_time=wall_time,
+            )
+
+        return MILPResult(
+            status=status,
+            x=x_val,
+            objective=objective,
+            bound=bound,
+            gap=gap,
+            node_count=node_count,
+            wall_time=wall_time,
+        )
+    finally:
+        model.dispose()
+        env.dispose()

--- a/python/tests/test_gurobi_backend.py
+++ b/python/tests/test_gurobi_backend.py
@@ -1,0 +1,181 @@
+"""Tests for the optional Gurobi LP/MILP backend."""
+
+from __future__ import annotations
+
+import sys
+import types
+
+import discopt.modeling as dm
+import numpy as np
+import pytest
+from discopt.modeling.core import SolveResult
+from discopt.solvers import SolveStatus
+from discopt.solvers import gurobi as gurobi_backend
+
+
+def _install_fake_rust_classifier(monkeypatch, problem_kind: str) -> None:
+    """Install just enough of discopt._rust for solver dispatch tests.
+
+    The local source worktree used by these tests may not have a compiled PyO3
+    extension, while CI builds it before running the broader suite.
+    """
+
+    class _FakeRepr:
+        n_constraints = 0
+
+        def is_objective_linear(self):
+            return problem_kind in {"lp", "milp"}
+
+        def is_objective_quadratic(self):
+            return problem_kind == "qp"
+
+        def is_constraint_linear(self, _idx):
+            return True
+
+    fake_rust = types.SimpleNamespace(
+        PyTreeManager=object,
+        model_to_repr=lambda _model, _builder=None: _FakeRepr(),
+    )
+    monkeypatch.setitem(sys.modules, "discopt._rust", fake_rust)
+
+
+def _require_gurobi():
+    gp = pytest.importorskip("gurobipy")
+    try:
+        env = gp.Env(empty=True)
+        env.setParam("OutputFlag", 0)
+        env.start()
+        env.dispose()
+    except Exception as exc:
+        pytest.skip(f"Gurobi is installed but no usable license is available: {exc}")
+
+
+def test_gurobi_lp_validates_dimensions_without_importing_gurobipy():
+    with pytest.raises(ValueError, match="columns"):
+        gurobi_backend.solve_lp(
+            c=np.array([1.0, 2.0]),
+            A_ub=np.array([[1.0, 2.0, 3.0]]),
+            b_ub=np.array([1.0]),
+        )
+
+
+def test_gurobi_lp_reports_missing_gurobipy(monkeypatch):
+    monkeypatch.setitem(sys.modules, "gurobipy", None)
+    with pytest.raises(ImportError, match="gurobipy is required"):
+        gurobi_backend.solve_lp(c=np.array([1.0]), bounds=[(0.0, 1.0)])
+
+
+def test_model_solve_gurobi_dispatches_lp(monkeypatch):
+    _install_fake_rust_classifier(monkeypatch, "lp")
+    import discopt.solver as solver
+
+    calls = {}
+
+    def fake_gurobi_lp(model, t_start, time_limit=None, threads=None, options=None):
+        calls["model"] = model
+        calls["time_limit"] = time_limit
+        calls["threads"] = threads
+        calls["options"] = options
+        return SolveResult(status="optimal", objective=1.0, bound=1.0, gap=0.0)
+
+    monkeypatch.setattr(solver, "_solve_lp_gurobi", fake_gurobi_lp)
+
+    m = dm.Model("lp_dispatch_gurobi")
+    x = m.continuous("x", lb=0, ub=5)
+    m.minimize(x + 1)
+
+    result = m.solve(
+        solver="gurobi",
+        time_limit=12.0,
+        threads=3,
+        gurobi_options={"Method": 1},
+    )
+
+    assert result.status == "optimal"
+    assert calls["model"] is m
+    assert calls["time_limit"] == 12.0
+    assert calls["threads"] == 3
+    assert calls["options"] == {"Method": 1}
+
+
+def test_model_solve_gurobi_dispatches_milp(monkeypatch):
+    _install_fake_rust_classifier(monkeypatch, "milp")
+    import discopt.solver as solver
+
+    calls = {}
+
+    def fake_gurobi_milp(
+        model,
+        t_start,
+        time_limit=None,
+        gap_tolerance=1e-4,
+        threads=None,
+        options=None,
+    ):
+        calls["model"] = model
+        calls["gap_tolerance"] = gap_tolerance
+        calls["threads"] = threads
+        calls["options"] = options
+        return SolveResult(status="optimal", objective=2.0, bound=2.0, gap=0.0)
+
+    monkeypatch.setattr(solver, "_solve_milp_gurobi", fake_gurobi_milp)
+
+    m = dm.Model("milp_dispatch_gurobi")
+    y = m.integer("y", lb=0, ub=2)
+    m.minimize(y)
+
+    result = m.solve(
+        solver="gurobi",
+        gap_tolerance=1e-5,
+        threads=2,
+        gurobi_options={"MIPFocus": 1},
+    )
+
+    assert result.status == "optimal"
+    assert calls["model"] is m
+    assert calls["gap_tolerance"] == 1e-5
+    assert calls["threads"] == 2
+    assert calls["options"] == {"MIPFocus": 1}
+
+
+def test_model_solve_gurobi_rejects_qp_for_stage_one(monkeypatch):
+    _install_fake_rust_classifier(monkeypatch, "qp")
+    m = dm.Model("qp_rejected_by_gurobi_stage_one")
+    x = m.continuous("x", lb=0, ub=2)
+    m.minimize(x**2)
+
+    with pytest.raises(NotImplementedError, match="LP and MILP"):
+        m.solve(solver="gurobi")
+
+
+def test_gurobi_lp_smoke_if_available():
+    _require_gurobi()
+
+    result = gurobi_backend.solve_lp(
+        c=np.array([-1.0, -2.0]),
+        A_ub=np.array([[1.0, 1.0]]),
+        b_ub=np.array([10.0]),
+        bounds=[(0.0, float("inf")), (0.0, float("inf"))],
+    )
+
+    assert result.status == SolveStatus.OPTIMAL
+    assert result.x is not None
+    np.testing.assert_allclose(result.x, [0.0, 10.0], atol=1e-6)
+    assert result.objective == pytest.approx(-20.0)
+
+
+def test_gurobi_milp_smoke_if_available():
+    _require_gurobi()
+
+    result = gurobi_backend.solve_milp(
+        c=np.array([-1.0, -2.0]),
+        A_ub=np.array([[1.0, 1.0]]),
+        b_ub=np.array([4.0]),
+        bounds=[(0.0, 4.0), (0.0, 4.0)],
+        integrality=np.array([0, 1], dtype=np.int32),
+    )
+
+    assert result.status == SolveStatus.OPTIMAL
+    assert result.x is not None
+    np.testing.assert_allclose(result.x, [0.0, 4.0], atol=1e-6)
+    assert result.objective == pytest.approx(-8.0)

--- a/python/tests/test_gurobi_backend.py
+++ b/python/tests/test_gurobi_backend.py
@@ -9,7 +9,7 @@ import discopt.modeling as dm
 import numpy as np
 import pytest
 from discopt.modeling.core import SolveResult
-from discopt.solvers import SolveStatus
+from discopt.solvers import MILPResult, SolveStatus
 from discopt.solvers import gurobi as gurobi_backend
 
 
@@ -146,6 +146,46 @@ def test_model_solve_gurobi_rejects_qp_for_stage_one(monkeypatch):
 
     with pytest.raises(NotImplementedError, match="LP and MILP"):
         m.solve(solver="gurobi")
+
+
+def test_gurobi_milp_maximize_time_limit_maps_dual_bound(monkeypatch):
+    _install_fake_rust_classifier(monkeypatch, "milp")
+    import discopt.solver as solver
+    from discopt._jax import problem_classifier
+
+    m = dm.Model("gurobi_max_milp_bound_mapping")
+    y = m.integer("y", lb=0, ub=10)
+    m.maximize(y)
+
+    lp_data = problem_classifier.LPData(
+        c=np.array([-1.0]),
+        A_eq=np.zeros((0, 1)),
+        b_eq=np.zeros(0),
+        x_l=np.array([0.0]),
+        x_u=np.array([10.0]),
+        obj_const=0.0,
+    )
+    monkeypatch.setattr(problem_classifier, "extract_lp_data", lambda _model: lp_data)
+
+    def fake_solve_milp(**_kwargs):
+        return MILPResult(
+            status=SolveStatus.TIME_LIMIT,
+            x=np.array([8.0]),
+            objective=-8.0,
+            bound=-10.0,
+            gap=0.25,
+            node_count=7,
+        )
+
+    monkeypatch.setattr(gurobi_backend, "solve_milp", fake_solve_milp)
+
+    result = solver._solve_milp_gurobi(m, t_start=0.0, time_limit=1.0)
+
+    assert result.status == "time_limit"
+    assert result.objective == pytest.approx(8.0)
+    assert result.bound == pytest.approx(10.0)
+    assert result.gap == pytest.approx(0.25)
+    assert result.node_count == 7
 
 
 def test_gurobi_lp_smoke_if_available():


### PR DESCRIPTION
## Summary

Closes #99.

Adds the stage-1 optional Gurobi backend for LP and MILP models:

- adds `python/discopt/solvers/gurobi.py` as a thin matrix-form LP/MILP wrapper analogous to the existing HiGHS wrappers;
- supports explicit `model.solve(solver="gurobi")` for `ProblemClass.LP` and `ProblemClass.MILP`;
- keeps `gurobipy` optional and imported only inside the Gurobi backend path;
- maps Gurobi statuses/objective/solution/bound/gap/node count into existing discopt result dataclasses;
- rejects unsupported model classes with `NotImplementedError` instead of silently falling back to another backend;
- adds `gurobi_options={...}` pass-through for Gurobi parameters and forwards `threads`, `time_limit`, and `gap_tolerance`.

## Tests

- `PYTHONPATH=python pytest python/tests/test_gurobi_backend.py -q`
  - `5 passed, 2 skipped`
  - the skipped tests require a working Gurobi install/license
- `PYTHONPATH=python pytest python/tests/test_lp_highs.py -q`
  - `20 passed`
- `python -m ruff check python/discopt/solvers/gurobi.py python/discopt/solver.py python/discopt/modeling/core.py python/tests/test_gurobi_backend.py`
  - passed
- `python -m ruff format --check python/discopt/solvers/gurobi.py python/discopt/solver.py python/discopt/modeling/core.py python/tests/test_gurobi_backend.py`
  - passed
- `python -m mypy python/discopt --ignore-missing-imports`
  - passed, with existing notes about unchecked untyped function bodies

Pre-commit note: the local hook-managed mypy environment failed before checking project code because it pulled NumPy stubs containing Python 3.12 `type` statement syntax while this repo configures mypy with `python_version = "3.10"`. I ran the repository mypy command manually and committed with only that hook skipped; Ruff hook and format hook passed.

## Branch Hygiene

- PR base branch: `gurobi`
- PR source branch: `fix/issue-99-gurobi-lp-milp`
- Source branch point: `origin/gurobi @ e76b88c`
- Stacked status: fork-local staged development branch for the Gurobi effort; this PR targets `bernalde/discopt:gurobi` by issue policy, not `main`
- Prerequisite PRs: none
- Later upstream path: after staged Gurobi work is complete, `bernalde:gurobi` should become the source branch for the upstream PR into `jkitchin/discopt:main`

## Notes

This PR intentionally does not add QP, MIQP, quadratic-constraint, or nonlinear/MINLP Gurobi support. Those are tracked in the later staged issues.

