### PR TITLE
Add Gurobi QCP and MIQCP backend support

### DIFF
--- a/python/discopt/_jax/problem_classifier.py
+++ b/python/discopt/_jax/problem_classifier.py
@@ -1,5 +1,6 @@
 """
-Problem classification and standard-form extraction for LP, QP, MILP, MIQP, NLP, MINLP.
+Problem classification and standard-form extraction for LP, QP, QCP, MILP,
+MIQP, MIQCP, NLP, MINLP.
 
 Uses existing Rust structure detection (is_linear, is_quadratic) via PyO3 bindings
 to classify problems, then extracts standard-form data using the JAX DAG compiler.
@@ -45,14 +46,18 @@ class ProblemClass(Enum):
 
     LP = "lp"  # linear obj + linear constraints + all continuous
     QP = "qp"  # ≤quadratic obj + linear constraints + all continuous
+    QCP = "qcp"  # linear obj + at least one quadratic constraint + all continuous
+    QCQP = "qcqp"  # ≤quadratic obj + at least one quadratic constraint + all continuous
     MILP = "milp"  # linear obj + linear constraints + has integer/binary
     MIQP = "miqp"  # ≤quadratic obj + linear constraints + has integer/binary
+    MIQCP = "miqcp"  # linear obj + at least one quadratic constraint + has integer/binary
+    MIQCQP = "miqcqp"  # ≤quadratic obj + quadratic constraints + has integer/binary
     NLP = "nlp"  # general nonlinear + all continuous
     MINLP = "minlp"  # general nonlinear + has integer/binary
 
 
 def classify_problem(model: Model) -> ProblemClass:
-    """Classify a model into LP, QP, MILP, MIQP, NLP, or MINLP.
+    """Classify a model into LP, QP, QCP, MILP, MIQP, MIQCP, NLP, or MINLP.
 
     Uses Rust structure detection for degree analysis of the objective
     and constraints. Falls back to NLP/MINLP if Rust bindings unavailable.
@@ -75,6 +80,12 @@ def classify_problem(model: Model) -> ProblemClass:
         all_constraints_linear = all(
             repr.is_constraint_linear(i) for i in range(repr.n_constraints)
         )
+        if hasattr(repr, "is_constraint_quadratic"):
+            all_constraints_quadratic = all(
+                repr.is_constraint_quadratic(i) for i in range(repr.n_constraints)
+            )
+        else:
+            all_constraints_quadratic = all_constraints_linear
     except (ImportError, Exception):
         # Rust bindings unavailable — fall back to NLP/MINLP
         return ProblemClass.MINLP if has_integer else ProblemClass.NLP
@@ -84,6 +95,12 @@ def classify_problem(model: Model) -> ProblemClass:
             return ProblemClass.MILP if has_integer else ProblemClass.LP
         if obj_quadratic:
             return ProblemClass.MIQP if has_integer else ProblemClass.QP
+
+    if all_constraints_quadratic:
+        if obj_linear:
+            return ProblemClass.MIQCP if has_integer else ProblemClass.QCP
+        if obj_quadratic:
+            return ProblemClass.MIQCQP if has_integer else ProblemClass.QCQP
 
     return ProblemClass.MINLP if has_integer else ProblemClass.NLP
 
@@ -106,6 +123,30 @@ class QPData(NamedTuple):
     c: jnp.ndarray  # (n,) linear objective coefficients
     A_eq: jnp.ndarray  # (m, n) equality constraint matrix
     b_eq: jnp.ndarray  # (m,) equality RHS
+    x_l: jnp.ndarray  # (n,) lower bounds
+    x_u: jnp.ndarray  # (n,) upper bounds
+    obj_const: float = 0.0  # constant term in objective
+
+
+class QuadraticConstraintData(NamedTuple):
+    """Quadratic row data: 0.5 x'Qx + c'x sense rhs."""
+
+    Q: jnp.ndarray
+    c: jnp.ndarray
+    sense: str
+    rhs: float
+
+
+class QCPData(NamedTuple):
+    """Standard-form QCP/QCQP data with explicit linear and quadratic rows."""
+
+    Q: jnp.ndarray  # (n, n) quadratic objective matrix (symmetric)
+    c: jnp.ndarray  # (n,) linear objective coefficients
+    A_ub: jnp.ndarray  # (m_ub, n) linear inequality matrix
+    b_ub: jnp.ndarray  # (m_ub,) linear inequality RHS
+    A_eq: jnp.ndarray  # (m_eq, n) linear equality matrix
+    b_eq: jnp.ndarray  # (m_eq,) linear equality RHS
+    quadratic_constraints: tuple[QuadraticConstraintData, ...]
     x_l: jnp.ndarray  # (n,) lower bounds
     x_u: jnp.ndarray  # (n,) upper bounds
     obj_const: float = 0.0  # constant term in objective
@@ -623,6 +664,61 @@ def _extract_constraints_algebraic(model: Model, n_orig: int):
     return A_eq, b_eq, x_l, x_u, n_slack
 
 
+def _quadratic_row_has_terms(Q: np.ndarray, tol: float = 1e-12) -> bool:
+    return bool(np.any(np.abs(Q) > tol))
+
+
+def _empty_matrix(n_cols: int) -> np.ndarray:
+    return np.zeros((0, n_cols), dtype=np.float64)
+
+
+def _extract_qcp_constraints_algebraic(
+    model: Model,
+    n_orig: int,
+) -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray, tuple[QuadraticConstraintData, ...]]:
+    """Extract linear and quadratic rows without introducing slack variables."""
+
+    constraints = [con for con in model._constraints if isinstance(con, Constraint)]
+
+    ub_rows: list[np.ndarray] = []
+    ub_rhs: list[float] = []
+    eq_rows: list[np.ndarray] = []
+    eq_rhs: list[float] = []
+    q_rows: list[QuadraticConstraintData] = []
+
+    for con in constraints:
+        Q, c_vec, const = _extract_quadratic_coefficients(con.body, model, n_orig)
+        rhs = float(con.rhs) - float(const)
+        if _quadratic_row_has_terms(Q):
+            q_rows.append(
+                QuadraticConstraintData(
+                    Q=np.asarray(Q),  # type: ignore[arg-type]
+                    c=np.asarray(c_vec),  # type: ignore[arg-type]
+                    sense=con.sense,
+                    rhs=rhs,
+                )
+            )
+            continue
+
+        if con.sense == "==":
+            eq_rows.append(c_vec)
+            eq_rhs.append(rhs)
+        elif con.sense == "<=":
+            ub_rows.append(c_vec)
+            ub_rhs.append(rhs)
+        elif con.sense == ">=":
+            ub_rows.append(-c_vec)
+            ub_rhs.append(-rhs)
+        else:
+            raise _NotQuadraticError(f"Unknown constraint sense: {con.sense}")
+
+    A_ub = np.stack(ub_rows).astype(np.float64) if ub_rows else _empty_matrix(n_orig)
+    b_ub = np.asarray(ub_rhs, dtype=np.float64)
+    A_eq = np.stack(eq_rows).astype(np.float64) if eq_rows else _empty_matrix(n_orig)
+    b_eq = np.asarray(eq_rhs, dtype=np.float64)
+    return A_ub, b_ub, A_eq, b_eq, tuple(q_rows)
+
+
 def extract_lp_data_algebraic(model: Model) -> LPData:
     """Extract LP standard form by walking the expression DAG algebraically.
 
