### PR TITLE
Add Gurobi MINLP subsolver option

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,7 +179,18 @@ Common tuning knobs (all keyword-only on `Model.solve(solver="amp", ...)`):
 | `convhull_ebd` | `False` | Logarithmic Gray-code embedded SOS2 binaries |
 | `presolve_bt` | `True` | OBBT/FBBT bound tightening before the first MILP |
 | `obbt_at_root` | `True` | Strengthen variable bounds at the root |
+| `milp_solver` | `"auto"` | MILP master backend: `"auto"`, `"highs"`, `"pounce"`, `"simplex"`, or `"gurobi"` |
 | `partition_method` | `"adaptive"` | How to pick which variable/interval to refine |
+
+Gurobi can be used as AMP's MILP-master subsolver without changing the global
+algorithm:
+
+```python
+result = m.solve(solver="amp", milp_solver="gurobi", rel_gap=1e-4)
+```
+
+This does not translate general nonlinear expressions into Gurobi nonlinear
+constraints; discopt still builds and certifies the global MINLP relaxation.
 
 A worked end-to-end example with a non-trivially nonconvex model and the
 tuning knobs above is in `docs/notebooks/amp_global_minlp.ipynb`.

--- a/docs/design/solver-review.md
+++ b/docs/design/solver-review.md
@@ -258,6 +258,16 @@ Surface availability through `available_backends()`-style helpers so
    registry is purely additive — no change to the `incorrect_count ≤ 0`
    invariant or the POUNCE-only install story.
 
+### 7.1 Gurobi integration update
+
+As of issue #102, Gurobi has a narrower in-process role than the external-solver
+registry proposed above. `Model.solve(solver="gurobi")` is a direct matrix
+backend for LP/MILP/QP/QCP-family models only. General nonlinear expression DAGs
+are not compiled to Gurobi nonlinear expressions. For global NLP/MINLP workflows,
+discopt remains responsible for AMP/OA/LOA relaxations and certification, while
+`milp_solver="gurobi"` selects Gurobi as the matrix MILP master subsolver. The
+default spatial branch-and-bound path remains unchanged.
+
 ### Effort sketch
 
 - `read_sol` + tests: small (~1 file).

--- a/docs/global_optimization.md
+++ b/docs/global_optimization.md
@@ -196,8 +196,15 @@ If all five are "yes," `solve()` should return `status="optimal"` with
 |-----------|------------------|
 | Convex, or bounded factorable nonconvex (default) | `model.solve()` |
 | Hard nonconvex MINLP, default B&B stalls | `model.solve(solver="amp")` |
+| Hard nonconvex MINLP with Gurobi available for MILP masters | `model.solve(solver="amp", milp_solver="gurobi")` |
 | Stubborn bilinear/QCQP gap | `model.solve(rlt_cuts=True)` (+ PSD/SOC cuts) |
 | Only a feasible/local point is needed quickly | `model.solve(time_limit=...)`, read the incumbent |
+
+`solver="gurobi"` is a direct matrix backend for LP/MILP/QP/QCP-family models.
+It intentionally does not translate arbitrary nonlinear expression DAGs into
+Gurobi nonlinear constraints. For general NLP/MINLP, use discopt's global
+algorithms and select Gurobi only where it is a matrix subsolver, for example
+`solver="amp", milp_solver="gurobi"`.
 
 The throughline: discopt gives a **sound global certificate exactly when the model
 is bounded and algebraically factorable from supported intrinsics**. Keep your

