### PR TITLE
Add MIP-NLP initialization strategies

### DIFF
--- a/python/discopt/modeling/core.py
+++ b/python/discopt/modeling/core.py
@@ -2787,10 +2787,12 @@ class Model:
             and ``"ecp"``; ``"goa"``, ``"roa"``, ``"fp"``, and
             ``"lp_nlp_bb"`` are reserved until their dedicated implementations
             land. Top-level OA/ECP options such as ``equality_relaxation``,
-            ``ecp_mode``, and ``feasibility_cuts`` take precedence over
-            duplicate keys in ``mip_nlp_options``. The ``mip_nlp_method``
-            selector determines the effective ``ecp_mode`` and cannot be
-            overridden by ``mip_nlp_options``.
+            ``ecp_mode``, ``feasibility_cuts``, and ``init_strategy`` take
+            precedence over duplicate keys in ``mip_nlp_options``. Supported
+            initialization strategies are ``"rNLP"``, ``"initial_binary"``,
+            and ``"max_binary"``. The ``mip_nlp_method`` selector determines
+            the effective ``ecp_mode`` and cannot be overridden by
+            ``mip_nlp_options``.
         validate : bool, default False
             If True, run Examiner-style KKT validation on the returned
             point and attach the :class:`~discopt.validation.ExaminerReport`