@@ -699,6 +795,38 @@ def extract_qp_data_algebraic(model: Model) -> QPData:
         b_eq=b_eq,
         x_l=x_l,
         x_u=x_u,
+        obj_const=obj_const,
+    )
+
+
+def extract_qcp_data_algebraic(model: Model) -> QCPData:
+    """Extract QCP/QCQP data by walking the expression DAG algebraically."""
+
+    from discopt.modeling.core import ObjectiveSense
+
+    n_orig = sum(v.size for v in model._variables)
+    assert model._objective is not None
+    obj_expr = model._objective.expression
+
+    Q, c_vec, obj_const = _extract_quadratic_coefficients(obj_expr, model, n_orig)
+    A_ub, b_ub, A_eq, b_eq, q_rows = _extract_qcp_constraints_algebraic(model, n_orig)
+    x_l, x_u = _get_variable_bounds(model)
+
+    if model._objective.sense == ObjectiveSense.MAXIMIZE:
+        Q = -Q
+        c_vec = -c_vec
+        obj_const = -obj_const
+
+    return QCPData(
+        Q=np.asarray(Q),  # type: ignore[arg-type]
+        c=np.asarray(c_vec),  # type: ignore[arg-type]
+        A_ub=np.asarray(A_ub),  # type: ignore[arg-type]
+        b_ub=np.asarray(b_ub),  # type: ignore[arg-type]
+        A_eq=np.asarray(A_eq),  # type: ignore[arg-type]
+        b_eq=np.asarray(b_eq),  # type: ignore[arg-type]
+        quadratic_constraints=q_rows,
+        x_l=np.asarray(x_l),  # type: ignore[arg-type]
+        x_u=np.asarray(x_u),  # type: ignore[arg-type]
         obj_const=obj_const,
     )
 
@@ -885,6 +1013,114 @@ def _extract_qp_data_from_repr(model: Model) -> QPData:
     )
 
 
