### PR TITLE
Route MIP-NLP API to OA and ECP

### DIFF
--- a/python/discopt/modeling/core.py
+++ b/python/discopt/modeling/core.py
@@ -2786,7 +2786,11 @@ class Model:
             family. Current implemented ``mip_nlp_method`` values are ``"oa"``
             and ``"ecp"``; ``"goa"``, ``"roa"``, ``"fp"``, and
             ``"lp_nlp_bb"`` are reserved until their dedicated implementations
-            land.
+            land. Top-level OA/ECP options such as ``equality_relaxation``,
+            ``ecp_mode``, and ``feasibility_cuts`` take precedence over
+            duplicate keys in ``mip_nlp_options``. The ``mip_nlp_method``
+            selector determines the effective ``ecp_mode`` and cannot be
+            overridden by ``mip_nlp_options``.
         validate : bool, default False
             If True, run Examiner-style KKT validation on the returned
             point and attach the :class:`~discopt.validation.ExaminerReport`

--- a/python/discopt/profiles.py
+++ b/python/discopt/profiles.py
@@ -34,6 +34,12 @@ BUILTIN_PROFILES: dict[str, dict[str, Any]] = {
         "gap_tolerance": 1e-2,
         "tuning": {"node_bound_mode": "lp", "node_nlp_stride": 8},
     },