--- a/python/discopt/solver.py
+++ b/python/discopt/solver.py
@@ -2210,8 +2210,10 @@ def solve_model(
         ``"ecp"``; ``"goa"``, ``"roa"``, ``"fp"``, and ``"lp_nlp_bb"`` raise
         ``NotImplementedError`` until their dedicated implementations land.
         Existing OA options ``equality_relaxation``, ``ecp_mode``, and
-        ``feasibility_cuts`` may be passed as top-level aliases and take
-        precedence over duplicate keys in ``mip_nlp_options``. The
+        ``feasibility_cuts`` and initialization option ``init_strategy`` may
+        be passed as top-level aliases and take precedence over duplicate keys
+        in ``mip_nlp_options``. Supported ``init_strategy`` values are
+        ``"rNLP"``, ``"initial_binary"``, and ``"max_binary"``. The
         ``mip_nlp_method`` selector determines the effective ``ecp_mode`` and
         cannot be overridden by ``mip_nlp_options``; a conflicting top-level
         ``ecp_mode`` and explicit ``mip_nlp_method`` raises ``ValueError``.
@@ -2377,7 +2379,7 @@ def solve_model(
         mip_nlp_method = kwargs.pop("mip_nlp_method", None)
         mip_nlp_options = kwargs.pop("mip_nlp_options", None)
         mip_nlp_kwargs: dict[str, Any] = {}
-        for key in ("equality_relaxation", "ecp_mode", "feasibility_cuts"):
+        for key in ("equality_relaxation", "ecp_mode", "feasibility_cuts", "init_strategy"):
             if key in kwargs:
                 mip_nlp_kwargs[key] = kwargs.pop(key)
         if mip_nlp_method is None:
@@ -2433,7 +2435,6 @@ def solve_model(
         _note_ignored_mip_nlp("decomposition", decomposition is not None)
         _note_ignored_mip_nlp("lagrangian_bound", lagrangian_bound is not False)
         _note_ignored_mip_nlp("lagrangian_frequency", lagrangian_frequency != 1)
-        _note_ignored_mip_nlp("initial_point", initial_point is not None)
         _note_ignored_mip_nlp("skip_convex_check", skip_convex_check is not False)
         _note_ignored_mip_nlp("nlp_bb", nlp_bb is not None)
         _note_ignored_mip_nlp("lazy_constraints", lazy_constraints is not None)
@@ -2474,6 +2475,7 @@ def solve_model(
             gap_tolerance=gap_tolerance,
             max_iterations=max_nodes,
             nlp_solver=nlp_solver,
+            initial_point=initial_point,
             **mip_nlp_kwargs,
         )
 

--- a/python/discopt/solvers/mip_nlp.py
+++ b/python/discopt/solvers/mip_nlp.py
@@ -17,7 +17,7 @@ SUPPORTED_METHODS = _IMPLEMENTED_METHODS | frozenset(_RESERVED_METHOD_ISSUES)
 _METHOD_ALIASES = {
     "lp/nlp-bb": "lp_nlp_bb",
 }
-_OA_OPTION_KEYS = {"equality_relaxation", "ecp_mode", "feasibility_cuts"}
+_OA_OPTION_KEYS = {"equality_relaxation", "ecp_mode", "feasibility_cuts", "init_strategy"}
 
 
 def _normalize_method(method: Any) -> str:
@@ -43,6 +43,7 @@ def solve_mip_nlp(
     gap_tolerance: float = 1e-4,
     max_iterations: int = 100,
     nlp_solver: str = "pounce",
+    initial_point=None,
     **kwargs: Any,
 ) -> SolveResult:
     """Solve a MINLP with a MIP-NLP decomposition method."""
@@ -67,7 +68,7 @@ def solve_mip_nlp(
                 + ", ".join(sorted(_OA_OPTION_KEYS))
             )
 
-        from discopt.solvers.oa import solve_oa
+        from discopt.solvers.oa import _normalize_init_strategy, solve_oa
 
         if "ecp_mode" in kwargs:
             alias_method = "ecp" if bool(kwargs["ecp_mode"]) else "oa"
@@ -77,6 +78,7 @@ def solve_mip_nlp(
                     f"mip_nlp_method={method!r} and ecp_mode={kwargs['ecp_mode']!r}."
                 )
         options["ecp_mode"] = method == "ecp"
+        options["init_strategy"] = _normalize_init_strategy(options.get("init_strategy", "rNLP"))
 
         return solve_oa(
             model,
@@ -84,6 +86,7 @@ def solve_mip_nlp(
             gap_tolerance=gap_tolerance,
             max_iterations=max_iterations,
             nlp_solver=nlp_solver,
+            initial_point=initial_point,
             **options,
         )
 

--- a/python/discopt/solvers/oa.py
+++ b/python/discopt/solvers/oa.py
@@ -131,7 +131,6 @@ class OAConfig:
     gap_tolerance: float = 1e-4
     max_iterations: int = 100
     nlp_solver: str = "ipm"
-    init_strategy: str = "rNLP"
     equality_relaxation: bool = False
     ecp_mode: bool = False
     feasibility_cuts: bool = True
@@ -759,8 +758,9 @@ def solve_oa(
         when no practical finite upper bound exists.
     initial_point : numpy.ndarray, optional
         Flat model start produced from ``Model.solve(initial_solution=...)``.
-        Used by ``init_strategy="initial_binary"`` and as the continuous part
-        of ``"max_binary"``.
+        Used to warm-start the continuous relaxation for ``init_strategy="rNLP"``,
+        by ``init_strategy="initial_binary"``, and as the continuous part of
+        ``"max_binary"``.
     equality_relaxation : bool
         Relax nonlinear equalities to inequalities in OA cuts
         (Viswanathan & Grossmann 1990). Helps when nonlinear equalities
@@ -807,7 +807,13 @@ def solve_oa(
 
     # If no integer variables, just solve the NLP directly
     if len(decomp.int_indices) == 0:
-        x_sol, obj = _solve_nlp_relaxation(evaluator, decomp.lb, decomp.ub, nlp_solver)
+        x_sol, obj = _solve_nlp_relaxation(
+            evaluator,
+            decomp.lb,
+            decomp.ub,
+            nlp_solver,
+            initial_point=initial_point,
+        )
         wall_time = time.perf_counter() - t_start
         if x_sol is not None:
             return SolveResult(
@@ -837,7 +843,13 @@ def solve_oa(
     incumbent_obj = None
 
     if init_strategy == "rNLP":
-        x_relax, obj_relax = _solve_nlp_relaxation(evaluator, decomp.lb, decomp.ub, nlp_solver)
+        x_relax, obj_relax = _solve_nlp_relaxation(
+            evaluator,
+            decomp.lb,
+            decomp.ub,
+            nlp_solver,
+            initial_point=initial_point,
+        )
 
         if x_relax is not None:
             _add_oa_cuts(

--- a/python/discopt/solvers/oa.py
+++ b/python/discopt/solvers/oa.py
@@ -51,9 +51,9 @@ def _normalize_init_strategy(init_strategy: str) -> str:
 
 def _default_nlp_start(lb: np.ndarray, ub: np.ndarray) -> np.ndarray:
     """Return the existing deterministic midpoint NLP start."""
-    lb_clip = np.clip(lb, -_START_BOUND_CLIP, _START_BOUND_CLIP)
-    ub_clip = np.clip(ub, -_START_BOUND_CLIP, _START_BOUND_CLIP)
-    return 0.5 * (lb_clip + ub_clip)
+    lb_clip = np.clip(np.asarray(lb, dtype=np.float64), -_START_BOUND_CLIP, _START_BOUND_CLIP)
+    ub_clip = np.clip(np.asarray(ub, dtype=np.float64), -_START_BOUND_CLIP, _START_BOUND_CLIP)
+    return np.asarray(0.5 * (lb_clip + ub_clip), dtype=np.float64)
 
 
 def _round_integral_to_bounds(value: float, lb: float, ub: float) -> float:

--- a/python/discopt/solvers/oa.py
+++ b/python/discopt/solvers/oa.py
@@ -29,6 +29,96 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
+_INIT_STRATEGIES = frozenset({"rNLP", "initial_binary", "max_binary"})
+_START_BOUND_CLIP = 1e8
+
+
+def _normalize_init_strategy(init_strategy: str) -> str:
+    """Normalize and validate the MindtPy-style initialization strategy."""
+    if not isinstance(init_strategy, str):
+        raise ValueError(f"init_strategy must be a string, got {type(init_strategy).__name__}.")
+    key = init_strategy.strip().lower().replace("-", "_")
+    if key == "rnlp":
+        return "rNLP"
+    if key in {"initial_binary", "max_binary"}:
+        return key
+    raise ValueError(
+        f"Unknown init_strategy={init_strategy!r}. Choose one of: "
+        + ", ".join(sorted(_INIT_STRATEGIES))
+        + "."
+    )
+
+
+def _default_nlp_start(lb: np.ndarray, ub: np.ndarray) -> np.ndarray:
+    """Return the existing deterministic midpoint NLP start."""
+    lb_clip = np.clip(lb, -_START_BOUND_CLIP, _START_BOUND_CLIP)
+    ub_clip = np.clip(ub, -_START_BOUND_CLIP, _START_BOUND_CLIP)
+    return 0.5 * (lb_clip + ub_clip)
+
+
+def _round_integral_to_bounds(value: float, lb: float, ub: float) -> float:
+    """Round half-up, then clamp to the nearest integer-compatible bounds."""
+    rounded = float(np.floor(float(value) + 0.5))
+    lo = float(np.ceil(lb))
+    hi = float(np.floor(ub))
+    if lo <= hi:
+        return float(np.clip(rounded, lo, hi))
+    return float(np.clip(rounded, lb, ub))
+
+
+def _max_integral_seed(lb: float, ub: float, fallback: float) -> float:
+    """Largest practical integer seed; fallback handles effectively unbounded uppers."""
+    hi = float(np.floor(ub))
+    lo = float(np.ceil(lb))
+    if lo <= hi and np.isfinite(hi) and abs(hi) <= _START_BOUND_CLIP:
+        return hi
+    return _round_integral_to_bounds(fallback, lb, ub)
+
+
+def _build_initial_strategy_point(
+    decomp: _DecomposedProblem,
+    init_strategy: str,
+    initial_point: Optional[np.ndarray],
+) -> np.ndarray:
+    """Build the deterministic fixed-integer seed for non-rNLP strategies.
+
+    ``initial_binary`` starts from the user/model start when supplied and rounds
+    discrete variables half-up after bound clamping. ``max_binary`` activates
+    binary variables at their largest feasible value; for general integers it
+    uses the largest practical finite upper-bound value, falling back to the
+    rounded clipped midpoint when the upper bound is effectively unbounded.
+    """
+    x_seed = _default_nlp_start(decomp.lb, decomp.ub)
+    if initial_point is not None:
+        x0 = np.asarray(initial_point, dtype=np.float64)
+        if x0.shape != (decomp.n_vars,):
+            raise ValueError(
+                f"initial_point has shape {x0.shape}; expected ({decomp.n_vars},) "
+                "for MIP-NLP initialization."
+            )
+        x_seed = np.clip(x0, decomp.lb, decomp.ub)
+
+    if init_strategy == "initial_binary":
+        for idx in decomp.int_indices:
+            x_seed[idx] = _round_integral_to_bounds(x_seed[idx], decomp.lb[idx], decomp.ub[idx])
+        return x_seed
+
+    if init_strategy == "max_binary":
+        midpoint = _default_nlp_start(decomp.lb, decomp.ub)
+        for idx in decomp.binary_indices:
+            x_seed[idx] = _max_integral_seed(decomp.lb[idx], decomp.ub[idx], fallback=1.0)
+        for idx in decomp.general_integer_indices:
+            x_seed[idx] = _max_integral_seed(
+                decomp.lb[idx],
+                decomp.ub[idx],
+                fallback=midpoint[idx],
+            )
+        return x_seed
+
+    raise ValueError(
+        f"Internal error: non-rNLP initializer received init_strategy={init_strategy!r}."
+    )
+
 
 # ── Configuration ──────────────────────────────────────────────
 
@@ -41,6 +131,7 @@ class OAConfig:
     gap_tolerance: float = 1e-4
     max_iterations: int = 100
     nlp_solver: str = "ipm"
+    init_strategy: str = "rNLP"
     equality_relaxation: bool = False
     ecp_mode: bool = False
     feasibility_cuts: bool = True
@@ -61,6 +152,8 @@ class _DecomposedProblem:
     lb: np.ndarray
     ub: np.ndarray
     int_indices: list[int]
+    binary_indices: list[int]
+    general_integer_indices: list[int]
     integrality: np.ndarray
     linear_A_rows: list[np.ndarray]
     linear_b_rows: list[float]
@@ -89,11 +182,20 @@ def _decompose_model(model: Model) -> _DecomposedProblem:
 
     # Identify integer/binary variable indices
     int_indices = []
+    binary_indices = []
+    general_integer_indices = []
     offset = 0
     for v in model._variables:
-        if v.var_type in (VarType.BINARY, VarType.INTEGER):
+        if v.var_type == VarType.BINARY:
             for i in range(v.size):
-                int_indices.append(offset + i)
+                idx = offset + i
+                int_indices.append(idx)
+                binary_indices.append(idx)
+        elif v.var_type == VarType.INTEGER:
+            for i in range(v.size):
+                idx = offset + i
+                int_indices.append(idx)
+                general_integer_indices.append(idx)
         offset += v.size
 
     integrality = np.zeros(n_vars, dtype=np.int32)
@@ -150,6 +252,8 @@ def _decompose_model(model: Model) -> _DecomposedProblem:
         lb=lb,
         ub=ub,
         int_indices=int_indices,
+        binary_indices=binary_indices,
+        general_integer_indices=general_integer_indices,
         integrality=integrality,
         linear_A_rows=linear_A_rows,
         linear_b_rows=linear_b_rows,
@@ -206,11 +310,17 @@ def _is_primal_feasible(evaluator, x, tol: float = 1e-4) -> bool:
         return False
 
 
-def _solve_nlp(evaluator, lb, ub, nlp_solver: str, max_iter: int = 200):
+def _solve_nlp(evaluator, lb, ub, nlp_solver: str, max_iter: int = 200, x0=None):
     """Solve an NLP with given bounds. Returns (x, obj) or (None, None)."""
-    lb_clip = np.clip(lb, -1e8, 1e8)
-    ub_clip = np.clip(ub, -1e8, 1e8)
-    x0 = 0.5 * (lb_clip + ub_clip)
+    if x0 is None:
+        x0 = _default_nlp_start(lb, ub)
+    else:
+        x0 = np.asarray(x0, dtype=np.float64)
+        if x0.shape != (evaluator.n_variables,):
+            raise ValueError(
+                f"NLP initial point has shape {x0.shape}; expected ({evaluator.n_variables},)."
+            )
+        x0 = np.clip(x0, lb, ub)
 
     try:
         if nlp_solver == "ipopt":
@@ -236,22 +346,22 @@ def _solve_nlp(evaluator, lb, ub, nlp_solver: str, max_iter: int = 200):
     return None, None
 
 
-def _solve_nlp_relaxation(evaluator, lb, ub, nlp_solver: str):
+def _solve_nlp_relaxation(evaluator, lb, ub, nlp_solver: str, initial_point=None):
     """Solve the continuous NLP relaxation (all integers relaxed)."""
-    return _solve_nlp(evaluator, lb, ub, nlp_solver)
+    return _solve_nlp(evaluator, lb, ub, nlp_solver, x0=initial_point)
 
 
-def _solve_nlp_subproblem(evaluator, lb, ub, int_indices, x_master, nlp_solver):
+def _solve_nlp_subproblem(evaluator, lb, ub, int_indices, x_master, nlp_solver, initial_point=None):
     """Fix integers at master values and solve NLP subproblem."""
     sub_lb = lb.copy()
     sub_ub = ub.copy()
     for idx in int_indices:
-        val = round(x_master[idx])
+        val = _round_integral_to_bounds(x_master[idx], lb[idx], ub[idx])
         sub_lb[idx] = val
         sub_ub[idx] = val
 
     proxy = _BoundsProxy(evaluator, sub_lb, sub_ub)
-    return _solve_nlp(proxy, sub_lb, sub_ub, nlp_solver)
+    return _solve_nlp(proxy, sub_lb, sub_ub, nlp_solver, x0=initial_point)
 
 
 def _solve_feasibility_subproblem(evaluator, lb, ub, int_indices, x_master, nlp_solver):
@@ -265,15 +375,13 @@ def _solve_feasibility_subproblem(evaluator, lb, ub, int_indices, x_master, nlp_
     sub_lb = lb.copy()
     sub_ub = ub.copy()
     for idx in int_indices:
-        val = round(x_master[idx])
+        val = _round_integral_to_bounds(x_master[idx], lb[idx], ub[idx])
         sub_lb[idx] = val
         sub_ub[idx] = val
 
     # Try solving the NLP from the master point as initial guess
     proxy = _BoundsProxy(evaluator, sub_lb, sub_ub)
-    lb_clip = np.clip(sub_lb, -1e8, 1e8)
-    ub_clip = np.clip(sub_ub, -1e8, 1e8)
-    x0 = np.clip(x_master[: evaluator.n_variables], lb_clip, ub_clip)
+    x0 = np.clip(x_master[: evaluator.n_variables], sub_lb, sub_ub)
 
     try:
         if nlp_solver == "ipopt":
@@ -428,7 +536,7 @@ def _add_no_good_cut(x_master, int_indices, oa_A_rows, oa_b_rows, n_vars):
     coeffs = np.zeros(n_vars)
     count_ones = 0
     for idx in int_indices:
-        val = round(x_master[idx])
+        val = _round_integral_to_bounds(x_master[idx], 0.0, 1.0)
         if val >= 0.5:
             coeffs[idx] = 1.0
             count_ones += 1
@@ -615,6 +723,8 @@ def solve_oa(
     gap_tolerance: float = 1e-4,
     max_iterations: int = 100,
     nlp_solver: str = "ipm",
+    init_strategy: str = "rNLP",
+    initial_point: Optional[np.ndarray] = None,
     equality_relaxation: bool = False,
     ecp_mode: bool = False,
     feasibility_cuts: bool = True,
@@ -638,6 +748,19 @@ def solve_oa(
         Maximum OA iterations.
     nlp_solver : str
         NLP backend: ``"ipm"``, ``"ipopt"``, ``"pounce"``.
+    init_strategy : {"rNLP", "initial_binary", "max_binary"}
+        Initialization strategy for the first master cuts and fixed-integer
+        NLP seed. ``"rNLP"`` solves the continuous relaxation and generates
+        cuts at that point. ``"initial_binary"`` rounds and clamps discrete
+        variables from ``initial_point`` when supplied, otherwise from the
+        deterministic midpoint start. ``"max_binary"`` starts binary variables
+        at their largest feasible values; general integers use their largest
+        practical finite upper-bound value, or the rounded clipped midpoint
+        when no practical finite upper bound exists.
+    initial_point : numpy.ndarray, optional
+        Flat model start produced from ``Model.solve(initial_solution=...)``.
+        Used by ``init_strategy="initial_binary"`` and as the continuous part
+        of ``"max_binary"``.
     equality_relaxation : bool
         Relax nonlinear equalities to inequalities in OA cuts
         (Viswanathan & Grossmann 1990). Helps when nonlinear equalities
@@ -655,6 +778,7 @@ def solve_oa(
     SolveResult
     """
     t_start = time.perf_counter()
+    init_strategy = _normalize_init_strategy(init_strategy)
 
     # 1. Decompose model
     decomp = _decompose_model(model)
@@ -703,57 +827,104 @@ def solve_oa(
             wall_time=wall_time,
         )
 
-    # 2. Solve initial NLP relaxation for first linearization point
+    # 2. Generate initial linearization cuts.
     oa_A_rows: list[np.ndarray] = []
     oa_b_rows: list[float] = []
-
-    x_relax, obj_relax = _solve_nlp_relaxation(evaluator, decomp.lb, decomp.ub, nlp_solver)
 
     UB = 1e20
     LB = -1e20
     incumbent = None
     incumbent_obj = None
 
-    if x_relax is not None:
-        _add_oa_cuts(
-            evaluator,
-            x_relax,
-            n_vars,
-            n_cons,
-            decomp.constraint_senses,
-            oa_A_rows,
-            oa_b_rows,
-            decomp.obj_is_linear,
-            decomp.oa_constraint_mask,
-            decomp.oa_objective_is_convex,
-            equality_relaxation=equality_relaxation,
-        )
-        # Check if relaxation solution is already integer-feasible
-        is_int_feasible = all(
-            abs(x_relax[idx] - round(x_relax[idx])) < 1e-5 for idx in decomp.int_indices
-        )
-        if is_int_feasible and obj_relax is not None:
-            UB = obj_relax
-            incumbent = x_relax.copy()
-            incumbent_obj = obj_relax
+    if init_strategy == "rNLP":
+        x_relax, obj_relax = _solve_nlp_relaxation(evaluator, decomp.lb, decomp.ub, nlp_solver)
+
+        if x_relax is not None:
+            _add_oa_cuts(
+                evaluator,
+                x_relax,
+                n_vars,
+                n_cons,
+                decomp.constraint_senses,
+                oa_A_rows,
+                oa_b_rows,
+                decomp.obj_is_linear,
+                decomp.oa_constraint_mask,
+                decomp.oa_objective_is_convex,
+                equality_relaxation=equality_relaxation,
+            )
+            # Check if relaxation solution is already integer-feasible.
+            is_int_feasible = all(
+                abs(x_relax[idx] - round(x_relax[idx])) < 1e-5 for idx in decomp.int_indices
+            )
+            if is_int_feasible and obj_relax is not None:
+                UB = obj_relax
+                incumbent = x_relax.copy()
+                incumbent_obj = obj_relax
+        else:
+            # NLP relaxation failed; generate initial cuts at the deterministic midpoint.
+            x_mid = _default_nlp_start(decomp.lb, decomp.ub)
+            _add_oa_cuts(
+                evaluator,
+                x_mid,
+                n_vars,
+                n_cons,
+                decomp.constraint_senses,
+                oa_A_rows,
+                oa_b_rows,
+                decomp.obj_is_linear,
+                decomp.oa_constraint_mask,
+                decomp.oa_objective_is_convex,
+                equality_relaxation=equality_relaxation,
+            )
     else:
-        # NLP relaxation failed — generate initial cuts at midpoint
-        lb_clip = np.clip(decomp.lb, -1e8, 1e8)
-        ub_clip = np.clip(decomp.ub, -1e8, 1e8)
-        x_mid = 0.5 * (lb_clip + ub_clip)
-        _add_oa_cuts(
-            evaluator,
-            x_mid,
-            n_vars,
-            n_cons,
-            decomp.constraint_senses,
-            oa_A_rows,
-            oa_b_rows,
-            decomp.obj_is_linear,
-            decomp.oa_constraint_mask,
-            decomp.oa_objective_is_convex,
-            equality_relaxation=equality_relaxation,
-        )
+        x_seed = _build_initial_strategy_point(decomp, init_strategy, initial_point)
+        if ecp_mode:
+            _add_oa_cuts(
+                evaluator,
+                x_seed,
+                n_vars,
+                n_cons,
+                decomp.constraint_senses,
+                oa_A_rows,
+                oa_b_rows,
+                decomp.obj_is_linear,
+                decomp.oa_constraint_mask,
+                decomp.oa_objective_is_convex,
+                equality_relaxation=equality_relaxation,
+            )
+            if _is_primal_feasible(evaluator, x_seed):
+                UB = float(evaluator.evaluate_objective(x_seed))
+                incumbent = x_seed.copy()
+                incumbent_obj = UB
+        else:
+            x_init, obj_init = _solve_nlp_subproblem(
+                evaluator,
+                decomp.lb,
+                decomp.ub,
+                decomp.int_indices,
+                x_seed,
+                nlp_solver,
+                initial_point=x_seed,
+            )
+            x_cut = x_init if x_init is not None else x_seed
+            _add_oa_cuts(
+                evaluator,
+                x_cut,
+                n_vars,
+                n_cons,
+                decomp.constraint_senses,
+                oa_A_rows,
+                oa_b_rows,
+                decomp.obj_is_linear,
+                decomp.oa_constraint_mask,
+                decomp.oa_objective_is_convex,
+                equality_relaxation=equality_relaxation,
+            )
+            if x_init is not None and obj_init is not None:
+                UB = obj_init
+                incumbent = x_init.copy()
+                incumbent_obj = obj_init
 
     # 3. Main OA loop
     for iteration in range(max_iterations):

--- a/python/tests/test_mip_nlp.py
+++ b/python/tests/test_mip_nlp.py
@@ -1,4 +1,5 @@
 import discopt.modeling as dm
+import numpy as np
 import pytest
 from discopt.modeling.core import SolveResult, _DisjunctiveConstraint
 
@@ -15,6 +16,15 @@ def _gdp_model(name="mip_nlp_gdp_route"):
     x = m.continuous("x", lb=0, ub=10)
     m.minimize(x)
     m.either_or([[x <= 3], [x >= 7]], name="mode")
+    return m
+
+
+def _mixed_discrete_model(name="mip_nlp_init_strategy"):
+    m = dm.Model(name)
+    x = m.continuous("x", lb=-2, ub=2)
+    y = m.binary("y", shape=(2,))
+    z = m.integer("z", lb=-2, ub=3)
+    m.minimize(x + y[0] + y[1] + z)
     return m
 
 
@@ -96,6 +106,54 @@ def test_mip_nlp_options_precedence(monkeypatch):
     assert calls["equality_relaxation"] is True
     assert calls["feasibility_cuts"] is True
     assert calls["ecp_mode"] is False
+
+
+def test_mip_nlp_init_strategy_precedence(monkeypatch):
+    import discopt.solvers.oa as oa_module
+    from discopt.solvers.mip_nlp import solve_mip_nlp
+
+    calls = {}
+
+    def fake_solve_oa(model, **kwargs):
+        calls.update(kwargs)
+        return SolveResult(status="optimal", objective=0.0, bound=0.0, gap=0.0)
+
+    monkeypatch.setattr(oa_module, "solve_oa", fake_solve_oa)
+
+    result = solve_mip_nlp(
+        _binary_model("init_strategy_precedence"),
+        method="oa",
+        mip_nlp_options={"init_strategy": "max_binary"},
+        init_strategy="initial_binary",
+    )
+
+    assert result.status == "optimal"
+    assert calls["init_strategy"] == "initial_binary"
+
+
+def test_model_solve_passes_initial_solution_to_mip_nlp(monkeypatch):
+    import discopt.solvers.mip_nlp as mip_nlp_module
+
+    model = _binary_model("initial_solution_forwarding")
+    y = model._variables[0]
+    calls = {}
+
+    def fake_solve_mip_nlp(model, **kwargs):
+        calls.update(kwargs)
+        return SolveResult(status="optimal", objective=0.0, bound=0.0, gap=0.0)
+
+    monkeypatch.setattr(mip_nlp_module, "solve_mip_nlp", fake_solve_mip_nlp)
+
+    result = model.solve(
+        solver="mip-nlp",
+        init_strategy="initial_binary",
+        initial_solution={y: 1.0},
+    )
+
+    assert result.status == "optimal"
+    assert calls["init_strategy"] == "initial_binary"
+    assert calls["initial_point"] is not None
+    assert calls["initial_point"].tolist() == pytest.approx([1.0])
 
 
 def test_mip_nlp_method_ecp_overrides_nested_ecp_mode(monkeypatch):
@@ -238,6 +296,25 @@ def test_mip_nlp_conflicting_ecp_alias_fails_before_oa(monkeypatch):
     assert called is False
 
 
+def test_mip_nlp_invalid_init_strategy_fails_before_oa(monkeypatch):
+    import discopt.solvers.oa as oa_module
+    from discopt.solvers.mip_nlp import solve_mip_nlp
+
+    called = False
+
+    def fake_solve_oa(model, **kwargs):
+        nonlocal called
+        called = True
+        return SolveResult(status="optimal")
+
+    monkeypatch.setattr(oa_module, "solve_oa", fake_solve_oa)
+
+    with pytest.raises(ValueError, match="Unknown init_strategy"):
+        solve_mip_nlp(_binary_model("bad_init_strategy"), method="oa", init_strategy="bad")
+
+    assert called is False
+
+
 def test_mip_nlp_rejects_unsupported_oa_options():
     from discopt.solvers.mip_nlp import solve_mip_nlp
 
@@ -258,3 +335,97 @@ def test_mip_nlp_options_must_be_dict():
             method="oa",
             mip_nlp_options=[("ecp_mode", True)],
         )
+
+
+def test_oa_initial_binary_seed_rounds_and_clamps_discrete_values():
+    from discopt.solvers.oa import _build_initial_strategy_point, _decompose_model
+
+    decomp = _decompose_model(_mixed_discrete_model("initial_binary_seed"))
+    seed = _build_initial_strategy_point(
+        decomp,
+        "initial_binary",
+        np.array([1.25, 1.8, -0.2, 2.6], dtype=float),
+    )
+
+    assert seed.tolist() == pytest.approx([1.25, 1.0, 0.0, 3.0])
+
+
+def test_oa_max_binary_seed_sets_binaries_and_general_integer_fallback():
+    from discopt.solvers.oa import _build_initial_strategy_point, _decompose_model
+
+    decomp = _decompose_model(_mixed_discrete_model("max_binary_seed"))
+    seed = _build_initial_strategy_point(
+        decomp,
+        "max_binary",
+        np.array([1.25, 0.0, 0.0, -1.0], dtype=float),
+    )
+
+    assert seed.tolist() == pytest.approx([1.25, 1.0, 1.0, 3.0])
+
+
+def test_oa_rnlp_initialization_adds_cuts_at_relaxation_point(monkeypatch):
+    import discopt.solvers.oa as oa_module
+
+    model = _mixed_discrete_model("rnlp_init_point")
+    relaxation_point = np.array([0.25, 0.5, 0.5, 1.5], dtype=float)
+    cut_points = []
+
+    def fake_solve_nlp_relaxation(evaluator, lb, ub, nlp_solver, initial_point=None):
+        assert initial_point is None
+        return relaxation_point, 0.0
+
+    def fake_add_oa_cuts(evaluator, x_star, *args, **kwargs):
+        cut_points.append(np.asarray(x_star, dtype=float).copy())
+
+    monkeypatch.setattr(oa_module, "_solve_nlp_relaxation", fake_solve_nlp_relaxation)
+    monkeypatch.setattr(oa_module, "_add_oa_cuts", fake_add_oa_cuts)
+
+    result = oa_module.solve_oa(model, init_strategy="rNLP", max_iterations=0)
+
+    assert result.status == "infeasible"
+    assert cut_points[0].tolist() == pytest.approx(relaxation_point.tolist())
+
+
+@pytest.mark.parametrize(
+    ("strategy", "start", "expected_fixed"),
+    [
+        ("initial_binary", [1.25, 1.8, -0.2, 2.6], [1.25, 1.0, 0.0, 3.0]),
+        ("max_binary", [1.25, 0.0, 0.0, -1.0], [1.25, 1.0, 1.0, 3.0]),
+    ],
+)
+def test_oa_fixed_integer_initializers_seed_first_nlp(monkeypatch, strategy, start, expected_fixed):
+    import discopt.solvers.oa as oa_module
+
+    model = _mixed_discrete_model(f"{strategy}_first_nlp")
+    fixed_points = []
+    cut_points = []
+
+    def fake_solve_nlp_subproblem(
+        evaluator,
+        lb,
+        ub,
+        int_indices,
+        x_master,
+        nlp_solver,
+        initial_point=None,
+    ):
+        fixed_points.append(np.asarray(x_master, dtype=float).copy())
+        assert np.asarray(initial_point, dtype=float).tolist() == pytest.approx(expected_fixed)
+        return np.asarray(x_master, dtype=float), 0.0
+
+    def fake_add_oa_cuts(evaluator, x_star, *args, **kwargs):
+        cut_points.append(np.asarray(x_star, dtype=float).copy())
+
+    monkeypatch.setattr(oa_module, "_solve_nlp_subproblem", fake_solve_nlp_subproblem)
+    monkeypatch.setattr(oa_module, "_add_oa_cuts", fake_add_oa_cuts)
+
+    result = oa_module.solve_oa(
+        model,
+        init_strategy=strategy,
+        initial_point=np.array(start, dtype=float),
+        max_iterations=0,
+    )
+
+    assert result.status == "feasible"
+    assert fixed_points[0].tolist() == pytest.approx(expected_fixed)
+    assert cut_points[0].tolist() == pytest.approx(expected_fixed)

--- a/python/tests/test_mip_nlp.py
+++ b/python/tests/test_mip_nlp.py
@@ -3,11 +3,25 @@ import numpy as np
 import pytest
 from discopt.modeling.core import SolveResult, _DisjunctiveConstraint
 
+try:
+    import highspy  # noqa: F401
+
+    HAS_HIGHS = True
+except ImportError:
+    HAS_HIGHS = False
+
 
 def _binary_model(name="mip_nlp_route"):
     m = dm.Model(name)
     x = m.binary("x")
     m.minimize(x)
+    return m
+
+
+def _continuous_model(name="mip_nlp_continuous"):
+    m = dm.Model(name)
+    x = m.continuous("x", lb=0, ub=4)
+    m.minimize((x - 2) ** 2)
     return m
 
 
@@ -25,6 +39,22 @@ def _mixed_discrete_model(name="mip_nlp_init_strategy"):
     y = m.binary("y", shape=(2,))
     z = m.integer("z", lb=-2, ub=3)
     m.minimize(x + y[0] + y[1] + z)
+    return m
+
+
+def _mindtpy_simple_minlp(name="mindtpy_init_strategy"):
+    m = dm.Model(name)
+    x = m.continuous("x", shape=(2,), lb=0, ub=4)
+    y = m.binary("y", shape=(3,))
+
+    m.subject_to((x[0] - 2) ** 2 - x[1] <= 0)
+    m.subject_to(x[0] - 2 * y[0] >= 0)
+    m.subject_to(x[0] - x[1] - 4 * (1 - y[1]) <= 0)
+    m.subject_to(x[0] - (1 - y[0]) >= 0)
+    m.subject_to(x[1] - y[1] >= 0)
+    m.subject_to(x[0] + x[1] >= 3 * y[2])
+    m.subject_to(y[0] + y[1] + y[2] >= 1)
+    m.minimize(y[0] + 1.5 * y[1] + 0.5 * y[2] + x[0] ** 2 + x[1] ** 2)
     return m
 
 
@@ -367,11 +397,14 @@ def test_oa_rnlp_initialization_adds_cuts_at_relaxation_point(monkeypatch):
     import discopt.solvers.oa as oa_module
 
     model = _mixed_discrete_model("rnlp_init_point")
+    initial_point = np.array([1.25, 1.0, 0.0, 2.0], dtype=float)
     relaxation_point = np.array([0.25, 0.5, 0.5, 1.5], dtype=float)
     cut_points = []
 
     def fake_solve_nlp_relaxation(evaluator, lb, ub, nlp_solver, initial_point=None):
-        assert initial_point is None
+        assert np.asarray(initial_point, dtype=float).tolist() == pytest.approx(
+            [1.25, 1.0, 0.0, 2.0]
+        )
         return relaxation_point, 0.0
 
     def fake_add_oa_cuts(evaluator, x_star, *args, **kwargs):
@@ -380,10 +413,35 @@ def test_oa_rnlp_initialization_adds_cuts_at_relaxation_point(monkeypatch):
     monkeypatch.setattr(oa_module, "_solve_nlp_relaxation", fake_solve_nlp_relaxation)
     monkeypatch.setattr(oa_module, "_add_oa_cuts", fake_add_oa_cuts)
 
-    result = oa_module.solve_oa(model, init_strategy="rNLP", max_iterations=0)
+    result = oa_module.solve_oa(
+        model,
+        init_strategy="rNLP",
+        initial_point=initial_point,
+        max_iterations=0,
+    )
 
     assert result.status == "infeasible"
     assert cut_points[0].tolist() == pytest.approx(relaxation_point.tolist())
+
+
+def test_oa_no_discrete_relaxation_uses_initial_point(monkeypatch):
+    import discopt.solvers.oa as oa_module
+
+    initial_point = np.array([3.0], dtype=float)
+
+    def fake_solve_nlp_relaxation(evaluator, lb, ub, nlp_solver, initial_point=None):
+        assert np.asarray(initial_point, dtype=float).tolist() == pytest.approx([3.0])
+        return np.asarray(initial_point, dtype=float), 1.0
+
+    monkeypatch.setattr(oa_module, "_solve_nlp_relaxation", fake_solve_nlp_relaxation)
+
+    result = oa_module.solve_oa(
+        _continuous_model("no_discrete_initial_point"),
+        initial_point=initial_point,
+    )
+
+    assert result.status == "optimal"
+    assert result.x["x"] == pytest.approx(3.0)
 
 
 @pytest.mark.parametrize(
@@ -429,3 +487,22 @@ def test_oa_fixed_integer_initializers_seed_first_nlp(monkeypatch, strategy, sta
     assert result.status == "feasible"
     assert fixed_points[0].tolist() == pytest.approx(expected_fixed)
     assert cut_points[0].tolist() == pytest.approx(expected_fixed)
+
+
+@pytest.mark.skipif(not HAS_HIGHS, reason="highspy not installed")
+@pytest.mark.parametrize("method", ["oa", "ecp"])
+@pytest.mark.parametrize("strategy", ["rNLP", "initial_binary", "max_binary"])
+def test_mip_nlp_init_strategies_solve_mindtpy_baseline_to_optimum(method, strategy):
+    result = _mindtpy_simple_minlp(f"mindtpy_{method}_{strategy}").solve(
+        solver="mip-nlp",
+        mip_nlp_method=method,
+        init_strategy=strategy,
+        time_limit=60,
+        max_nodes=100,
+    )
+
+    assert result.status == "optimal"
+    assert result.objective == pytest.approx(3.5, abs=1e-3)
+    assert result.bound == pytest.approx(3.5, abs=1e-3)
+    assert result.gap == pytest.approx(0.0, abs=1e-9)
+    assert np.asarray(result.x["y"]).tolist() == pytest.approx([0.0, 1.0, 0.0])


### PR DESCRIPTION
## Summary

Adds MindtPy-style MIP-NLP initialization strategies for OA/ECP:

- `init_strategy="rNLP"` preserves the existing continuous-relaxation initialization.
- `init_strategy="initial_binary"` rounds and clamps discrete values from `initial_solution` when provided, then seeds the first fixed-integer NLP and initial cuts.
- `init_strategy="max_binary"` deterministically activates binary variables and uses a documented finite-upper-bound fallback for general integers.

The MIP-NLP facade validates unsupported strategy values before entering OA, forwards `initial_solution` as the flat OA start, and documents the new option in the public solve docs.

Closes #113

## Tests

- `env PYTHONPATH=python pytest python/tests/test_mip_nlp.py -q` -> 24 passed
- `env PYTHONPATH=python pytest python/tests/test_oa.py -q` -> 11 passed, 10 deselected
- `env PYTHONPATH=python pytest python/tests/test_mip_nlp.py python/tests/test_oa.py -q` -> 35 passed, 10 deselected
- `env PYTHONPATH=python python -m ruff check python/discopt/solvers/oa.py python/discopt/solvers/mip_nlp.py python/discopt/solver.py python/discopt/modeling/core.py python/tests/test_mip_nlp.py` -> passed
- `env PYTHONPATH=python python -m ruff format --check python/discopt/solvers/oa.py python/discopt/solvers/mip_nlp.py python/discopt/solver.py python/discopt/modeling/core.py python/tests/test_mip_nlp.py` -> passed
- `git diff --check` -> passed

Notes:

- `python/tests/test_oa.py` emitted JAX persistent-cache warnings because the sandbox cannot write to `/home/bernalde/.cache/discopt/jax-cache`; tests still passed.
- The local generated pre-commit hook could not run because `pre-commit` was not installed and its cached hook Python no longer exists. The commit was created with `--no-verify` after the checks above.
- Scoped mypy was attempted with `env PYTHONPATH=python mypy python/discopt/solvers/oa.py python/discopt/solvers/mip_nlp.py python/discopt/solver.py python/discopt/modeling/core.py --ignore-missing-imports`, but local NumPy stubs failed before project checking with: `Type statement is only supported in Python 3.12 and greater`.

## Branch Hygiene

- Base branch: `bernalde:feature/mip-nlp-solver`
- Head branch: `bernalde:fix/issue-113-init-strategies`
- Source branch point: `origin/feature/mip-nlp-solver` at `065773436998f9a39bb5574b7fbda848cf716d6b`
- Stacked status: not stacked on a prior child branch; this branch was created directly from the remote integration branch.
- Prerequisite PRs: none for this child PR beyond the existing integration branch contents.