+def _extract_quadratic_coefficients_from_values(evaluate, n_vars: int):
+    """Extract 0.5*x'Q*x + c'x + d from a quadratic scalar evaluator."""
+
+    x_zero = np.zeros(n_vars, dtype=np.float64)
+    d = float(evaluate(x_zero))
+
+    f_ej = np.zeros(n_vars, dtype=np.float64)
+    f_neg_ej = np.zeros(n_vars, dtype=np.float64)
+    for j in range(n_vars):
+        ej = np.zeros(n_vars, dtype=np.float64)
+        ej[j] = 1.0
+        f_ej[j] = float(evaluate(ej))
+        ej[j] = -1.0
+        f_neg_ej[j] = float(evaluate(ej))
+
+    Q = np.zeros((n_vars, n_vars), dtype=np.float64)
+    for j in range(n_vars):
+        Q[j, j] = f_ej[j] + f_neg_ej[j] - 2.0 * d
+
+    for i in range(n_vars):
+        for j in range(i + 1, n_vars):
+            eij = np.zeros(n_vars, dtype=np.float64)
+            eij[i] = 1.0
+            eij[j] = 1.0
+            f_eij = float(evaluate(eij))
+            qij = f_eij - f_ej[i] - f_ej[j] + d
+            Q[i, j] = qij
+            Q[j, i] = qij
+
+    c_vec = np.zeros(n_vars, dtype=np.float64)
+    for j in range(n_vars):
+        c_vec[j] = f_ej[j] - d - 0.5 * Q[j, j]
+
+    return Q, c_vec, d
+
+
+def _extract_qcp_data_from_repr(model: Model) -> QCPData:
+    """Extract QCP/QCQP data by evaluating the Rust ModelRepr."""
+
+    from discopt._rust import model_to_repr
+
+    _builder = getattr(model, "_builder", None)
+    repr_ = model_to_repr(model, _builder)
+
+    n_orig = repr_.n_vars
+    Q, c_vec, obj_const = _extract_quadratic_coefficients_from_values(
+        repr_.evaluate_objective,
+        n_orig,
+    )
+
+    ub_rows: list[np.ndarray] = []
+    ub_rhs: list[float] = []
+    eq_rows: list[np.ndarray] = []
+    eq_rhs: list[float] = []
+    q_rows: list[QuadraticConstraintData] = []
+
+    for i in range(repr_.n_constraints):
+        row_Q, row_c, row_const = _extract_quadratic_coefficients_from_values(
+            lambda x, _i=i: repr_.evaluate_constraint(_i, x),
+            n_orig,
+        )
+        sense = repr_.constraint_sense(i)
+        rhs = float(repr_.constraint_rhs(i)) - float(row_const)
+        if _quadratic_row_has_terms(row_Q):
+            q_rows.append(
+                QuadraticConstraintData(
+                    Q=np.asarray(row_Q),  # type: ignore[arg-type]
+                    c=np.asarray(row_c),  # type: ignore[arg-type]
+                    sense=sense,
+                    rhs=rhs,
+                )
+            )
+            continue
+        if sense == "==":
+            eq_rows.append(row_c)
+            eq_rhs.append(rhs)
+        elif sense == "<=":
+            ub_rows.append(row_c)
+            ub_rhs.append(rhs)
+        elif sense == ">=":
+            ub_rows.append(-row_c)
+            ub_rhs.append(-rhs)
+
+    x_l, x_u = _get_variable_bounds(model)
+    A_ub = np.stack(ub_rows).astype(np.float64) if ub_rows else _empty_matrix(n_orig)
+    b_ub = np.asarray(ub_rhs, dtype=np.float64)
+    A_eq = np.stack(eq_rows).astype(np.float64) if eq_rows else _empty_matrix(n_orig)
+    b_eq = np.asarray(eq_rhs, dtype=np.float64)
+
+    if repr_.objective_sense == "maximize":
+        Q = -Q
+        c_vec = -c_vec
+        obj_const = -obj_const
+
+    return QCPData(
+        Q=np.asarray(Q),  # type: ignore[arg-type]
+        c=np.asarray(c_vec),  # type: ignore[arg-type]
+        A_ub=np.asarray(A_ub),  # type: ignore[arg-type]
+        b_ub=np.asarray(b_ub),  # type: ignore[arg-type]
+        A_eq=np.asarray(A_eq),  # type: ignore[arg-type]
+        b_eq=np.asarray(b_eq),  # type: ignore[arg-type]
+        quadratic_constraints=tuple(q_rows),
+        x_l=np.asarray(x_l),  # type: ignore[arg-type]
+        x_u=np.asarray(x_u),  # type: ignore[arg-type]
+        obj_const=float(obj_const),
+    )
+
+
 def extract_lp_data(model: Model) -> LPData:
     """Extract LP standard form from a model classified as LP.
 
@@ -1036,6 +1272,18 @@ def extract_qp_data(model: Model) -> QPData:
         pass
 
     return _extract_qp_data_autodiff(model)
+
+
+def extract_qcp_data(model: Model) -> QCPData:
+    """Extract QCP/QCQP data from a model classified as QCP/QCQP/MIQCP/MIQCQP."""
+    _builder = getattr(model, "_builder", None)
+    if _builder is not None:
+        try:
+            return _extract_qcp_data_from_repr(model)
+        except Exception:
+            pass
+
+    return extract_qcp_data_algebraic(model)
 
 
 def _extract_qp_data_autodiff(model: Model) -> QPData:

--- a/python/discopt/modeling/core.py
+++ b/python/discopt/modeling/core.py
@@ -2783,9 +2783,10 @@ class Model:
             ``obbt_at_root``, ``obbt_with_cutoff``, ``alphabb_cutoff_obbt``,
             and ``obbt_time_limit``.
             Use ``solver="gurobi"`` to select the optional Gurobi backend for
-            LP, MILP, QP, and MIQP models. Quadratic objectives use the
-            ``0.5 * x.T @ Q @ x + c.T @ x`` convention; nonconvex QP/MIQP
-            objectives require opting into Gurobi's nonconvex mode explicitly,
+            LP, MILP, QP, MIQP, QCP, and MIQCP models. Quadratic objectives
+            and quadratic constraints use the ``0.5 * x.T @ Q @ x + c.T @ x``
+            convention; nonconvex quadratic objectives or constraints require
+            opting into Gurobi's nonconvex mode explicitly,
             for example ``gurobi_options={"NonConvex": 2}``. Unsupported model
             classes raise ``NotImplementedError`` instead of silently falling
             back to another backend. Pass Gurobi parameters through

--- a/python/discopt/solver.py
+++ b/python/discopt/solver.py
@@ -2982,7 +2982,7 @@ def solve_model(
         if problem_class is None:
             raise NotImplementedError(
                 "solver='gurobi' requires problem classification and currently "
-                "supports LP, MILP, QP, and MIQP models only."
+                "supports LP, MILP, QP, MIQP, QCP, and MIQCP models only."
             )
         if problem_class == ProblemClass.LP:
             return _solve_lp_gurobi(model, t_start, time_limit, threads, gurobi_options)
@@ -2998,8 +2998,17 @@ def solve_model(
             return _solve_qp_gurobi(
                 model, t_start, time_limit, gap_tolerance, threads, gurobi_options
             )
+        if problem_class in (
+            ProblemClass.QCP,
+            ProblemClass.QCQP,
+            ProblemClass.MIQCP,
+            ProblemClass.MIQCQP,
+        ):
+            return _solve_qcp_gurobi(
+                model, t_start, time_limit, gap_tolerance, threads, gurobi_options
+            )
         raise NotImplementedError(
-            f"solver='gurobi' supports LP, MILP, QP, and MIQP models only; "
+            f"solver='gurobi' supports LP, MILP, QP, MIQP, QCP, and MIQCP models only; "
             f"classified this model as {problem_class.value!r}."
         )
 
@@ -7684,6 +7693,149 @@ def _solve_qp_gurobi(
     if result is None:  # pragma: no cover - strict mode raises before this
         raise RuntimeError("Gurobi QP/MIQP solve failed without returning a result.")
     return result
+
+
+def _quadratic_rows_solution_feasible(x, quadratic_constraints, tol=1e-6) -> bool:
+    x = np.asarray(x, dtype=np.float64)
+    if not np.all(np.isfinite(x)):
+        return False
+    x_scale = 1.0 + float(np.max(np.abs(x))) if x.size else 1.0
+    for row in quadratic_constraints:
+        Q = np.asarray(row.Q, dtype=np.float64)
+        c = np.asarray(row.c, dtype=np.float64)
+        rhs = float(row.rhs)
+        value = float(0.5 * x @ Q @ x + c @ x)
+        scale = x_scale + abs(rhs) + abs(value)
+        if row.sense == "<=" and value > rhs + tol * scale:
+            return False
+        if row.sense == ">=" and value < rhs - tol * scale:
+            return False
+        if row.sense == "==" and abs(value - rhs) > tol * scale:
+            return False
+    return True
+
+
+def _solve_qcp_gurobi(
+    model: Model,
+    t_start: float,
+    time_limit: float | None = None,
+    gap_tolerance: float = 1e-4,
+    threads: int | None = None,
+    options: Optional[dict] = None,
+) -> SolveResult:
+    """Solve a QCP/QCQP/MIQCP/MIQCQP using the explicit Gurobi backend."""
+    from discopt._jax.problem_classifier import extract_qcp_data
+    from discopt.modeling.core import ObjectiveSense
+    from discopt.solvers import SolveStatus
+    from discopt.solvers.gurobi import solve_qcp as _gurobi_solve_qcp
+
+    qcp_data = extract_qcp_data(model)
+    n_orig = sum(v.size for v in model._variables)
+
+    bounds = list(
+        zip(
+            np.asarray(qcp_data.x_l[:n_orig]).tolist(),
+            np.asarray(qcp_data.x_u[:n_orig]).tolist(),
+        )
+    )
+
+    A_ub = np.asarray(qcp_data.A_ub, dtype=np.float64)
+    b_ub = np.asarray(qcp_data.b_ub, dtype=np.float64)
+    A_eq = np.asarray(qcp_data.A_eq, dtype=np.float64)
+    b_eq = np.asarray(qcp_data.b_eq, dtype=np.float64)
+    A_ub_arg = A_ub if A_ub.shape[0] else None
+    b_ub_arg = b_ub if b_ub.shape[0] else None
+    A_eq_arg = A_eq if A_eq.shape[0] else None
+    b_eq_arg = b_eq if b_eq.shape[0] else None
+
+    integrality = None
+    if any(v.var_type in (VarType.BINARY, VarType.INTEGER) for v in model._variables):
+        int_arr = np.zeros(n_orig, dtype=np.int32)
+        offset = 0
+        for v in model._variables:
+            if v.var_type in (VarType.BINARY, VarType.INTEGER):
+                int_arr[offset : offset + v.size] = 1
+            offset += v.size
+        integrality = int_arr
+
+    result = _gurobi_solve_qcp(
+        Q=np.asarray(qcp_data.Q[:n_orig, :n_orig]),
+        c=np.asarray(qcp_data.c[:n_orig]),
+        A_ub=A_ub_arg,
+        b_ub=b_ub_arg,
+        A_eq=A_eq_arg,
+        b_eq=b_eq_arg,
+        bounds=bounds,
+        quadratic_constraints=qcp_data.quadratic_constraints,
+        integrality=integrality,
+        time_limit=time_limit,
+        gap_tolerance=gap_tolerance,
+        threads=threads,
+        options=options,
+    )
+
+    wall_time = time.perf_counter() - t_start
+    assert model._objective is not None
+    sense = model._objective.sense
+
+    objective = None
+    if result.objective is not None:
+        objective = float(result.objective) + float(qcp_data.obj_const)
+        if sense == ObjectiveSense.MAXIMIZE:
+            objective = -objective
+
+    bound = None
+    if result.status == SolveStatus.OPTIMAL and objective is not None:
+        bound = objective
+    elif result.bound is not None:
+        bound = float(result.bound) + float(qcp_data.obj_const)
+        if sense == ObjectiveSense.MAXIMIZE:
+            bound = -bound
+
+    if result.status == SolveStatus.OPTIMAL:
+        assert result.x is not None and objective is not None
+        x_flat = np.asarray(result.x[:n_orig], dtype=np.float64)
+        if not _matrix_solution_feasible(x_flat, A_ub_arg, b_ub_arg, A_eq_arg, b_eq_arg, bounds):
+            raise RuntimeError("Gurobi QCP returned an infeasible point labeled optimal.")
+        if not _quadratic_rows_solution_feasible(x_flat, qcp_data.quadratic_constraints):
+            raise RuntimeError("Gurobi QCP returned a quadratic-row-infeasible optimal point.")
+        return SolveResult(
+            status="optimal",
+            objective=objective,
+            bound=objective,
+            gap=result.gap if result.gap is not None else _optimal_relative_gap(objective),
+            x=_unpack_solution(model, x_flat),
+            wall_time=wall_time,
+            node_count=result.node_count,
+            rust_time=0.0,
+            jax_time=0.0,
+            python_time=wall_time,
+        )
+    if result.status == SolveStatus.INFEASIBLE:
+        return SolveResult(status="infeasible", wall_time=wall_time, node_count=result.node_count)
+    if result.status == SolveStatus.UNBOUNDED:
+        return SolveResult(status="unbounded", wall_time=wall_time, node_count=result.node_count)
+    if result.status == SolveStatus.TIME_LIMIT:
+        return SolveResult(
+            status="time_limit",
+            objective=objective,
+            bound=bound,
+            gap=_relative_gap_from_objective_bound(objective, bound),
+            x=_unpack_solution(model, result.x[:n_orig]) if result.x is not None else None,
+            wall_time=wall_time,
+            node_count=result.node_count,
+        )
+    if result.status == SolveStatus.ITERATION_LIMIT:
+        return SolveResult(
+            status="iteration_limit",
+            objective=objective,
+            bound=bound,
+            gap=_relative_gap_from_objective_bound(objective, bound),
+            x=_unpack_solution(model, result.x[:n_orig]) if result.x is not None else None,
+            wall_time=wall_time,
+            node_count=result.node_count,
+        )
+    return SolveResult(status="error", wall_time=wall_time, node_count=result.node_count)
 
 
 def _matrix_solution_feasible(x, A_ub, b_ub, A_eq, b_eq, bounds, tol=1e-6) -> bool:

--- a/python/discopt/solvers/gurobi.py
+++ b/python/discopt/solvers/gurobi.py
@@ -1,13 +1,13 @@
-"""Gurobi LP/MILP/QP/MIQP solver wrappers.
+"""Gurobi LP/MILP/QP/MIQP/QCP/MIQCP solver wrappers.
 
 This module mirrors the matrix-form HiGHS wrappers: callers pass extracted
 standard-form arrays and receive discopt result dataclasses. ``gurobipy`` stays
 optional and is imported only inside the solver path.
 
-Quadratic objectives use the discopt/HiGHS convention
+Quadratic objectives and quadratic constraints use the discopt/HiGHS convention
 ``0.5 * x.T @ Q @ x + c.T @ x``. Nonconvex ``Q`` matrices are rejected by
 default; pass an explicit Gurobi ``NonConvex`` parameter through ``options`` to
-delegate nonconvex QP/MIQP handling to Gurobi.
+delegate nonconvex quadratic handling to Gurobi.
 """
 
 from __future__ import annotations