+    "mip-nlp-fast": {
+        "solver": "mip-nlp",
+        "mip_nlp_method": "oa",
+        "time_limit": 10.0,
+        "gap_tolerance": 1e-2,
+    },
     "exact": {
         "time_limit": 3600.0,
         "gap_tolerance": 1e-6,

--- a/python/discopt/solver.py
+++ b/python/discopt/solver.py
@@ -2210,7 +2210,11 @@ def solve_model(
         ``"ecp"``; ``"goa"``, ``"roa"``, ``"fp"``, and ``"lp_nlp_bb"`` raise
         ``NotImplementedError`` until their dedicated implementations land.
         Existing OA options ``equality_relaxation``, ``ecp_mode``, and
-        ``feasibility_cuts`` may be passed as top-level aliases.
+        ``feasibility_cuts`` may be passed as top-level aliases and take
+        precedence over duplicate keys in ``mip_nlp_options``. The
+        ``mip_nlp_method`` selector determines the effective ``ecp_mode`` and
+        cannot be overridden by ``mip_nlp_options``; a conflicting top-level
+        ``ecp_mode`` and explicit ``mip_nlp_method`` raises ``ValueError``.
 
     Returns
     -------
@@ -2370,12 +2374,14 @@ def solve_model(
 
         from discopt.solvers.mip_nlp import solve_mip_nlp
 
-        mip_nlp_method = kwargs.pop("mip_nlp_method", "oa")
+        mip_nlp_method = kwargs.pop("mip_nlp_method", None)
         mip_nlp_options = kwargs.pop("mip_nlp_options", None)
         mip_nlp_kwargs: dict[str, Any] = {}
         for key in ("equality_relaxation", "ecp_mode", "feasibility_cuts"):
             if key in kwargs:
                 mip_nlp_kwargs[key] = kwargs.pop(key)
+        if mip_nlp_method is None:
+            mip_nlp_method = "ecp" if bool(mip_nlp_kwargs.get("ecp_mode", False)) else "oa"
 
         gdp_methods = {"big-m", "hull", "mbigm", "auto"}
         if gdp_method == "oa":
@@ -2390,12 +2396,10 @@ def solve_model(
         elif gdp_method in gdp_methods:
             resolved_gdp_method = gdp_method
         else:
-            warnings.warn(
-                f"solver='mip-nlp' does not use gdp_method={gdp_method!r} as a "
-                "MINLP algorithm selector; using 'big-m' for GDP reformulation.",
-                stacklevel=2,
+            allowed = ", ".join(sorted(gdp_methods | {"oa"}))
+            raise ValueError(
+                f"Unknown gdp_method={gdp_method!r} for solver='mip-nlp'. Choose one of: {allowed}."
             )
-            resolved_gdp_method = "big-m"
 
         ignored_mip_nlp_options = []
 

--- a/python/discopt/solver.py
+++ b/python/discopt/solver.py
@@ -2384,6 +2384,7 @@ def solve_model(
             mip_nlp_method = "ecp" if bool(mip_nlp_kwargs.get("ecp_mode", False)) else "oa"
 
         gdp_methods = {"big-m", "hull", "mbigm", "auto"}
+        native_gdp_methods = {"loa"}
         if gdp_method == "oa":
             warnings.warn(
                 "gdp_method='oa' is deprecated for selecting MINLP OA. Use "
@@ -2395,6 +2396,13 @@ def solve_model(
             resolved_gdp_method = "big-m"
         elif gdp_method in gdp_methods:
             resolved_gdp_method = gdp_method
+        elif gdp_method in native_gdp_methods:
+            allowed = ", ".join(sorted(gdp_methods))
+            raise ValueError(
+                f"gdp_method={gdp_method!r} conflicts with solver='mip-nlp'. "
+                "Use mip_nlp_method to select the MIP-NLP algorithm and reserve "
+                f"gdp_method for GDP reformulation methods: {allowed}."
+            )
         else:
             allowed = ", ".join(sorted(gdp_methods | {"oa"}))
             raise ValueError(

--- a/python/discopt/solvers/mip_nlp.py
+++ b/python/discopt/solvers/mip_nlp.py
@@ -6,20 +6,30 @@ from typing import Any, Optional
 
 from discopt.modeling.core import Model, SolveResult
 
-SUPPORTED_METHODS = {"oa", "ecp", "goa", "roa", "fp", "lp_nlp_bb"}
+_IMPLEMENTED_METHODS = frozenset({"oa", "ecp"})
+_RESERVED_METHOD_ISSUES = {
+    "fp": "#115",
+    "roa": "#116/#117",
+    "goa": "#118",
+    "lp_nlp_bb": "#119",
+}
+SUPPORTED_METHODS = _IMPLEMENTED_METHODS | frozenset(_RESERVED_METHOD_ISSUES)
 _METHOD_ALIASES = {
-    "lp-nlp-bb": "lp_nlp_bb",
     "lp/nlp-bb": "lp_nlp_bb",
-    "lp_nlp_bb": "lp_nlp_bb",
 }
 _OA_OPTION_KEYS = {"equality_relaxation", "ecp_mode", "feasibility_cuts"}
 
 
-def _normalize_method(method: str) -> str:
-    normalized = _METHOD_ALIASES.get(method, method)
+def _normalize_method(method: Any) -> str:
+    if not isinstance(method, str):
+        raise ValueError(f"mip_nlp_method must be a string, got {type(method).__name__}.")
+    normalized = method.strip().lower().replace("-", "_")
+    normalized = _METHOD_ALIASES.get(normalized, normalized)
     if normalized not in SUPPORTED_METHODS:
+        reserved = ", ".join(sorted(_RESERVED_METHOD_ISSUES))
         raise ValueError(
-            f"Unknown mip_nlp_method={method!r}. Choose one of {sorted(SUPPORTED_METHODS)}."
+            f"Unknown mip_nlp_method={method!r}. Choose 'oa' or 'ecp'. "
+            f"Reserved future methods are: {reserved}."
         )
     return normalized
 
@@ -38,11 +48,16 @@ def solve_mip_nlp(
     """Solve a MINLP with a MIP-NLP decomposition method."""
     method = _normalize_method(method)
     options: dict[str, Any] = {}
-    if mip_nlp_options:
+    if mip_nlp_options is not None:
+        if not isinstance(mip_nlp_options, dict):
+            raise TypeError(
+                "mip_nlp_options must be a dict of OA/ECP solver options, "
+                f"got {type(mip_nlp_options).__name__}."
+            )
         options.update(mip_nlp_options)
     options.update(kwargs)
 
-    if method in {"oa", "ecp"}:
+    if method in _IMPLEMENTED_METHODS:
         unexpected = sorted(set(options) - _OA_OPTION_KEYS)
         if unexpected:
             raise ValueError(
@@ -54,10 +69,14 @@ def solve_mip_nlp(
 
         from discopt.solvers.oa import solve_oa
 
-        if method == "ecp":
-            options["ecp_mode"] = True
-        else:
-            options.setdefault("ecp_mode", False)
+        if "ecp_mode" in kwargs:
+            alias_method = "ecp" if bool(kwargs["ecp_mode"]) else "oa"
+            if alias_method != method:
+                raise ValueError(
+                    "Conflicting MIP-NLP method selectors: "
+                    f"mip_nlp_method={method!r} and ecp_mode={kwargs['ecp_mode']!r}."
+                )
+        options["ecp_mode"] = method == "ecp"
 
         return solve_oa(
             model,
@@ -69,6 +88,7 @@ def solve_mip_nlp(
         )
 
     raise NotImplementedError(
-        f"mip_nlp_method={method!r} is reserved for the MIP-NLP decomposition "
-        "family but is not implemented yet."
+        f"mip_nlp_method={method!r} is reserved for a future MIP-NLP "
+        f"implementation tracked in {_RESERVED_METHOD_ISSUES[method]}; currently "
+        "implemented methods are 'oa' and 'ecp'."
     )

--- a/python/discopt/solvers/mip_nlp.py
+++ b/python/discopt/solvers/mip_nlp.py
@@ -23,8 +23,8 @@ _OA_OPTION_KEYS = {"equality_relaxation", "ecp_mode", "feasibility_cuts"}
 def _normalize_method(method: Any) -> str:
     if not isinstance(method, str):
         raise ValueError(f"mip_nlp_method must be a string, got {type(method).__name__}.")
-    normalized = method.strip().lower().replace("-", "_")
-    normalized = _METHOD_ALIASES.get(normalized, normalized)
+    raw = method.strip().lower()
+    normalized = _METHOD_ALIASES.get(raw, raw.replace("-", "_"))
     if normalized not in SUPPORTED_METHODS:
         reserved = ", ".join(sorted(_RESERVED_METHOD_ISSUES))
         raise ValueError(

--- a/python/tests/test_mip_nlp.py
+++ b/python/tests/test_mip_nlp.py
@@ -155,7 +155,7 @@ def test_mip_nlp_rejects_native_gdp_solver_method(monkeypatch):
 
     monkeypatch.setattr(mip_nlp_module, "solve_mip_nlp", fake_solve_mip_nlp)
 
-    with pytest.raises(ValueError, match="Unknown gdp_method='loa'"):
+    with pytest.raises(ValueError, match="conflicts with solver='mip-nlp'"):
         _binary_model("native_gdp_method").solve(solver="mip-nlp", gdp_method="loa")
 
     assert called is False
@@ -188,6 +188,7 @@ def test_mip_nlp_and_deprecated_oa_alias_reformulate_gdp(monkeypatch):
         ("roa", "#116/#117"),
         ("goa", "#118"),
         ("lp_nlp_bb", "#119"),
+        ("lp/nlp-bb", "#119"),
     ],
 )
 def test_mip_nlp_reserved_methods_raise(method, issue):

--- a/python/tests/test_mip_nlp.py
+++ b/python/tests/test_mip_nlp.py
@@ -50,6 +50,76 @@ def test_model_solve_routes_mip_nlp_options(monkeypatch):
     assert calls["equality_relaxation"] is True
 
 
+def test_model_solve_ecp_alias_derives_method(monkeypatch):
+    import discopt.solvers.mip_nlp as mip_nlp_module
+
+    calls = {}
+
+    def fake_solve_mip_nlp(model, **kwargs):
+        calls.update(kwargs)
+        return SolveResult(status="optimal", objective=0.0, bound=0.0, gap=0.0)
+
+    monkeypatch.setattr(mip_nlp_module, "solve_mip_nlp", fake_solve_mip_nlp)
+
+    result = _binary_model("ecp_alias").solve(solver="mip-nlp", ecp_mode=True)
+
+    assert result.status == "optimal"
+    assert calls["method"] == "ecp"
+    assert calls["ecp_mode"] is True
+
+
+def test_mip_nlp_options_precedence(monkeypatch):
+    import discopt.solvers.oa as oa_module
+    from discopt.solvers.mip_nlp import solve_mip_nlp
+
+    calls = {}
+
+    def fake_solve_oa(model, **kwargs):
+        calls.update(kwargs)
+        return SolveResult(status="optimal", objective=0.0, bound=0.0, gap=0.0)
+
+    monkeypatch.setattr(oa_module, "solve_oa", fake_solve_oa)
+
+    result = solve_mip_nlp(
+        _binary_model("option_precedence"),
+        method="oa",
+        mip_nlp_options={
+            "equality_relaxation": False,
+            "feasibility_cuts": False,
+            "ecp_mode": True,
+        },
+        equality_relaxation=True,
+        feasibility_cuts=True,
+    )
+
+    assert result.status == "optimal"
+    assert calls["equality_relaxation"] is True
+    assert calls["feasibility_cuts"] is True
+    assert calls["ecp_mode"] is False
+
+
+def test_mip_nlp_method_ecp_overrides_nested_ecp_mode(monkeypatch):
+    import discopt.solvers.oa as oa_module
+    from discopt.solvers.mip_nlp import solve_mip_nlp
+
+    calls = {}
+
+    def fake_solve_oa(model, **kwargs):
+        calls.update(kwargs)
+        return SolveResult(status="optimal", objective=0.0, bound=0.0, gap=0.0)
+
+    monkeypatch.setattr(oa_module, "solve_oa", fake_solve_oa)
+
+    result = solve_mip_nlp(
+        _binary_model("ecp_overrides_nested"),
+        method="ecp",
+        mip_nlp_options={"ecp_mode": False},
+    )
+
+    assert result.status == "optimal"
+    assert calls["ecp_mode"] is True
+
+
 def test_gdp_method_oa_deprecated_alias_routes_to_mip_nlp(monkeypatch):
     import discopt.solvers.mip_nlp as mip_nlp_module
 
@@ -73,6 +143,24 @@ def test_gdp_method_oa_deprecated_alias_routes_to_mip_nlp(monkeypatch):
     assert calls["equality_relaxation"] is True
 
 
+def test_mip_nlp_rejects_native_gdp_solver_method(monkeypatch):
+    import discopt.solvers.mip_nlp as mip_nlp_module
+
+    called = False
+
+    def fake_solve_mip_nlp(model, **kwargs):
+        nonlocal called
+        called = True
+        return SolveResult(status="optimal")
+
+    monkeypatch.setattr(mip_nlp_module, "solve_mip_nlp", fake_solve_mip_nlp)
+
+    with pytest.raises(ValueError, match="Unknown gdp_method='loa'"):
+        _binary_model("native_gdp_method").solve(solver="mip-nlp", gdp_method="loa")
+
+    assert called is False
+
+
 def test_mip_nlp_and_deprecated_oa_alias_reformulate_gdp(monkeypatch):
     import discopt.solvers.mip_nlp as mip_nlp_module
 
@@ -93,11 +181,60 @@ def test_mip_nlp_and_deprecated_oa_alias_reformulate_gdp(monkeypatch):
     assert not _has_disjunctions(captured[1])
 
 
-def test_mip_nlp_reserved_methods_raise():
+@pytest.mark.parametrize(
+    ("method", "issue"),
+    [
+        ("fp", "#115"),
+        ("roa", "#116/#117"),
+        ("goa", "#118"),
+        ("lp_nlp_bb", "#119"),
+    ],
+)
+def test_mip_nlp_reserved_methods_raise(method, issue):
     from discopt.solvers.mip_nlp import solve_mip_nlp
 
-    with pytest.raises(NotImplementedError, match="mip_nlp_method='fp'"):
-        solve_mip_nlp(_binary_model("fp_reserved"), method="fp")
+    with pytest.raises(NotImplementedError, match=issue):
+        solve_mip_nlp(_binary_model(f"{method}_reserved"), method=method)
+
+
+def test_mip_nlp_unknown_method_fails_before_oa(monkeypatch):
+    import discopt.solvers.oa as oa_module
+
+    called = False
+
+    def fake_solve_oa(model, **kwargs):
+        nonlocal called
+        called = True
+        return SolveResult(status="optimal")
+
+    monkeypatch.setattr(oa_module, "solve_oa", fake_solve_oa)
+
+    with pytest.raises(ValueError, match="Unknown mip_nlp_method"):
+        _binary_model("unknown_method").solve(solver="mip-nlp", mip_nlp_method="not-a-method")
+
+    assert called is False
+
+
+def test_mip_nlp_conflicting_ecp_alias_fails_before_oa(monkeypatch):
+    import discopt.solvers.oa as oa_module
+
+    called = False
+
+    def fake_solve_oa(model, **kwargs):
+        nonlocal called
+        called = True
+        return SolveResult(status="optimal")
+
+    monkeypatch.setattr(oa_module, "solve_oa", fake_solve_oa)
+
+    with pytest.raises(ValueError, match="Conflicting MIP-NLP method selectors"):
+        _binary_model("conflicting_ecp_alias").solve(
+            solver="mip-nlp",
+            mip_nlp_method="oa",
+            ecp_mode=True,
+        )
+
+    assert called is False
 
 
 def test_mip_nlp_rejects_unsupported_oa_options():
@@ -108,4 +245,15 @@ def test_mip_nlp_rejects_unsupported_oa_options():
             _binary_model("unsupported_oa_option"),
             method="oa",
             mip_nlp_options={"add_slack": True},
+        )
+
+
+def test_mip_nlp_options_must_be_dict():
+    from discopt.solvers.mip_nlp import solve_mip_nlp
+
+    with pytest.raises(TypeError, match="mip_nlp_options must be a dict"):
+        solve_mip_nlp(
+            _binary_model("bad_options_type"),
+            method="oa",
+            mip_nlp_options=[("ecp_mode", True)],
         )

--- a/python/tests/test_oa.py
+++ b/python/tests/test_oa.py
@@ -26,7 +26,8 @@ INTEGRALITY_TOL = 1e-5
 
 def _solve_oa(model, **kwargs):
     """Solve model with OA and return result."""
-    defaults = dict(solver="mip-nlp", mip_nlp_method="oa", time_limit=60)
+    mip_nlp_method = "ecp" if kwargs.pop("ecp_mode", False) else "oa"
+    defaults = dict(solver="mip-nlp", mip_nlp_method=mip_nlp_method, time_limit=60)
     defaults.update(kwargs)
     return model.solve(**defaults)
 


### PR DESCRIPTION
## Summary

- Adds `solver="mip-nlp"` dispatch in `solve_model`.
- Routes `mip_nlp_method="oa"` to the existing OA solver and `mip_nlp_method="ecp"` to OA with `ecp_mode=True`.
- Reserves `fp`, `roa`, `goa`, and `lp_nlp_bb` with roadmap issue references, and rejects unknown methods before OA dispatch.
- Keeps `gdp_method` as the GDP reformulation axis for MIP-NLP and rejects native GDP solver conflicts such as `gdp_method="loa"`.
- Updates OA tests and solver docs to use the two-axis API.

## Tests

- `PYTHONPATH=python OPENBLAS_NUM_THREADS=1 python -m pytest python/tests/test_mip_nlp.py python/tests/test_profiles.py python/tests/test_oa.py -q` -> 28 passed, 10 deselected.
- `python -m ruff check python/` -> passed.
- `python -m ruff format --check python/` -> passed.
- `PYTHONPATH=python python -m py_compile python/discopt/solvers/mip_nlp.py python/discopt/solver.py python/discopt/profiles.py python/discopt/modeling/core.py` -> passed.
- Commit hook on `74da703`: `ruff`, `ruff format`, and `mypy` passed; `cargo fmt` skipped because no Rust files were staged.
- `make test` was attempted locally but broad PR-fast xdist workers aborted in unrelated solver/JAX tests outside the touched MIP-NLP/Profile/OA files. Details are in the review follow-up summary comment.

## Branch Hygiene

- Base branch: `feature/mip-nlp-solver`.
- Fork main: `bernalde/discopt:main` synced to `jkitchin/discopt:main` at `204085b`.
- Integration branch: `bernalde/discopt:feature/mip-nlp-solver` at `204085b`, equal to synced fork `main`.
- Head branch: `bernalde/discopt:fix/issue-111-mip-nlp-api` at `74da703`.
- Stacked status: intentional issue-series child PR into the MIP-NLP integration branch per #110 and #111.
- Prerequisite PRs: none; this child PR is one commit on top of the clean integration branch and is not stacked on a previous child PR branch.

Closes #111