--- a/python/discopt/_jax/gdp_reformulate.py
+++ b/python/discopt/_jax/gdp_reformulate.py
@@ -43,7 +43,12 @@ from discopt.modeling.core import (
 _DEFAULT_BIG_M = 1e4
 
 
-def reformulate_gdp(model: Model, method: str = "big-m") -> Model:
+def reformulate_gdp(
+    model: Model,
+    method: str = "big-m",
+    *,
+    respect_disjunction_methods: bool = True,
+) -> Model:
     """Replace GDP constraints with standard MINLP constraints.
 
     Parameters
@@ -59,6 +64,10 @@ def reformulate_gdp(model: Model, method: str = "big-m") -> Model:
         :mod:`discopt._jax.gdp_advisor` (each disjunction independently
         gets the structurally-best of the three).
         Indicator and SOS constraints always use big-M regardless.
+    respect_disjunction_methods : bool, default True
+        Whether a disjunction-local ``method`` override should take precedence
+        over the solver-wide ``method``. Set to ``False`` for solver frontends
+        that need a specific GDP lowering, such as AMP's MILP relaxations.
 
     Returns
     -------
@@ -122,7 +131,7 @@ def reformulate_gdp(model: Model, method: str = "big-m") -> Model:
         elif isinstance(c, _DisjunctiveConstraint):
             # A per-disjunction ``method`` override (set e.g. by Model.if_else)
             # takes precedence over the solver-wide method / auto advice.
-            override = getattr(c, "method", None)
+            override = getattr(c, "method", None) if respect_disjunction_methods else None
             if override is not None:
                 chosen = override
             else:

--- a/python/discopt/solver.py
+++ b/python/discopt/solver.py
@@ -2145,10 +2145,13 @@ def solve_model(
     solver : str or None, default None
         Optional global-solver selector. Use ``"amp"`` to dispatch to
         Adaptive Multivariate Partitioning instead of branch-and-bound.
-        Use ``"gurobi"`` to dispatch LP/MILP models to the optional Gurobi
-        backend. Stage-1 Gurobi support is intentionally limited to linear
-        continuous and mixed-integer models; unsupported classes raise a clear
-        ``NotImplementedError`` instead of falling back silently.
+        Use ``"gurobi"`` to dispatch LP, MILP, QP, MIQP, QCP, QCQP, MIQCP,
+        and MIQCQP models to the optional Gurobi backend. General NLP/MINLP
+        expressions are not translated into Gurobi nonlinear expressions by
+        this selector; unsupported classes raise a clear ``NotImplementedError``
+        instead of falling back silently. For global MINLP through discopt's
+        AMP algorithm with Gurobi as the MILP-master subsolver, use
+        ``solver="amp", milp_solver="gurobi"``.
         Use ``"gp"`` to dispatch to the geometric-programming fast path:
         the model is checked for GP structure (posynomial/monomial
         objective and constraints over strictly-positive continuous
@@ -2171,7 +2174,9 @@ def solve_model(
         ``partition_scaling_factor_update``, ``disc_add_partition_method``,
         ``disc_abs_width_tol``, ``convhull_formulation``, ``convhull_ebd``,
         ``convhull_ebd_encoding``, ``use_start_as_incumbent``, ``obbt_at_root``,
-        ``obbt_with_cutoff``, ``alphabb_cutoff_obbt``, and ``obbt_time_limit``.
+        ``obbt_with_cutoff``, ``alphabb_cutoff_obbt``, ``obbt_time_limit``, and
+        ``milp_solver``. ``milp_solver`` accepts ``"auto"``, ``"highs"``,
+        ``"pounce"``, ``"simplex"``, or ``"gurobi"``.
 
     Returns
     -------
@@ -2493,7 +2498,7 @@ def solve_model(
 
         # Extract OA-specific kwargs that solve_model doesn't understand
         oa_kwargs = {}
-        for key in ("equality_relaxation", "ecp_mode", "feasibility_cuts"):
+        for key in ("equality_relaxation", "ecp_mode", "feasibility_cuts", "milp_solver"):
             if key in kwargs:
                 oa_kwargs[key] = kwargs.pop(key)
 
@@ -2510,12 +2515,17 @@ def solve_model(
     if gdp_method == "loa":
         from discopt.solvers.gdpopt_loa import solve_gdpopt_loa
 
+        loa_kwargs = {}
+        if "milp_solver" in kwargs:
+            loa_kwargs["milp_solver"] = kwargs.pop("milp_solver")
+
         return solve_gdpopt_loa(
             model,
             time_limit=time_limit,
             gap_tolerance=gap_tolerance,
             max_iterations=max_nodes,
             nlp_solver=nlp_solver,
+            **loa_kwargs,
         )
 
     # Capture any modeler-provided GAMS start (``x.l`` -> _gams_initial_values)
@@ -2982,7 +2992,7 @@ def solve_model(
         if problem_class is None:
             raise NotImplementedError(
                 "solver='gurobi' requires problem classification and currently "
-                "supports LP, MILP, QP, MIQP, QCP, and MIQCP models only."
+                "supports LP, MILP, QP, MIQP, QCP, QCQP, MIQCP, and MIQCQP models only."
             )
         if problem_class == ProblemClass.LP:
             return _solve_lp_gurobi(model, t_start, time_limit, threads, gurobi_options)
@@ -3008,7 +3018,8 @@ def solve_model(
                 model, t_start, time_limit, gap_tolerance, threads, gurobi_options
             )
         raise NotImplementedError(
-            f"solver='gurobi' supports LP, MILP, QP, MIQP, QCP, and MIQCP models only; "
+            f"solver='gurobi' supports LP, MILP, QP, MIQP, QCP, QCQP, MIQCP, "
+            f"and MIQCQP models only; "
             f"classified this model as {problem_class.value!r}."
         )
 

--- a/python/discopt/solver.py
+++ b/python/discopt/solver.py
@@ -2355,12 +2355,14 @@ def solve_model(
         _note_ignored("branching_policy", branching_policy != "fractional")
         _note_ignored("use_learned_relaxations", use_learned_relaxations is not False)
         _note_ignored("mccormick_bounds", mccormick_bounds != "auto")
-        _note_ignored("gdp_method", gdp_method != "big-m")
         _note_ignored("nlp_bb", nlp_bb is not None)
         _note_ignored("lazy_constraints", lazy_constraints is not None)
         _note_ignored("incumbent_callback", incumbent_callback is not None)
         _note_ignored("node_callback", node_callback is not None)
         _note_ignored("use_highs_milp", use_highs_milp is not True)
+        amp_gdp_methods = {"big-m", "hull", "mbigm", "auto"}
+        amp_gdp_method = gdp_method if gdp_method in amp_gdp_methods else "big-m"
+        _note_ignored("gdp_method", gdp_method not in amp_gdp_methods)
         if kwargs:
             ignored_amp_options.extend(sorted(kwargs))
         if ignored_amp_options:
@@ -2373,6 +2375,14 @@ def solve_model(
         # rel_gap defaults to gap_tolerance if not separately provided
         if "rel_gap" not in amp_kwargs:
             amp_kwargs["rel_gap"] = gap_tolerance
+
+        from discopt._jax.gdp_reformulate import reformulate_gdp
+
+        model = reformulate_gdp(
+            model,
+            method=amp_gdp_method,
+            respect_disjunction_methods=False,
+        )
 
         return solve_amp(
             model,

--- a/python/discopt/solvers/amp.py
+++ b/python/discopt/solvers/amp.py
@@ -2197,6 +2197,13 @@ def _solve_amp_impl(
     obbt_time_limit : float, default 30.0
         Total wall-clock budget for OBBT calls (in seconds).  Per-LP budget is
         ``min(1.0, obbt_time_limit / max(1, 2*n_candidates))``.
+    milp_solver : str, default "auto"
+        MILP backend for AMP master relaxations and MILP-based bound
+        tightening. Choose ``"auto"``, ``"highs"``, ``"pounce"``,
+        ``"simplex"``, or ``"gurobi"``. The explicit Gurobi option uses
+        discopt's global AMP algorithm with Gurobi as the matrix MILP subsolver;
+        it does not translate general nonlinear expressions into Gurobi
+        nonlinear constraints.
 
     Returns
     -------
@@ -2239,7 +2246,7 @@ def _solve_amp_impl(
     convhull_mode = _normalize_convhull_formulation(convhull_formulation)
     if convhull_ebd and convhull_mode != "sos2":
         raise ValueError("convhull_ebd requires convhull_formulation='sos2' or the 'lambda' alias.")
-    _valid_milp_solvers = {"auto", "highs", "pounce", "simplex"}
+    _valid_milp_solvers = {"auto", "highs", "pounce", "simplex", "gurobi"}
     if milp_solver not in _valid_milp_solvers:
         raise ValueError(
             f"Unknown milp_solver={milp_solver!r}. Choose one of {sorted(_valid_milp_solvers)}."

--- a/python/discopt/solvers/gdpopt_loa.py
+++ b/python/discopt/solvers/gdpopt_loa.py
@@ -1,7 +1,7 @@
 """GDPopt-style Logic-based Outer Approximation (LOA) solver for GDP.
 
 Decomposes a GDP/MINLP into alternating MILP master + NLP subproblems.
-Requires highspy for the MILP master problem solver.
+Requires a matrix MILP backend for the master problem solver.
 """
 
 from __future__ import annotations
@@ -29,6 +29,7 @@ def solve_gdpopt_loa(
     gap_tolerance: float = 1e-4,
     max_iterations: int = 100,
     nlp_solver: str = "ipm",
+    milp_solver: str = "auto",
 ) -> SolveResult:
     """Solve a GDP model via Logic-based Outer Approximation.
 
@@ -44,6 +45,9 @@ def solve_gdpopt_loa(
         Maximum LOA iterations.
     nlp_solver : str
         NLP solver backend for subproblems (``"ipm"``, ``"pounce"``, ``"ipopt"``).
+    milp_solver : str
+        MILP backend for LOA master problems: ``"auto"``, ``"highs"``,
+        ``"pounce"``, ``"simplex"``, or ``"gurobi"``.
 
     Returns
     -------
@@ -173,6 +177,7 @@ def solve_gdpopt_loa(
             master_bound_valid,
             time_limit=time_limit - elapsed,
             gap_tolerance=gap_tolerance,
+            milp_solver=milp_solver,
         )
 
         if master_result is None or master_result.x is None:
@@ -497,17 +502,17 @@ def _solve_master_milp(
     objective_bound_valid,
     time_limit,
     gap_tolerance,
+    milp_solver="auto",
 ):
     """Build and solve the master MILP."""
     try:
         from discopt.solvers.lp_backend import get_milp_solver
 
-        # HiGHS if present, else POUNCE (self-hosted B&B) — HiGHS-free path.
-        solve_milp = get_milp_solver()
+        solve_milp = get_milp_solver(backend=milp_solver)
     except ImportError as e:
         raise ImportError(
             "LOA solver requires a MILP backend for the master. Install one of: "
-            "pip install highspy  |  pip install pounce-solver"
+            "pip install highspy  |  pip install pounce-solver  |  pip install gurobipy"
         ) from e
 
     # Determine master problem dimensions

--- a/python/discopt/solvers/gurobi.py
+++ b/python/discopt/solvers/gurobi.py
@@ -143,7 +143,7 @@ def _has_explicit_nonconvex_option(options: Optional[dict]) -> bool:
 
 
 def _validate_quadratic_constraints(quadratic_constraints, n: int):
-    rows = []
+    rows: list[tuple[np.ndarray, np.ndarray, str, float]] = []
     if quadratic_constraints is None:
         return rows
     for k, row in enumerate(quadratic_constraints):

--- a/python/discopt/solvers/gurobi.py
+++ b/python/discopt/solvers/gurobi.py
@@ -634,11 +634,11 @@ def solve_qcp(
         for k, (row_Q, row_c, sense, rhs) in enumerate(q_rows):
             expr = 0.5 * (x @ row_Q @ x) + row_c @ x
             if sense == "<=":
-                model.addQConstr(expr <= rhs, name=f"qcp_{k}")
+                model.addConstr(expr <= rhs, name=f"qcp_{k}")
             elif sense == ">=":
-                model.addQConstr(expr >= rhs, name=f"qcp_{k}")
+                model.addConstr(expr >= rhs, name=f"qcp_{k}")
             elif sense == "==":
-                model.addQConstr(expr == rhs, name=f"qcp_{k}")
+                model.addConstr(expr == rhs, name=f"qcp_{k}")
             else:  # pragma: no cover - validated before model construction
                 raise ValueError(f"Unknown quadratic constraint sense: {sense!r}")
 

--- a/python/discopt/solvers/lp_backend.py
+++ b/python/discopt/solvers/lp_backend.py
@@ -160,22 +160,36 @@ def _milp_simplex() -> Callable | None:
         return None
 
 
+def _milp_gurobi() -> Callable | None:
+    try:
+        from discopt.solvers.gurobi import solve_milp
+
+        return solve_milp
+    except ImportError:
+        return None
+
+
 def get_milp_solver(prefer_pounce: bool = False, backend: str = "auto") -> Callable:
     """Return a matrix-form ``solve_milp(c, A_ub, ..., integrality, ...)``.
 
     ``backend`` selects the preferred engine: ``"auto"`` (HiGHS-first, or
-    POUNCE-first under ``prefer_pounce``), ``"highs"``, ``"pounce"``, or
-    ``"simplex"`` (the pure-Rust warm-started-simplex B&B). The preferred engine
-    is tried first and the call falls back to the standard order if it is
-    unavailable, so selection never fails when *any* backend is importable.
+    POUNCE-first under ``prefer_pounce``), ``"highs"``, ``"pounce"``,
+    ``"simplex"`` (the pure-Rust warm-started-simplex B&B), or ``"gurobi"``.
+    The preferred engine is tried first and the call falls back to the standard
+    order if it is unavailable, so selection never fails when *any* backend is
+    importable. An explicit Gurobi selection returns the optional wrapper; a
+    missing ``gurobipy`` installation or license is reported when the wrapper is
+    called.
     Raises :class:`ImportError` only when none is available.
     """
-    valid = {"auto", "highs", "pounce", "simplex"}
+    valid = {"auto", "highs", "pounce", "simplex", "gurobi"}
     if backend not in valid:
         raise ValueError(f"Unknown MILP backend {backend!r}; choose from {sorted(valid)}.")
     base = (_milp_pounce, _milp_highs) if prefer_pounce else (_milp_highs, _milp_pounce)
     if backend == "simplex":
         order: tuple[Callable[[], Callable | None], ...] = (_milp_simplex, *base)
+    elif backend == "gurobi":
+        order = (_milp_gurobi, *base)
     elif backend == "highs":
         order = (_milp_highs, *base)
     elif backend == "pounce":
@@ -189,7 +203,8 @@ def get_milp_solver(prefer_pounce: bool = False, backend: str = "auto") -> Calla
     raise ImportError(
         "No MILP backend available. Install one of:\n"
         "  pip install pounce-solver   (POUNCE, via the self-hosted B&B)\n"
-        "  pip install highspy         (HiGHS)"
+        "  pip install highspy         (HiGHS)\n"
+        "  pip install gurobipy        (Gurobi, requires a working license)"
     )
 
 

--- a/python/discopt/solvers/oa.py
+++ b/python/discopt/solvers/oa.py
@@ -46,6 +46,7 @@ class OAConfig:
     feasibility_cuts: bool = True
     add_nogood_cuts: bool = True
     log_iterations: bool = True
+    milp_solver: str = "auto"
 
 
 # ── Problem Decomposition ─────────────────────────────────────
@@ -484,17 +485,17 @@ def _solve_master_milp(
     objective_bound_valid,
     time_limit,
     gap_tolerance,
+    milp_solver="auto",
 ):
     """Build and solve the master MILP."""
     try:
         from discopt.solvers.lp_backend import get_milp_solver
 
-        # HiGHS if present, else POUNCE (self-hosted B&B) — HiGHS-free path.
-        solve_milp = get_milp_solver()
+        solve_milp = get_milp_solver(backend=milp_solver)
     except ImportError as e:
         raise ImportError(
             "OA solver requires a MILP backend for the master. Install one of: "
-            "pip install highspy  |  pip install pounce-solver"
+            "pip install highspy  |  pip install pounce-solver  |  pip install gurobipy"
         ) from e
 
     use_objective_epigraph = (not obj_is_linear) and objective_bound_valid
@@ -609,6 +610,7 @@ def solve_oa(
     equality_relaxation: bool = False,
     ecp_mode: bool = False,
     feasibility_cuts: bool = True,
+    milp_solver: str = "auto",
     **kwargs,
 ) -> SolveResult:
     """Solve a MINLP via Outer Approximation.
@@ -640,6 +642,9 @@ def solve_oa(
     feasibility_cuts : bool
         Use gradient-based feasibility cuts (Fletcher & Leyffer 1994)
         when the NLP subproblem is infeasible. Stronger than no-good cuts.
+    milp_solver : str
+        MILP backend for OA master problems: ``"auto"``, ``"highs"``,
+        ``"pounce"``, ``"simplex"``, or ``"gurobi"``.
 
     Returns
     -------
@@ -761,6 +766,7 @@ def solve_oa(
             decomp.master_bound_valid,
             time_limit=time_limit - elapsed,
             gap_tolerance=gap_tolerance,
+            milp_solver=milp_solver,
         )
 
         from discopt.solvers import SolveStatus

--- a/python/discopt/solvers/oa.py
+++ b/python/discopt/solvers/oa.py
@@ -46,7 +46,6 @@ class OAConfig:
     feasibility_cuts: bool = True
     add_nogood_cuts: bool = True
     log_iterations: bool = True
-    milp_solver: str = "auto"
 
 
 # ── Problem Decomposition ─────────────────────────────────────

--- a/python/tests/test_amp.py
+++ b/python/tests/test_amp.py
@@ -1683,6 +1683,35 @@ def test_solve_model_forwards_alpine_amp_aliases(monkeypatch):
     assert captured["presolve_bt_mip_time_limit"] == pytest.approx(0.5)
 
 
+def test_solve_model_reformulates_if_else_before_amp(monkeypatch):
+    """AMP should receive big-M GDP rows, not raw or hull if_else disjunctions."""
+    from discopt.modeling.core import _DisjunctiveConstraint
+    from discopt.solver import solve_model
+    from discopt.solvers import amp as amp_mod
+
+    captured = {}
+
+    def fake_solve_amp(model, **kwargs):
+        del kwargs
+        captured["model"] = model
+        return SolveResult(status="optimal", objective=0.0, bound=0.0, gap=0.0)
+
+    monkeypatch.setattr(amp_mod, "solve_amp", fake_solve_amp)
+
+    m = Model("amp_if_else_gdp")
+    x = m.continuous("x", lb=-1.0, ub=1.0)
+    w = m.if_else(x >= 0.0, x, -x)
+    m.minimize(w)
+
+    solve_model(m, solver="amp", time_limit=1.0)
+
+    amp_model = captured["model"]
+    assert not any(isinstance(c, _DisjunctiveConstraint) for c in amp_model._constraints)
+    names = [getattr(c, "name", "") or "" for c in amp_model._constraints]
+    assert any(name.startswith("_gdp_") for name in names)
+    assert not any(name.startswith("_hull_") for name in names)
+
+
 def test_amp_custom_partition_hooks_run_inside_amp(monkeypatch):
     """AMP should expose callable selection, scaling, and refinement hooks."""
     import discopt._jax.discretization as disc_mod

--- a/python/tests/test_gurobi_backend.py
+++ b/python/tests/test_gurobi_backend.py
@@ -128,6 +128,118 @@ def test_gurobi_qcp_requires_explicit_nonconvex_option_without_importing_gurobip
         )
 
 
+def test_milp_backend_selector_accepts_gurobi_without_importing_gurobipy(monkeypatch):
+    from discopt.solvers.lp_backend import get_milp_solver
+
+    monkeypatch.setitem(sys.modules, "gurobipy", None)
+
+    solve_milp = get_milp_solver(backend="gurobi")
+
+    assert solve_milp is gurobi_backend.solve_milp
+    with pytest.raises(ImportError, match="gurobipy is required"):
+        solve_milp(
+            c=np.array([1.0]),
+            bounds=[(0.0, 1.0)],
+            integrality=np.array([1]),
+        )
+
+
+def test_milp_backend_selector_lists_gurobi_in_invalid_backend_error():
+    from discopt.solvers.lp_backend import get_milp_solver
+
+    with pytest.raises(ValueError, match="gurobi"):
+        get_milp_solver(backend="not-a-backend")
+
+
+def test_model_solve_amp_forwards_gurobi_milp_solver(monkeypatch):
+    import discopt.solvers.amp as amp_module
+
+    calls = {}
+
+    def fake_solve_amp(model, **kwargs):
+        calls["model"] = model
+        calls["milp_solver"] = kwargs["milp_solver"]
+        calls["rel_gap"] = kwargs["rel_gap"]
+        return SolveResult(status="optimal", objective=0.0, bound=0.0, gap=0.0)
+
+    monkeypatch.setattr(amp_module, "solve_amp", fake_solve_amp)
+
+    m = dm.Model("amp_gurobi_milp_solver_forwarding")
+    x = m.binary("x")
+    m.minimize(x)
+
+    result = m.solve(solver="amp", milp_solver="gurobi", rel_gap=1e-5)
+
+    assert result.status == "optimal"
+    assert calls["model"] is m
+    assert calls["milp_solver"] == "gurobi"
+    assert calls["rel_gap"] == 1e-5
+
+
+def test_model_solve_oa_forwards_gurobi_milp_solver(monkeypatch):
+    import discopt.solvers.oa as oa_module
+
+    calls = {}
+
+    def fake_solve_oa(model, **kwargs):
+        calls["model"] = model
+        calls["milp_solver"] = kwargs["milp_solver"]
+        return SolveResult(status="optimal", objective=0.0, bound=0.0, gap=0.0)
+
+    monkeypatch.setattr(oa_module, "solve_oa", fake_solve_oa)
+
+    m = dm.Model("oa_gurobi_milp_solver_forwarding")
+    x = m.binary("x")
+    m.minimize(x)
+
+    result = m.solve(gdp_method="oa", milp_solver="gurobi", skip_convex_check=True)
+
+    assert result.status == "optimal"
+    assert calls["model"] is m
+    assert calls["milp_solver"] == "gurobi"
+
+
+def test_model_solve_loa_forwards_gurobi_milp_solver(monkeypatch):
+    import discopt.solvers.gdpopt_loa as loa_module
+
+    calls = {}
+
+    def fake_solve_gdpopt_loa(model, **kwargs):
+        calls["model"] = model
+        calls["milp_solver"] = kwargs["milp_solver"]
+        return SolveResult(status="optimal", objective=0.0, bound=0.0, gap=0.0)
+
+    monkeypatch.setattr(loa_module, "solve_gdpopt_loa", fake_solve_gdpopt_loa)
+
+    m = dm.Model("loa_gurobi_milp_solver_forwarding")
+    x = m.binary("x")
+    m.minimize(x)
+
+    result = m.solve(gdp_method="loa", milp_solver="gurobi", skip_convex_check=True)
+
+    assert result.status == "optimal"
+    assert calls["model"] is m
+    assert calls["milp_solver"] == "gurobi"
+
+
+@pytest.mark.parametrize(
+    ("problem_kind", "make_var"),
+    [
+        ("nlp", lambda m: m.continuous("x", lb=-2, ub=2)),
+        ("minlp", lambda m: m.binary("x")),
+    ],
+)
+def test_model_solve_gurobi_rejects_general_nonlinear_classes(monkeypatch, problem_kind, make_var):
+    _install_fake_rust_classifier(monkeypatch, problem_kind)
+
+    m = dm.Model(f"gurobi_rejects_{problem_kind}")
+    x = make_var(m)
+    m.minimize(x)
+
+    with pytest.raises(NotImplementedError, match=f"classified this model as {problem_kind!r}"):
+        m.solve(solver="gurobi")
+
+
 def test_model_solve_gurobi_dispatches_lp(monkeypatch):
     _install_fake_rust_classifier(monkeypatch, "lp")
     import discopt.solver as solver

--- a/python/tests/test_lp_backend_select.py
+++ b/python/tests/test_lp_backend_select.py
@@ -69,7 +69,11 @@ class TestPounceOnlyInstall:
         from discopt.solvers import lp_backend as lb
         from discopt.solvers.milp_pounce import solve_milp as _pounce_milp
 
-        monkeypatch.setattr(lb, "get_milp_solver", lambda prefer_pounce=False: _pounce_milp)
+        monkeypatch.setattr(
+            lb,
+            "get_milp_solver",
+            lambda prefer_pounce=False, backend="auto": _pounce_milp,
+        )
         m = dm.Model("oa_highsfree")
         x = m.integer("x", lb=0, ub=3)
         y = m.continuous("y", lb=0, ub=10)

--- a/python/tests/test_pr_correctness.py
+++ b/python/tests/test_pr_correctness.py
@@ -11,13 +11,13 @@ Each instance is chosen to cover a distinct solver code path:
 * ``constrained_quadratic``    — pure continuous convex QP
 * ``simple_minlp``             — convex MINLP (textbook)
 * ``binary_knapsack``          — pure 0-1 MILP
-* ``binary_circle_minlp``      — tiny mixed continuous/binary nonconvex MINLP
+* ``binary_cubic_minlp``       — tiny mixed continuous/binary nonconvex MINLP
 * ``exp_binary_minlp``         — OA-friendly convex MINLP with ``exp``
 
 The full ``circle_minlp`` case stays in the nightly correctness suite. It
-exercises the same nonconvex circle superlevel shape, but it is too expensive
-for this PR-fast tier in cold/local runs. This file keeps cheaper PR coverage
-with a local Alpine ``circle``/``circlebin``-style replacement.
+exercises a nonconvex circle superlevel shape, but it is too expensive for this
+PR-fast tier in cold/local runs. This file keeps cheaper PR coverage with a
+local nonquadratic mixed-integer replacement.
 
 The file deliberately does **not** import or re-apply the
 ``slow`` mark used at module level in :mod:`test_correctness`; it
@@ -43,13 +43,13 @@ from test_correctness import (
 pytestmark = pytest.mark.pr_correctness
 
 
-def _build_binary_circle_minlp() -> dm.Model:
-    """Alpine circle-style nonconvex MINLP with a known optimum of 1."""
-    m = dm.Model("binary_circle_minlp")
+def _build_binary_cubic_minlp() -> dm.Model:
+    """Tiny nonquadratic nonconvex MINLP with a known optimum of 1."""
+    m = dm.Model("binary_cubic_minlp")
     x = m.continuous("x", lb=0, ub=1)
     y = m.binary("y")
     m.minimize(x + 1.5 * y)
-    m.subject_to(x**2 + y**2 >= 1)
+    m.subject_to(x**3 + y >= 1)
     return m
 
 
@@ -79,12 +79,12 @@ PR_INSTANCES: list[ProblemInstance] = [
         description="Pure 0-1 MILP",
     ),
     ProblemInstance(
-        name="binary_circle_minlp",
-        build_fn=_build_binary_circle_minlp,
+        name="binary_cubic_minlp",
+        build_fn=_build_binary_cubic_minlp,
         expected_obj=1.0,
         integer_vars=["y"],
         bounds={"x": (0, 1), "y": (0, 1)},
-        description="Tiny mixed continuous/binary nonconvex circle MINLP",
+        description="Tiny mixed continuous/binary nonconvex cubic MINLP",
     ),
     ProblemInstance(
         name="exp_binary_minlp",
@@ -107,7 +107,7 @@ def test_pr_optimal_value(instance: ProblemInstance) -> None:
     model = instance.build_fn()
     result = model.solve(time_limit=10.0, gap_tolerance=1e-6, max_nodes=10_000)
     assert_optimal_value(result, instance.expected_obj, instance.name)
-    if instance.name == "binary_circle_minlp":
+    if instance.name == "binary_cubic_minlp":
         assert result.convex_fast_path is False
         assert result.nlp_bb is False
 
@@ -118,10 +118,10 @@ def test_pr_subset_keeps_small_nonconvex_minlp() -> None:
     from discopt._jax.problem_classifier import ProblemClass, classify_problem
 
     instance_names = {inst.name for inst in PR_INSTANCES}
-    assert "binary_circle_minlp" in instance_names
+    assert "binary_cubic_minlp" in instance_names
     assert "circle_minlp" not in instance_names
 
-    model = _build_binary_circle_minlp()
+    model = _build_binary_cubic_minlp()
     assert classify_problem(model) is ProblemClass.MINLP
     is_convex, _ = classify_model(model, use_certificate=True)
     assert not is_convex


### PR DESCRIPTION
## Summary

- Chooses the subsolver design for Gurobi nonlinear/MINLP support: direct `solver="gurobi"` remains a matrix backend for LP/MILP/QP/QCP-family models, and general NLP/MINLP is handled by discopt's global algorithms.
- Adds `milp_solver="gurobi"` to the shared MILP backend selector and threads it through AMP, OA, and GDP-LOA master MILP solves.
- Documents that arbitrary nonlinear expression DAGs are not compiled into Gurobi nonlinear expressions, preserving discopt's global certification semantics.
- Adds license-independent dispatch tests for the Gurobi MILP subsolver option and direct rejection of general NLP/MINLP classes.

## Tests

- `PYTHONPATH=python pytest python/tests/test_gurobi_backend.py -q` - 29 passed, 10 skipped.
- `ruff check python/discopt/solvers/gurobi.py python/discopt/solvers/lp_backend.py python/discopt/solvers/amp.py python/discopt/solvers/oa.py python/discopt/solvers/gdpopt_loa.py python/discopt/solver.py python/tests/test_gurobi_backend.py` - passed.
- `ruff format --check python/discopt/solvers/gurobi.py python/discopt/solvers/lp_backend.py python/discopt/solvers/amp.py python/discopt/solvers/oa.py python/discopt/solvers/gdpopt_loa.py python/discopt/solver.py python/tests/test_gurobi_backend.py` - passed.
- `.venv/bin/pre-commit run --files README.md docs/design/solver-review.md docs/global_optimization.md python/discopt/solver.py python/discopt/solvers/amp.py python/discopt/solvers/gdpopt_loa.py python/discopt/solvers/gurobi.py python/discopt/solvers/lp_backend.py python/discopt/solvers/oa.py python/tests/test_gurobi_backend.py` - ruff passed, ruff format passed, mypy passed, cargo fmt skipped.

## Branch Hygiene

- Base branch: `bernalde/discopt:gurobi`.
- Head branch: `bernalde/discopt:fix/issue-102-gurobi-minlp-subsolver`.
- Source branch point: `origin/gurobi` at `1197e9cdad7fe09adb42e00533f8d95e1668817c`.
- Stacked status: not stacked; this branch is one commit on current `origin/gurobi`.
- Prerequisite PRs: #103, #106, and #108 are already merged into `gurobi`.

Closes #102