@@ -109,10 +109,74 @@ def _has_nonconvex_objective(Q: np.ndarray) -> bool:
     return min_eig < -1e-9 * scale
 
 
+def _eigenvalue_span(Q: np.ndarray) -> tuple[float, float]:
+    if Q.size == 0:
+        return 0.0, 0.0
+    try:
+        eigvals = np.linalg.eigvalsh(Q)
+    except np.linalg.LinAlgError:
+        return -np.inf, np.inf
+    return float(np.min(eigvals)), float(np.max(eigvals))
+
+
+def _quadratic_constraint_requires_nonconvex(Q: np.ndarray, sense: str) -> bool:
+    """Return true when the quadratic row is not a convex Gurobi QCP row."""
+
+    if not np.any(np.abs(Q) > 1e-12):
+        return False
+    min_eig, max_eig = _eigenvalue_span(Q)
+    scale = max(1.0, float(np.max(np.abs(Q))))
+    tol = 1e-9 * scale
+    if sense == "<=":
+        return min_eig < -tol
+    if sense == ">=":
+        return max_eig > tol
+    if sense == "==":
+        return True
+    raise ValueError(f"Unknown quadratic constraint sense: {sense!r}")
+
+
 def _has_explicit_nonconvex_option(options: Optional[dict]) -> bool:
     if not options:
         return False
     return any(str(key).lower() == "nonconvex" for key in options)
+
+
+def _validate_quadratic_constraints(quadratic_constraints, n: int):
+    rows = []
+    if quadratic_constraints is None:
+        return rows
+    for k, row in enumerate(quadratic_constraints):
+        if hasattr(row, "Q"):
+            Q_raw = row.Q
+            c_raw = row.c
+            sense = str(row.sense)
+            rhs = float(row.rhs)
+        else:
+            Q_raw, c_raw, sense_raw, rhs_raw = row
+            sense = str(sense_raw)
+            rhs = float(rhs_raw)
+        if sp.issparse(Q_raw):
+            Q_arr = sp.csr_matrix(Q_raw, dtype=np.float64).toarray()
+        else:
+            Q_arr = np.asarray(Q_raw, dtype=np.float64)
+        c_arr = np.asarray(c_raw, dtype=np.float64).ravel()
+        if Q_arr.shape != (n, n):
+            raise ValueError(
+                f"quadratic constraint {k} Q has shape {Q_arr.shape} but c has {n} elements"
+            )
+        if c_arr.shape[0] != n:
+            raise ValueError(
+                f"quadratic constraint {k} c has {c_arr.shape[0]} entries but objective c has {n}"
+            )
+        if sense not in {"<=", ">=", "=="}:
+            raise ValueError(f"quadratic constraint {k} has unknown sense {sense!r}")
+        if not np.all(np.isfinite(Q_arr)) or not np.all(np.isfinite(c_arr)):
+            raise ValueError(f"quadratic constraint {k} contains non-finite coefficients")
+        if not np.allclose(Q_arr, Q_arr.T, rtol=1e-10, atol=1e-12):
+            Q_arr = 0.5 * (Q_arr + Q_arr.T)
+        rows.append((Q_arr, c_arr, sense, rhs))
+    return rows
 
 
 def _normalise_bounds(
@@ -485,6 +549,124 @@ def solve_qp(
                 gap=0.0 if gap is None else gap,
                 dual_values=row_duals,
                 reduced_costs=reduced_costs,
+                node_count=node_count,
+                iterations=iters,
+                wall_time=wall_time,
+            )
+
+        return QPResult(
+            status=status,
+            x=x_val,
+            objective=objective,
+            bound=bound,
+            gap=gap,
+            node_count=node_count,
+            iterations=iters,
+            wall_time=wall_time,
+        )
+    finally:
+        model.dispose()
+        env.dispose()
+
+
+def solve_qcp(
+    Q: Union[np.ndarray, sp.spmatrix],
+    c: np.ndarray,
+    A_ub: Optional[Union[np.ndarray, sp.spmatrix]] = None,
+    b_ub: Optional[np.ndarray] = None,
+    A_eq: Optional[Union[np.ndarray, sp.spmatrix]] = None,
+    b_eq: Optional[np.ndarray] = None,
+    bounds: Optional[list[tuple[float, float]]] = None,
+    quadratic_constraints=None,
+    integrality: Optional[np.ndarray] = None,
+    time_limit: Optional[float] = None,
+    gap_tolerance: float = 1e-4,
+    threads: Optional[int] = None,
+    options: Optional[dict] = None,
+) -> QPResult:
+    """Solve a continuous or mixed-integer quadratically constrained program.
+
+    The objective and each quadratic row use ``0.5 * x.T @ Q @ x + c.T @ x``.
+    Convex QCP/MIQCP rows solve without extra options. Nonconvex objectives,
+    indefinite ``<=`` rows, non-concave ``>=`` rows, and quadratic equalities
+    require an explicit ``NonConvex`` Gurobi parameter in ``options``.
+    """
+    Q_arr, c_arr, n = _validate_qp_data(Q, c, A_ub, b_ub, A_eq, b_eq, bounds)
+    q_rows = _validate_quadratic_constraints(quadratic_constraints, n)
+
+    has_nonconvex_quadratic = _has_nonconvex_objective(Q_arr) or any(
+        _quadratic_constraint_requires_nonconvex(row_Q, sense)
+        for row_Q, _row_c, sense, _rhs in q_rows
+    )
+    if has_nonconvex_quadratic and not _has_explicit_nonconvex_option(options):
+        raise ValueError(
+            "Gurobi QCP/MIQCP nonconvex quadratic detected. Pass "
+            "gurobi_options={'NonConvex': 2} to Model.solve(solver='gurobi'), "
+            "or options={'NonConvex': 2} when calling "
+            "discopt.solvers.gurobi.solve_qcp directly."
+        )
+
+    gp, GRB = _load_gurobi()
+
+    has_integer = integrality is not None and np.any(np.asarray(integrality, dtype=np.int32) == 1)
+    qcp_bounds = bounds
+    if qcp_bounds is None:
+        qcp_bounds = [(-GRB.INFINITY, GRB.INFINITY)] * n
+
+    env, model, x, _ub_con, _eq_con = _build_model(
+        gp,
+        GRB,
+        name="discopt_miqcp" if has_integer else "discopt_qcp",
+        c=c_arr,
+        A_ub=A_ub,
+        b_ub=b_ub,
+        A_eq=A_eq,
+        b_eq=b_eq,
+        bounds=qcp_bounds,
+        integrality=integrality,
+        time_limit=time_limit,
+        gap_tolerance=gap_tolerance if has_integer else None,
+        threads=threads,
+        options=options,
+    )
+    try:
+        model.setObjective(0.5 * (x @ Q_arr @ x) + c_arr @ x, GRB.MINIMIZE)
+        for k, (row_Q, row_c, sense, rhs) in enumerate(q_rows):
+            expr = 0.5 * (x @ row_Q @ x) + row_c @ x
+            if sense == "<=":
+                model.addQConstr(expr <= rhs, name=f"qcp_{k}")
+            elif sense == ">=":
+                model.addQConstr(expr >= rhs, name=f"qcp_{k}")
+            elif sense == "==":
+                model.addQConstr(expr == rhs, name=f"qcp_{k}")
+            else:  # pragma: no cover - validated before model construction
+                raise ValueError(f"Unknown quadratic constraint sense: {sense!r}")
+
+        status_code = _optimize(model, GRB)
+        status = _status_map(GRB).get(status_code, SolveStatus.ERROR)
+        iters = int(_safe_attr(model, "IterCount") or 0)
+        node_count = int(_safe_attr(model, "NodeCount") or 0)
+        wall_time = float(_safe_attr(model, "Runtime") or 0.0)
+
+        objective = None
+        x_val = None
+        if int(_safe_attr(model, "SolCount") or 0) > 0:
+            objective = float(model.ObjVal)
+            x_val = np.asarray(x.X, dtype=np.float64).ravel()
+
+        bound = _safe_attr(model, "ObjBound")
+        bound = float(bound) if bound is not None and np.isfinite(bound) else None
+        gap = _safe_attr(model, "MIPGap")
+        gap = float(gap) if gap is not None and np.isfinite(gap) else None
+
+        if status == SolveStatus.OPTIMAL:
+            assert objective is not None and x_val is not None
+            return QPResult(
+                status=status,
+                x=x_val,
+                objective=objective,
+                bound=objective if bound is None else bound,
+                gap=0.0 if gap is None else gap,
                 node_count=node_count,
                 iterations=iters,
                 wall_time=wall_time,

--- a/python/tests/test_gurobi_backend.py
+++ b/python/tests/test_gurobi_backend.py
@@ -548,6 +548,112 @@ def test_gurobi_qcp_maximize_maps_objective(monkeypatch):
     assert result.x["x"] == pytest.approx(1.0)
 
 
+def test_gurobi_qcp_maximize_time_limit_maps_incumbent_bound_and_gap(monkeypatch):
+    import discopt.solver as solver
+    from discopt._jax import problem_classifier
+
+    m = dm.Model("gurobi_max_qcp_time_limit_mapping")
+    x = m.continuous("x", lb=-2, ub=2)
+    m.maximize(x)
+    m.subject_to(x**2 <= 1)
+
+    qcp_data = problem_classifier.QCPData(
+        Q=np.zeros((1, 1)),
+        c=np.array([-1.0]),
+        A_ub=np.zeros((0, 1)),
+        b_ub=np.zeros(0),
+        A_eq=np.zeros((0, 1)),
+        b_eq=np.zeros(0),
+        quadratic_constraints=(
+            problem_classifier.QuadraticConstraintData(
+                Q=np.array([[2.0]]),
+                c=np.array([0.0]),
+                sense="<=",
+                rhs=1.0,
+            ),
+        ),
+        x_l=np.array([-2.0]),
+        x_u=np.array([2.0]),
+        obj_const=0.0,
+    )
+    monkeypatch.setattr(problem_classifier, "extract_qcp_data", lambda _model: qcp_data)
+
+    def fake_solve_qcp(**_kwargs):
+        return QPResult(
+            status=SolveStatus.TIME_LIMIT,
+            x=np.array([0.75]),
+            objective=-0.75,
+            bound=-1.0,
+            gap=0.2,
+            node_count=9,
+        )
+
+    monkeypatch.setattr(gurobi_backend, "solve_qcp", fake_solve_qcp)
+
+    result = solver._solve_qcp_gurobi(m, t_start=0.0, time_limit=1.0)
+
+    assert result.status == "time_limit"
+    assert result.objective == pytest.approx(0.75)
+    assert result.bound == pytest.approx(1.0)
+    assert result.gap == pytest.approx(0.25)
+    assert result.node_count == 9
+    assert result.x["x"] == pytest.approx(0.75)
+
+
+@pytest.mark.parametrize(
+    ("backend_status", "public_status"),
+    [
+        (SolveStatus.INFEASIBLE, "infeasible"),
+        (SolveStatus.UNBOUNDED, "unbounded"),
+        (SolveStatus.ITERATION_LIMIT, "iteration_limit"),
+        (SolveStatus.ERROR, "error"),
+    ],
+)
+def test_gurobi_qcp_no_incumbent_status_mapping(monkeypatch, backend_status, public_status):
+    import discopt.solver as solver
+    from discopt._jax import problem_classifier
+
+    m = dm.Model("gurobi_qcp_no_incumbent_status_mapping")
+    x = m.continuous("x", lb=-2, ub=2)
+    m.minimize(x)
+    m.subject_to(x**2 <= 1)
+
+    qcp_data = problem_classifier.QCPData(
+        Q=np.zeros((1, 1)),
+        c=np.array([1.0]),
+        A_ub=np.zeros((0, 1)),
+        b_ub=np.zeros(0),
+        A_eq=np.zeros((0, 1)),
+        b_eq=np.zeros(0),
+        quadratic_constraints=(
+            problem_classifier.QuadraticConstraintData(
+                Q=np.array([[2.0]]),
+                c=np.array([0.0]),
+                sense="<=",
+                rhs=1.0,
+            ),
+        ),
+        x_l=np.array([-2.0]),
+        x_u=np.array([2.0]),
+        obj_const=0.0,
+    )
+    monkeypatch.setattr(problem_classifier, "extract_qcp_data", lambda _model: qcp_data)
+
+    def fake_solve_qcp(**_kwargs):
+        return QPResult(status=backend_status, node_count=6)
+
+    monkeypatch.setattr(gurobi_backend, "solve_qcp", fake_solve_qcp)
+
+    result = solver._solve_qcp_gurobi(m, t_start=0.0, time_limit=1.0)
+
+    assert result.status == public_status
+    assert result.objective is None
+    assert result.bound is None
+    assert result.gap is None
+    assert result.x is None
+    assert result.node_count == 6
+
+
 def test_gurobi_lp_smoke_if_available():
     _require_gurobi()
 

--- a/python/tests/test_gurobi_backend.py
+++ b/python/tests/test_gurobi_backend.py
@@ -1,4 +1,4 @@
-"""Tests for the optional Gurobi LP/MILP backend."""
+"""Tests for the optional Gurobi LP/MILP/QP/QCP backend."""
 
 from __future__ import annotations
 
@@ -20,17 +20,32 @@ def _install_fake_rust_classifier(monkeypatch, problem_kind: str) -> None:
     extension, while CI builds it before running the broader suite.
     """
 
+    linear_constraint_kinds = {"lp", "milp", "qp", "miqp"}
+    quadratic_constraint_kinds = {"qcp", "qcqp", "miqcp", "miqcqp"}
+
     class _FakeRepr:
-        n_constraints = 0
+        n_constraints = 1 if problem_kind in quadratic_constraint_kinds else 0
 
         def is_objective_linear(self):
-            return problem_kind in {"lp", "milp"}
+            return problem_kind in {"lp", "milp", "qcp", "miqcp"}
 
         def is_objective_quadratic(self):
-            return problem_kind in {"qp", "miqp"}
+            return problem_kind in {
+                "lp",
+                "milp",
+                "qp",
+                "miqp",
+                "qcp",
+                "miqcp",
+                "qcqp",
+                "miqcqp",
+            }
 
         def is_constraint_linear(self, _idx):
-            return True
+            return problem_kind in linear_constraint_kinds
+
+        def is_constraint_quadratic(self, _idx):
+            return problem_kind in linear_constraint_kinds | quadratic_constraint_kinds
 
     fake_rust = types.SimpleNamespace(
         PyTreeManager=object,
@@ -86,6 +101,30 @@ def test_gurobi_qp_requires_explicit_nonconvex_option_without_importing_gurobipy
             Q=np.array([[-2.0]]),
             c=np.array([0.0]),
             bounds=[(-1.0, 1.0)],
+        )
+
+
+def test_gurobi_qcp_validates_quadratic_constraint_dimensions_without_importing_gurobipy():
+    with pytest.raises(ValueError, match="quadratic constraint 0 Q has shape"):
+        gurobi_backend.solve_qcp(
+            Q=np.zeros((2, 2)),
+            c=np.array([1.0, 2.0]),
+            bounds=[(-1.0, 1.0), (-1.0, 1.0)],
+            quadratic_constraints=[
+                (np.eye(3), np.zeros(2), "<=", 1.0),
+            ],
+        )
+
+
+def test_gurobi_qcp_requires_explicit_nonconvex_option_without_importing_gurobipy():
+    with pytest.raises(ValueError, match="gurobi_options.*options"):
+        gurobi_backend.solve_qcp(
+            Q=np.zeros((1, 1)),
+            c=np.array([0.0]),
+            bounds=[(-2.0, 2.0)],
+            quadratic_constraints=[
+                (np.array([[-2.0]]), np.array([0.0]), "<=", 1.0),
+            ],
         )
 
 
@@ -248,6 +287,95 @@ def test_model_solve_gurobi_dispatches_miqp(monkeypatch):
     assert calls["options"] == {"MIPFocus": 1}
 
 
+def test_model_solve_gurobi_dispatches_qcp(monkeypatch):
+    _install_fake_rust_classifier(monkeypatch, "qcp")
+    import discopt.solver as solver
+
+    calls = {}
+
+    def fake_gurobi_qcp(
+        model,
+        t_start,
+        time_limit=None,
+        gap_tolerance=1e-4,
+        threads=None,
+        options=None,
+    ):
+        calls["model"] = model
+        calls["time_limit"] = time_limit
+        calls["gap_tolerance"] = gap_tolerance
+        calls["threads"] = threads
+        calls["options"] = options
+        return SolveResult(status="optimal", objective=-1.0, bound=-1.0, gap=0.0)
+
+    monkeypatch.setattr(solver, "_solve_qcp_gurobi", fake_gurobi_qcp)
+
+    m = dm.Model("qcp_dispatch_gurobi")
+    x = m.continuous("x", lb=-2, ub=2)
+    m.minimize(x)
+    m.subject_to(x**2 <= 1)
+
+    result = m.solve(
+        solver="gurobi",
+        time_limit=7.0,
+        gap_tolerance=1e-6,
+        threads=2,
+        gurobi_options={"BarConvTol": 1e-8},
+    )
+
+    assert result.status == "optimal"
+    assert calls["model"] is m
+    assert calls["time_limit"] == 7.0
+    assert calls["gap_tolerance"] == 1e-6
+    assert calls["threads"] == 2
+    assert calls["options"] == {"BarConvTol": 1e-8}
+
+
+def test_model_solve_gurobi_dispatches_miqcqp(monkeypatch):
+    _install_fake_rust_classifier(monkeypatch, "miqcqp")
+    import discopt.solver as solver
+
+    calls = {}
+
+    def fake_gurobi_qcp(
+        model,
+        t_start,
+        time_limit=None,
+        gap_tolerance=1e-4,
+        threads=None,
+        options=None,
+    ):
+        calls["model"] = model
+        calls["time_limit"] = time_limit
+        calls["gap_tolerance"] = gap_tolerance
+        calls["threads"] = threads
+        calls["options"] = options
+        return SolveResult(status="optimal", objective=0.0, bound=0.0, gap=0.0)
+
+    monkeypatch.setattr(solver, "_solve_qcp_gurobi", fake_gurobi_qcp)
+
+    m = dm.Model("miqcqp_dispatch_gurobi")
+    x = m.binary("x")
+    y = m.continuous("y", lb=-2, ub=2)
+    m.minimize((y - 1) ** 2 + x)
+    m.subject_to(y**2 <= x)
+
+    result = m.solve(
+        solver="gurobi",
+        time_limit=6.0,
+        gap_tolerance=1e-5,
+        threads=1,
+        gurobi_options={"MIPFocus": 1},
+    )
+
+    assert result.status == "optimal"
+    assert calls["model"] is m
+    assert calls["time_limit"] == 6.0
+    assert calls["gap_tolerance"] == 1e-5
+    assert calls["threads"] == 1
+    assert calls["options"] == {"MIPFocus": 1}
+
+
 def test_gurobi_milp_maximize_time_limit_maps_dual_bound(monkeypatch):
     _install_fake_rust_classifier(monkeypatch, "milp")
     import discopt.solver as solver
@@ -370,6 +498,56 @@ def test_gurobi_miqp_time_limit_maps_incumbent_bound_and_gap(monkeypatch):
     assert result.x["y"] == pytest.approx(1.0)
 
 
+def test_gurobi_qcp_maximize_maps_objective(monkeypatch):
+    import discopt.solver as solver
+    from discopt._jax import problem_classifier
+
+    m = dm.Model("gurobi_max_qcp_objective_mapping")
+    x = m.continuous("x", lb=-2, ub=2)
+    m.maximize(x)
+    m.subject_to(x**2 <= 1)
+
+    qcp_data = problem_classifier.QCPData(
+        Q=np.zeros((1, 1)),
+        c=np.array([-1.0]),
+        A_ub=np.zeros((0, 1)),
+        b_ub=np.zeros(0),
+        A_eq=np.zeros((0, 1)),
+        b_eq=np.zeros(0),
+        quadratic_constraints=(
+            problem_classifier.QuadraticConstraintData(
+                Q=np.array([[2.0]]),
+                c=np.array([0.0]),
+                sense="<=",
+                rhs=1.0,
+            ),
+        ),
+        x_l=np.array([-2.0]),
+        x_u=np.array([2.0]),
+        obj_const=0.0,
+    )
+    monkeypatch.setattr(problem_classifier, "extract_qcp_data", lambda _model: qcp_data)
+
+    def fake_solve_qcp(**kwargs):
+        assert len(kwargs["quadratic_constraints"]) == 1
+        return QPResult(
+            status=SolveStatus.OPTIMAL,
+            x=np.array([1.0]),
+            objective=-1.0,
+            bound=-1.0,
+            gap=0.0,
+        )
+
+    monkeypatch.setattr(gurobi_backend, "solve_qcp", fake_solve_qcp)
+
+    result = solver._solve_qcp_gurobi(m, t_start=0.0)
+
+    assert result.status == "optimal"
+    assert result.objective == pytest.approx(1.0)
+    assert result.bound == pytest.approx(1.0)
+    assert result.x["x"] == pytest.approx(1.0)
+
+
 def test_gurobi_lp_smoke_if_available():
     _require_gurobi()
 
@@ -436,6 +614,62 @@ def test_gurobi_miqp_smoke_if_available():
     assert result.objective == pytest.approx(-5.0)
 
 
+def test_gurobi_qcp_smoke_if_available():
+    _require_gurobi()
+
+    result = gurobi_backend.solve_qcp(
+        Q=np.zeros((1, 1)),
+        c=np.array([1.0]),
+        bounds=[(-2.0, 2.0)],
+        quadratic_constraints=[
+            (np.array([[2.0]]), np.array([0.0]), "<=", 1.0),
+        ],
+    )
+
+    assert result.status == SolveStatus.OPTIMAL
+    assert result.x is not None
+    assert result.x[0] == pytest.approx(-1.0, abs=1e-6)
+    assert result.objective == pytest.approx(-1.0, abs=1e-6)
+
+
+def test_gurobi_miqcp_smoke_if_available():
+    _require_gurobi()
+
+    result = gurobi_backend.solve_qcp(
+        Q=np.zeros((2, 2)),
+        c=np.array([-1.0, 0.0]),
+        bounds=[(0.0, 2.0), (0.0, 1.0)],
+        quadratic_constraints=[
+            (np.array([[2.0, 0.0], [0.0, 0.0]]), np.array([0.0, -1.0]), "<=", 0.0),
+        ],
+        integrality=np.array([0, 1], dtype=np.int32),
+    )
+
+    assert result.status == SolveStatus.OPTIMAL
+    assert result.x is not None
+    np.testing.assert_allclose(result.x, [1.0, 1.0], atol=1e-6)
+    assert result.objective == pytest.approx(-1.0, abs=1e-6)
+
+
+def test_gurobi_nonconvex_qcp_smoke_if_available():
+    _require_gurobi()
+
+    result = gurobi_backend.solve_qcp(
+        Q=np.zeros((1, 1)),
+        c=np.array([1.0]),
+        bounds=[(-2.0, 2.0)],
+        quadratic_constraints=[
+            (np.array([[2.0]]), np.array([0.0]), ">=", 1.0),
+        ],
+        options={"NonConvex": 2},
+    )
+
+    assert result.status == SolveStatus.OPTIMAL
+    assert result.x is not None
+    assert result.x[0] == pytest.approx(-2.0, abs=1e-6)
+    assert result.objective == pytest.approx(-2.0, abs=1e-6)
+
+
 def test_model_solve_gurobi_qp_smoke_if_available():
     _require_gurobi()
 
@@ -467,3 +701,18 @@ def test_model_solve_gurobi_miqp_smoke_if_available():
     assert result.objective == pytest.approx(0.0, abs=1e-7)
     assert result.x["x"] == pytest.approx(1.0, abs=1e-6)
     assert result.x["y"] == pytest.approx(2.0, abs=1e-6)
+
+
+def test_model_solve_gurobi_qcp_smoke_if_available():
+    _require_gurobi()
+
+    m = dm.Model("gurobi_qcp_model_solve_smoke")
+    x = m.continuous("x", lb=-2, ub=2)
+    m.minimize(x)
+    m.subject_to(x**2 <= 1)
+
+    result = m.solve(solver="gurobi", time_limit=30.0)
+
+    assert result.status == "optimal"
+    assert result.objective == pytest.approx(-1.0, abs=1e-6)
+    assert result.x["x"] == pytest.approx(-1.0, abs=1e-6)

--- a/python/tests/test_lp_qp_solvers.py
+++ b/python/tests/test_lp_qp_solvers.py
@@ -68,6 +68,48 @@ class TestProblemClassifier:
         m.subject_to(x + y <= 5)
         assert classify_problem(m) == ProblemClass.MIQP
 
+    def test_qcp_detection(self):
+        """Linear obj + quadratic constraints + continuous = QCP."""
+        from discopt._jax.problem_classifier import ProblemClass, classify_problem
+
+        m = dm.Model("qcp_test")
+        x = m.continuous("x", lb=-2, ub=2)
+        m.minimize(x)
+        m.subject_to(x**2 <= 1)
+        assert classify_problem(m) == ProblemClass.QCP
+
+    def test_qcqp_detection(self):
+        """Quadratic obj + quadratic constraints + continuous = QCQP."""
+        from discopt._jax.problem_classifier import ProblemClass, classify_problem
+
+        m = dm.Model("qcqp_test")
+        x = m.continuous("x", lb=-2, ub=2)
+        m.minimize((x - 1) ** 2)
+        m.subject_to(x**2 <= 1)
+        assert classify_problem(m) == ProblemClass.QCQP
+
+    def test_miqcp_detection(self):
+        """Linear obj + quadratic constraints + integer = MIQCP."""
+        from discopt._jax.problem_classifier import ProblemClass, classify_problem
+
+        m = dm.Model("miqcp_test")
+        x = m.continuous("x", lb=-2, ub=2)
+        y = m.binary("y")
+        m.minimize(x + y)
+        m.subject_to(x**2 <= y)
+        assert classify_problem(m) == ProblemClass.MIQCP
+
+    def test_miqcqp_detection(self):
+        """Quadratic obj + quadratic constraints + integer = MIQCQP."""
+        from discopt._jax.problem_classifier import ProblemClass, classify_problem
+
+        m = dm.Model("miqcqp_test")
+        x = m.continuous("x", lb=-2, ub=2)
+        y = m.binary("y")
+        m.minimize((x - 1) ** 2 + y)
+        m.subject_to(x**2 <= y)
+        assert classify_problem(m) == ProblemClass.MIQCQP
+
     def test_nlp_detection(self):
         """Nonlinear constraints + continuous = NLP."""
         from discopt._jax.problem_classifier import ProblemClass, classify_problem
@@ -80,7 +122,7 @@ class TestProblemClassifier:
         assert classify_problem(m) == ProblemClass.NLP
 
     def test_minlp_detection(self):
-        """Nonlinear + integer = MINLP."""
+        """Quadratic constraints with integers classify as MIQCQP."""
         from discopt._jax.problem_classifier import ProblemClass, classify_problem
 
         m = dm.Model("minlp_test")
@@ -88,10 +130,7 @@ class TestProblemClassifier:
         y = m.binary("y")
         m.minimize(x**2 + y)
         m.subject_to(x * x + y <= 5)
-        # x*x is quadratic in constraint but together with non-linear structure
-        # this should be detected properly
-        result = classify_problem(m)
-        assert result in (ProblemClass.MIQP, ProblemClass.MINLP)
+        assert classify_problem(m) == ProblemClass.MIQCQP
 
 
 # ---------------------------------------------------------------
@@ -128,6 +167,28 @@ class TestLPExtraction:
         assert jnp.allclose(qp_data.Q[:2, :2], 2.0 * jnp.eye(2), atol=1e-6)
         # c should be [3, 0]
         assert jnp.allclose(qp_data.c[:2], jnp.array([3.0, 0.0]), atol=1e-6)
+
+    def test_qcp_extraction(self):
+        """Extract QCP data with linear and quadratic rows preserved."""
+        from discopt._jax.problem_classifier import extract_qcp_data
+
+        m = dm.Model("test_qcp")
+        x = m.continuous("x", shape=(2,), lb=-2, ub=2)
+        m.minimize(3 * x[0] + x[1])
+        m.subject_to(x[0] + x[1] <= 5)
+        m.subject_to(x[0] ** 2 + x[1] <= 1)
+
+        qcp_data = extract_qcp_data(m)
+
+        assert jnp.allclose(qcp_data.c, jnp.array([3.0, 1.0]), atol=1e-10)
+        assert jnp.allclose(qcp_data.A_ub, jnp.array([[1.0, 1.0]]), atol=1e-10)
+        assert jnp.allclose(qcp_data.b_ub, jnp.array([5.0]), atol=1e-10)
+        assert len(qcp_data.quadratic_constraints) == 1
+        row = qcp_data.quadratic_constraints[0]
+        assert row.sense == "<="
+        assert row.rhs == pytest.approx(1.0)
+        assert jnp.allclose(row.Q, jnp.array([[2.0, 0.0], [0.0, 0.0]]), atol=1e-10)
+        assert jnp.allclose(row.c, jnp.array([0.0, 1.0]), atol=1e-10)
 
 
 # ---------------------------------------------------------------


### PR DESCRIPTION
## Summary

Adds Gurobi support for quadratically constrained models:

- classifies QCP, QCQP, MIQCP, and MIQCQP models when all constraints are quadratic-representable;
- extracts QCP data as matrix-form objective terms, linear rows, and explicit quadratic constraint rows;
- adds `discopt.solvers.gurobi.solve_qcp` with convex-row handling and explicit `NonConvex` opt-in for nonconvex quadratic objectives, indefinite rows, non-concave `>=` rows, and quadratic equalities;
- routes `Model.solve(solver="gurobi")` through the QCP backend and maps `SolveResult` objective, bound, gap, time-limit, infeasible, unbounded, and error statuses consistently;
- adds focused dispatch, extraction, validation, and optional Gurobi smoke coverage.

Closes #101.

## Tests

- `PYTHONPATH=python XDG_CACHE_HOME=/tmp/discopt-cache pytest python/tests/test_gurobi_backend.py -q`
  - `17 passed, 10 skipped`
- `PYTHONPATH=python XDG_CACHE_HOME=/tmp/discopt-cache pytest python/tests/test_lp_qp_solvers.py::TestLPExtraction::test_qcp_extraction -q`
  - `1 passed`
- `PYTHONPATH=python python -m py_compile python/discopt/_jax/problem_classifier.py python/discopt/solvers/gurobi.py python/discopt/solver.py python/discopt/modeling/core.py python/tests/test_gurobi_backend.py python/tests/test_lp_qp_solvers.py`
  - passed
- `PYTHONPATH=python python -m ruff check python/discopt/_jax/problem_classifier.py python/discopt/solvers/gurobi.py python/discopt/solver.py python/discopt/modeling/core.py python/tests/test_gurobi_backend.py python/tests/test_lp_qp_solvers.py`
  - passed
- `PYTHONPATH=python python -m ruff format --check python/discopt/_jax/problem_classifier.py python/discopt/solvers/gurobi.py python/discopt/solver.py python/discopt/modeling/core.py python/tests/test_gurobi_backend.py python/tests/test_lp_qp_solvers.py`
  - passed

Notes:

- Local optional Gurobi smoke tests skipped because no usable `gurobipy`/license is available in this environment.
- A broader local run of `test_lp_qp_solvers.py` is not representative here because `discopt._rust` is not built in this worktree; structural classifier tests fall back to NLP/MINLP without that extension.
- The commit hook could not run locally because `pre-commit` is not installed; the targeted ruff and compile checks above were run directly.

## Branch Hygiene

- Base branch: `gurobi`
- Source branch point: `origin/gurobi` at `db1eef6`
- Stacked status: not stacked
- Prerequisite PRs: #103 and #106 are merged into `gurobi`
