### PR TITLE
Add derivative OA regularization modes

### DIFF
--- a/python/discopt/modeling/core.py
+++ b/python/discopt/modeling/core.py
@@ -2792,8 +2792,11 @@ class Model:
             ``add_no_good_cuts``, ``feasibility_norm``, ``add_regularization``,
             ``level_coef``, ``stalling_limit``, ``cycling_check``, and
             ``init_strategy`` take precedence over duplicate keys in
-            ``mip_nlp_options``. Supported initialization strategies are
-            ``"rNLP"``, ``"initial_binary"``, ``"max_binary"``, and ``"fp"``.
+            ``mip_nlp_options``. Supported ``add_regularization`` values are
+            ``"level_L1"``, ``"level_L2"``, ``"level_L_infinity"``,
+            ``"grad_lag"``, ``"hess_lag"``, ``"hess_only_lag"``, and
+            ``"sqp_lag"``. Supported initialization strategies are ``"rNLP"``,
+            ``"initial_binary"``, ``"max_binary"``, and ``"fp"``.
             The ``mip_nlp_method`` selector determines the
             effective ``ecp_mode`` and cannot be overridden by
             ``mip_nlp_options``.

--- a/python/discopt/solver.py
+++ b/python/discopt/solver.py
@@ -2216,6 +2216,9 @@ def solve_model(
         ``stalling_limit``, and ``cycling_check`` plus initialization option
         ``init_strategy`` may be passed as top-level aliases and take
         precedence over duplicate keys in ``mip_nlp_options``.
+        Supported ``add_regularization`` values are ``"level_L1"``,
+        ``"level_L2"``, ``"level_L_infinity"``, ``"grad_lag"``,
+        ``"hess_lag"``, ``"hess_only_lag"``, and ``"sqp_lag"``.
         Supported ``init_strategy`` values are ``"rNLP"``,
         ``"initial_binary"``, ``"max_binary"``, and ``"fp"``. The
         ``mip_nlp_method`` selector determines the effective ``ecp_mode`` and

--- a/python/discopt/solvers/mip_nlp.py
+++ b/python/discopt/solvers/mip_nlp.py
@@ -70,6 +70,9 @@ def solve_mip_nlp(
 ) -> SolveResult:
     """Solve a MINLP with a MIP-NLP decomposition method."""
     method = _normalize_method(method)
+    from discopt._jax.factorable_reform import canonicalize_entropy
+
+    model = canonicalize_entropy(model)
     options: dict[str, Any] = {}
     if mip_nlp_options is not None:
         if not isinstance(mip_nlp_options, dict):

--- a/python/discopt/solvers/oa.py
+++ b/python/discopt/solvers/oa.py
@@ -150,6 +150,15 @@ def _qp_regularization_backend_error(add_regularization: str) -> RuntimeError:
     )
 
 
+def _qp_regularization_solve_error(add_regularization: str) -> RuntimeError:
+    return RuntimeError(
+        f"OA {add_regularization} regularized master was rejected by the QP/MIQP "
+        "backend. The regularization Hessian may be nonconvex or indefinite; "
+        "use a convex test model, add_regularization='sqp_lag' for a proximal "
+        "QP, or a linear derivative mode such as add_regularization='grad_lag'."
+    )
+
+
 def _l2_regularization_backend_error() -> RuntimeError:
     return _qp_regularization_backend_error("level_L2")
 
@@ -1623,6 +1632,9 @@ def _solve_regularized_master(
                     c[:n_vars] += derivative_data.gradient
             elif add_regularization == "sqp_lag":
                 assert derivative_data is not None  # guarded above
+                # First-slice MindtPy-compatible SQP regularization: keep a
+                # fixed unit proximal weight until a public tuning option is
+                # justified by solver behavior across more benchmark cases.
                 rho = 1.0
                 for idx in range(n_vars):
                     Q[idx, idx] = 2.0 * rho
@@ -1641,8 +1653,10 @@ def _solve_regularized_master(
                 time_limit=max(float(time_limit), 0.0),
                 gap_tolerance=gap_tolerance,
             )
-        except (ImportError, ValueError) as exc:
+        except ImportError as exc:
             raise _qp_regularization_backend_error(add_regularization) from exc
+        except ValueError as exc:
+            raise _qp_regularization_solve_error(add_regularization) from exc
     else:
         from discopt.solvers.lp_backend import get_milp_solver
 
@@ -1922,6 +1936,11 @@ def solve_oa(
     n_vars = decomp.n_vars
     n_cons = decomp.n_cons
     derivative_regularization = _regularization_requires_derivatives(add_regularization)
+    if derivative_regularization and init_strategy == "fp" and n_cons > 0:
+        raise ValueError(
+            "OA derivative regularization needs an NLP-based initialization that returns "
+            "duals; init_strategy='fp' does not provide constraint multipliers."
+        )
     if add_regularization in _QP_REGULARIZATION_MODES and decomp.int_indices:
         _require_qp_regularization_backend(add_regularization)
     # The whole OA loop runs in the evaluator's minimization convention (it

--- a/python/discopt/solvers/oa.py
+++ b/python/discopt/solvers/oa.py
@@ -37,7 +37,15 @@ _REGULARIZATION_MODES = {
     "level_l_infinity": "level_L_infinity",
     "level_linf": "level_L_infinity",
     "level_l_inf": "level_L_infinity",
+    "grad_lag": "grad_lag",
+    "hess_lag": "hess_lag",
+    "hess_only_lag": "hess_only_lag",
+    "sqp_lag": "sqp_lag",
 }
+_DERIVATIVE_REGULARIZATION_MODES = frozenset({"grad_lag", "hess_lag", "hess_only_lag", "sqp_lag"})
+_HESSIAN_REGULARIZATION_MODES = frozenset({"hess_lag", "hess_only_lag"})
+_QP_REGULARIZATION_MODES = frozenset({"level_L2", "hess_lag", "hess_only_lag", "sqp_lag"})
+_LINEAR_REGULARIZATION_MODES = frozenset({"level_L1", "level_L_infinity", "grad_lag"})
 _FEASIBILITY_NORMS = {
     "l1": "L1",
     "l2": "L2",
@@ -94,7 +102,8 @@ def _normalize_regularization(add_regularization: Optional[str]) -> Optional[str
         return normalized
     raise ValueError(
         "Unknown add_regularization="
-        f"{add_regularization!r}. Choose one of: level_L1, level_L2, level_L_infinity."
+        f"{add_regularization!r}. Choose one of: grad_lag, hess_lag, hess_only_lag, "
+        "level_L1, level_L2, level_L_infinity, sqp_lag."
     )
 
 
@@ -126,24 +135,33 @@ def _normalize_optional_positive_int(name: str, value: Optional[int]) -> Optiona
     return out
 
 
-def _l2_regularization_backend_error() -> RuntimeError:
+def _qp_regularization_backend_error(add_regularization: str) -> RuntimeError:
     return RuntimeError(
-        "OA level_L2 regularization requires a QP/MIQP-capable backend "
+        f"OA {add_regularization} regularization requires a QP/MIQP-capable backend "
         "for the regularized master. Install highspy or choose "
-        "add_regularization='level_L1'/'level_L_infinity'."
+        "a linear regularization mode such as add_regularization='level_L1', "
+        "'level_L_infinity', or 'grad_lag'."
     )
 
 
-def _require_l2_regularization_backend() -> None:
+def _l2_regularization_backend_error() -> RuntimeError:
+    return _qp_regularization_backend_error("level_L2")
+
+
+def _require_qp_regularization_backend(add_regularization: str) -> None:
     """Raise when the active QP backend cannot solve mixed-integer QPs."""
     try:
         from discopt.solvers.lp_backend import get_qp_solver
 
         solve_qp = get_qp_solver()
     except ImportError as exc:
-        raise _l2_regularization_backend_error() from exc
+        raise _qp_regularization_backend_error(add_regularization) from exc
     if getattr(solve_qp, "__module__", "").endswith("qp_pounce"):
-        raise _l2_regularization_backend_error()
+        raise _qp_regularization_backend_error(add_regularization)
+
+
+def _require_l2_regularization_backend() -> None:
+    _require_qp_regularization_backend("level_L2")
 
 
 def _default_nlp_start(lb: np.ndarray, ub: np.ndarray) -> np.ndarray:
@@ -254,6 +272,25 @@ class _FeasibilityPumpResult:
     best_near_merit: float
     iterations: int = 0
     mip_count: int = 0
+
+
+@dataclass
+class _NLPAttempt:
+    """Internal NLP solve result with derivative data retained when available."""
+
+    x: Optional[np.ndarray]
+    objective: Optional[float]
+    multipliers: Optional[np.ndarray]
+    status: Optional[object] = None
+
+
+@dataclass
+class _DerivativeRegularizationData:
+    """Lagrangian derivative data used by derivative-based ROA modes."""
+
+    target: np.ndarray
+    gradient: np.ndarray
+    hessian: Optional[np.ndarray] = None
 
 
 # ── Problem Decomposition ─────────────────────────────────────
@@ -427,8 +464,15 @@ def _is_primal_feasible(evaluator, x, tol: float = 1e-4) -> bool:
         return False
 
 
-def _solve_nlp(evaluator, lb, ub, nlp_solver: str, max_iter: int = 200, x0=None):
-    """Solve an NLP with given bounds. Returns (x, obj) or (None, None)."""
+def _solve_nlp_attempt(
+    evaluator,
+    lb,
+    ub,
+    nlp_solver: str,
+    max_iter: int = 200,
+    x0=None,
+) -> _NLPAttempt:
+    """Solve an NLP with given bounds, retaining solver multipliers."""
     if x0 is None:
         x0 = _default_nlp_start(lb, ub)
     else:
@@ -450,25 +494,64 @@ def _solve_nlp(evaluator, lb, ub, nlp_solver: str, max_iter: int = 200, x0=None)
         from discopt.solvers import SolveStatus
 
         if result.status == SolveStatus.OPTIMAL:
-            return result.x, float(evaluator.evaluate_objective(result.x))
+            return _NLPAttempt(
+                x=result.x,
+                objective=float(evaluator.evaluate_objective(result.x)),
+                multipliers=result.multipliers,
+                status=result.status,
+            )
 
         # Accept iteration-limited results if the solution is primal feasible.
         # The IPM may not certify dual convergence (code 4: stalled) yet still
         # find a valid primal point, which is sufficient for OA linearization cuts.
         if result.status == SolveStatus.ITERATION_LIMIT and result.x is not None:
             if _is_primal_feasible(evaluator, result.x):
-                return result.x, float(evaluator.evaluate_objective(result.x))
+                return _NLPAttempt(
+                    x=result.x,
+                    objective=float(evaluator.evaluate_objective(result.x)),
+                    multipliers=result.multipliers,
+                    status=result.status,
+                )
     except Exception:
         pass
-    return None, None
+    return _NLPAttempt(x=None, objective=None, multipliers=None)
 
 
-def _solve_nlp_relaxation(evaluator, lb, ub, nlp_solver: str, initial_point=None):
+def _solve_nlp(evaluator, lb, ub, nlp_solver: str, max_iter: int = 200, x0=None):
+    """Solve an NLP with given bounds. Returns (x, obj) or (None, None)."""
+    attempt = _solve_nlp_attempt(evaluator, lb, ub, nlp_solver, max_iter=max_iter, x0=x0)
+    return attempt.x, attempt.objective
+
+
+def _maybe_return_nlp_attempt(attempt: _NLPAttempt, return_attempt: bool):
+    if return_attempt:
+        return attempt
+    return attempt.x, attempt.objective
+
+
+def _solve_nlp_relaxation(
+    evaluator,
+    lb,
+    ub,
+    nlp_solver: str,
+    initial_point=None,
+    return_attempt: bool = False,
+):
     """Solve the continuous NLP relaxation (all integers relaxed)."""
-    return _solve_nlp(evaluator, lb, ub, nlp_solver, x0=initial_point)
+    attempt = _solve_nlp_attempt(evaluator, lb, ub, nlp_solver, x0=initial_point)
+    return _maybe_return_nlp_attempt(attempt, return_attempt)
 
 
-def _solve_nlp_subproblem(evaluator, lb, ub, int_indices, x_master, nlp_solver, initial_point=None):
+def _solve_nlp_subproblem(
+    evaluator,
+    lb,
+    ub,
+    int_indices,
+    x_master,
+    nlp_solver,
+    initial_point=None,
+    return_attempt: bool = False,
+):
     """Fix integers at master values and solve NLP subproblem."""
     sub_lb = lb.copy()
     sub_ub = ub.copy()
@@ -478,7 +561,93 @@ def _solve_nlp_subproblem(evaluator, lb, ub, int_indices, x_master, nlp_solver, 
         sub_ub[idx] = val
 
     proxy = _BoundsProxy(evaluator, sub_lb, sub_ub)
-    return _solve_nlp(proxy, sub_lb, sub_ub, nlp_solver, x0=initial_point)
+    attempt = _solve_nlp_attempt(proxy, sub_lb, sub_ub, nlp_solver, x0=initial_point)
+    return _maybe_return_nlp_attempt(attempt, return_attempt)
+
+
+def _regularization_requires_derivatives(add_regularization: Optional[str]) -> bool:
+    return add_regularization in _DERIVATIVE_REGULARIZATION_MODES
+
+
+def _constraint_multipliers_for_regularization(
+    decomp: _DecomposedProblem,
+    add_regularization: str,
+    multipliers: Optional[np.ndarray],
+) -> np.ndarray:
+    if multipliers is None:
+        if decomp.n_cons == 0:
+            return np.empty(0, dtype=np.float64)
+        raise RuntimeError(
+            f"OA {add_regularization} regularization requires NLP dual multipliers, "
+            "but the selected NLP backend did not return constraint duals."
+        )
+    lam = np.asarray(multipliers, dtype=np.float64).reshape(-1)
+    if lam.shape != (decomp.n_cons,):
+        raise RuntimeError(
+            f"OA {add_regularization} regularization received {lam.size} NLP dual "
+            f"multipliers for {decomp.n_cons} constraint rows."
+        )
+    return lam
+
+
+def _build_derivative_regularization_data(
+    decomp: _DecomposedProblem,
+    add_regularization: str,
+    x_star: np.ndarray,
+    multipliers: Optional[np.ndarray],
+) -> _DerivativeRegularizationData:
+    """Build Lagrangian gradient/Hessian data for derivative ROA modes."""
+    x = np.asarray(x_star, dtype=np.float64)
+    if x.shape != (decomp.n_vars,):
+        raise ValueError(
+            f"regularization reference point has shape {x.shape}; expected ({decomp.n_vars},)."
+        )
+
+    lam = _constraint_multipliers_for_regularization(decomp, add_regularization, multipliers)
+    try:
+        grad = np.asarray(decomp.evaluator.evaluate_gradient(x), dtype=np.float64).reshape(-1)
+        if decomp.n_cons:
+            jac = np.asarray(decomp.evaluator.evaluate_jacobian(x), dtype=np.float64)
+            grad = grad + jac.T @ lam
+    except Exception as exc:
+        raise RuntimeError(
+            f"OA {add_regularization} regularization requires NLP gradient and Jacobian "
+            "access for the Lagrangian."
+        ) from exc
+    if grad.shape != (decomp.n_vars,):
+        raise RuntimeError(
+            f"OA {add_regularization} regularization produced a Lagrangian gradient "
+            f"with shape {grad.shape}; expected ({decomp.n_vars},)."
+        )
+
+    # A fixed-integer NLP is already first-order stationary in continuous
+    # variables up to bound multipliers. Match MindtPy's intent by using the
+    # reduced Lagrangian gradient to guide only discrete moves.
+    if decomp.int_indices:
+        reduced_grad = np.zeros_like(grad)
+        reduced_grad[np.asarray(decomp.int_indices, dtype=np.intp)] = grad[decomp.int_indices]
+        grad = reduced_grad
+
+    hess = None
+    if add_regularization in _HESSIAN_REGULARIZATION_MODES:
+        try:
+            hess = np.asarray(
+                decomp.evaluator.evaluate_lagrangian_hessian(x, 1.0, lam),
+                dtype=np.float64,
+            )
+        except Exception as exc:
+            raise RuntimeError(
+                f"OA {add_regularization} regularization requires NLP Hessian access "
+                "for the Lagrangian."
+            ) from exc
+        if hess.shape != (decomp.n_vars, decomp.n_vars):
+            raise RuntimeError(
+                f"OA {add_regularization} regularization received a Lagrangian Hessian "
+                f"with shape {hess.shape}; expected ({decomp.n_vars}, {decomp.n_vars})."
+            )
+        hess = 0.5 * (hess + hess.T)
+
+    return _DerivativeRegularizationData(target=x.copy(), gradient=grad, hessian=hess)
 
 
 def _constraint_violation_data(evaluator, x) -> tuple[np.ndarray, np.ndarray]:
@@ -1277,14 +1446,15 @@ def _solve_regularized_master(
     oa_penalty_factor: float = 1000.0,
     oa_cut_relaxable=None,
     use_objective_epigraph: Optional[bool] = None,
+    derivative_data: Optional[_DerivativeRegularizationData] = None,
 ) -> Optional[np.ndarray]:
     """Solve the ROA level-set master and return its original-variable point.
 
     The regularized master keeps the current linear/OA master constraints,
-    adds a level constraint on the master objective estimate, and minimizes
-    distance from ``target`` over the original model variables. ``level_L1`` and
-    ``level_L_infinity`` are MILPs; ``level_L2`` is a convex MIQP and therefore
-    requires a QP backend that supports integrality.
+    adds a level constraint on the master objective estimate, and optimizes the
+    selected regularization objective. ``level_L1``, ``level_L_infinity``, and
+    ``grad_lag`` are MILPs; quadratic modes require a QP backend that supports
+    integrality.
     """
     from discopt.solvers import SolveStatus
 
@@ -1300,6 +1470,10 @@ def _solve_regularized_master(
 
     n_vars = decomp.n_vars
     target = np.clip(np.asarray(target, dtype=np.float64), decomp.lb, decomp.ub)
+    if add_regularization in _DERIVATIVE_REGULARIZATION_MODES and derivative_data is None:
+        raise RuntimeError(
+            f"OA {add_regularization} regularization requires Lagrangian derivative data."
+        )
     eta_index = n_vars if use_objective_epigraph else None
     n_base = n_vars + (1 if use_objective_epigraph else 0)
     slack_index = None
@@ -1307,14 +1481,14 @@ def _solve_regularized_master(
         slack_index = n_base
         n_base += 1
 
+    aux_start = None
     if add_regularization == "level_L1":
         aux_start = n_base
         n_master = n_base + n_vars
     elif add_regularization == "level_L_infinity":
         aux_start = n_base
         n_master = n_base + 1
-    elif add_regularization == "level_L2":
-        aux_start = n_base
+    elif add_regularization in {"level_L2", "grad_lag", "hess_lag", "hess_only_lag", "sqp_lag"}:
         n_master = n_base
     else:  # pragma: no cover - guarded by _normalize_regularization
         raise ValueError(f"Unsupported regularization mode {add_regularization!r}.")
@@ -1419,16 +1593,32 @@ def _solve_regularized_master(
     A_eq = np.asarray(a_eq_rows, dtype=np.float64) if a_eq_rows else None
     b_eq = np.asarray(b_eq_vals, dtype=np.float64) if b_eq_vals else None
 
-    if add_regularization == "level_L2":
+    if add_regularization in _QP_REGULARIZATION_MODES:
         try:
             from discopt.solvers.lp_backend import get_qp_solver
 
             solve_qp = get_qp_solver()
             Q = np.zeros((n_master, n_master), dtype=np.float64)
             c = np.zeros(n_master, dtype=np.float64)
-            for idx in range(n_vars):
-                Q[idx, idx] = 2.0
-                c[idx] = -2.0 * target[idx]
+            if add_regularization == "level_L2":
+                for idx in range(n_vars):
+                    Q[idx, idx] = 2.0
+                    c[idx] = -2.0 * target[idx]
+            elif add_regularization in {"hess_lag", "hess_only_lag"}:
+                assert derivative_data is not None  # guarded above
+                assert derivative_data.hessian is not None  # guarded by data builder
+                hess = derivative_data.hessian
+                ref = derivative_data.target
+                Q[:n_vars, :n_vars] = hess
+                c[:n_vars] = -hess @ ref
+                if add_regularization == "hess_lag":
+                    c[:n_vars] += derivative_data.gradient
+            elif add_regularization == "sqp_lag":
+                assert derivative_data is not None  # guarded above
+                rho = 1.0
+                for idx in range(n_vars):
+                    Q[idx, idx] = 2.0 * rho
+                c[:n_vars] = derivative_data.gradient - 2.0 * rho * derivative_data.target
             if slack_index is not None:
                 c[slack_index] = oa_penalty_factor
             result = solve_qp(
@@ -1444,16 +1634,21 @@ def _solve_regularized_master(
                 gap_tolerance=gap_tolerance,
             )
         except (ImportError, ValueError) as exc:
-            raise _l2_regularization_backend_error() from exc
+            raise _qp_regularization_backend_error(add_regularization) from exc
     else:
         from discopt.solvers.lp_backend import get_milp_solver
 
         solve_milp = get_milp_solver()
         c = np.zeros(n_master, dtype=np.float64)
         if add_regularization == "level_L1":
+            assert aux_start is not None
             c[aux_start : aux_start + n_vars] = 1.0
-        else:
+        elif add_regularization == "level_L_infinity":
+            assert aux_start is not None
             c[aux_start] = 1.0
+        elif add_regularization == "grad_lag":
+            assert derivative_data is not None  # guarded above
+            c[:n_vars] = derivative_data.gradient
         if slack_index is not None:
             c[slack_index] = oa_penalty_factor
         result = solve_milp(
@@ -1673,10 +1868,12 @@ def solve_oa(
         Add integer-exclusion cuts after infeasible fixed-integer NLP solves.
     feasibility_norm : {"L1", "L2", "L_infinity"}
         Violation norm minimized by the feasibility subproblem heuristic.
-    add_regularization : {None, "level_L1", "level_L2", "level_L_infinity"}
+    add_regularization : {None, "level_L1", "level_L2", "level_L_infinity",
+            "grad_lag", "hess_lag", "hess_only_lag", "sqp_lag"}
         Optional level-set regularized OA master before fixed-integer NLP solves.
-        L1 and L-infinity are solved as MILPs; L2 requires a MIQP-capable QP
-        backend.
+        L1, L-infinity, and ``grad_lag`` are solved as MILPs; quadratic modes
+        require a MIQP-capable QP backend. Derivative modes require NLP duals,
+        and Hessian modes require Lagrangian Hessian access.
     level_coef : float
         Coefficient in the open interval ``(0, 1)`` for the regularization
         level constraint. The level is
@@ -1714,8 +1911,9 @@ def solve_oa(
     evaluator = decomp.evaluator
     n_vars = decomp.n_vars
     n_cons = decomp.n_cons
-    if add_regularization == "level_L2" and decomp.int_indices:
-        _require_l2_regularization_backend()
+    derivative_regularization = _regularization_requires_derivatives(add_regularization)
+    if add_regularization in _QP_REGULARIZATION_MODES and decomp.int_indices:
+        _require_qp_regularization_backend(add_regularization)
     # The whole OA loop runs in the evaluator's minimization convention (it
     # negates a MAXIMIZE objective). Un-negate the user-facing objective/bound at
     # the return sites with this sign; the gap is convention-invariant.
@@ -1777,15 +1975,46 @@ def solve_oa(
     integer_assignments_seen: set[tuple[float, ...]] = set()
     incumbent_progress: list[float] = []
     termination_reason = None
+    incumbent_derivative_data: Optional[_DerivativeRegularizationData] = None
+
+    def accept_incumbent(
+        x: np.ndarray,
+        obj: float,
+        multipliers: Optional[np.ndarray],
+    ) -> None:
+        nonlocal UB, incumbent, incumbent_obj, incumbent_derivative_data
+        UB = float(obj)
+        incumbent = np.asarray(x, dtype=np.float64).copy()
+        incumbent_obj = float(obj)
+        if derivative_regularization:
+            assert add_regularization is not None
+            incumbent_derivative_data = _build_derivative_regularization_data(
+                decomp,
+                add_regularization,
+                incumbent,
+                multipliers,
+            )
 
     if init_strategy == "rNLP":
-        x_relax, obj_relax = _solve_nlp_relaxation(
-            evaluator,
-            decomp.lb,
-            decomp.ub,
-            nlp_solver,
-            initial_point=initial_point,
-        )
+        relax_attempt = None
+        if derivative_regularization:
+            relax_attempt = _solve_nlp_relaxation(
+                evaluator,
+                decomp.lb,
+                decomp.ub,
+                nlp_solver,
+                initial_point=initial_point,
+                return_attempt=True,
+            )
+            x_relax, obj_relax = relax_attempt.x, relax_attempt.objective
+        else:
+            x_relax, obj_relax = _solve_nlp_relaxation(
+                evaluator,
+                decomp.lb,
+                decomp.ub,
+                nlp_solver,
+                initial_point=initial_point,
+            )
 
         if x_relax is not None:
             _add_oa_cuts(
@@ -1807,9 +2036,8 @@ def solve_oa(
                 abs(x_relax[idx] - round(x_relax[idx])) < 1e-5 for idx in decomp.int_indices
             )
             if is_int_feasible and obj_relax is not None:
-                UB = obj_relax
-                incumbent = x_relax.copy()
-                incumbent_obj = obj_relax
+                multipliers = relax_attempt.multipliers if relax_attempt is not None else None
+                accept_incumbent(x_relax, obj_relax, multipliers)
         else:
             # NLP relaxation failed; generate initial cuts at the deterministic midpoint.
             x_mid = _default_nlp_start(decomp.lb, decomp.ub)
@@ -1858,9 +2086,7 @@ def solve_oa(
             oa_cut_relaxable=oa_cut_relaxable,
         )
         if fp_result.best_x is not None and fp_result.best_obj is not None:
-            UB = fp_result.best_obj
-            incumbent = fp_result.best_x.copy()
-            incumbent_obj = fp_result.best_obj
+            accept_incumbent(fp_result.best_x, fp_result.best_obj, None)
     else:
         x_seed = _build_initial_strategy_point(decomp, init_strategy, initial_point)
         if ecp_mode:
@@ -1879,19 +2105,31 @@ def solve_oa(
                 oa_cut_relaxable=oa_cut_relaxable,
             )
             if _is_primal_feasible(evaluator, x_seed):
-                UB = float(evaluator.evaluate_objective(x_seed))
-                incumbent = x_seed.copy()
-                incumbent_obj = UB
+                accept_incumbent(x_seed, float(evaluator.evaluate_objective(x_seed)), None)
         else:
-            x_init, obj_init = _solve_nlp_subproblem(
-                evaluator,
-                decomp.lb,
-                decomp.ub,
-                decomp.int_indices,
-                x_seed,
-                nlp_solver,
-                initial_point=x_seed,
-            )
+            init_attempt = None
+            if derivative_regularization:
+                init_attempt = _solve_nlp_subproblem(
+                    evaluator,
+                    decomp.lb,
+                    decomp.ub,
+                    decomp.int_indices,
+                    x_seed,
+                    nlp_solver,
+                    initial_point=x_seed,
+                    return_attempt=True,
+                )
+                x_init, obj_init = init_attempt.x, init_attempt.objective
+            else:
+                x_init, obj_init = _solve_nlp_subproblem(
+                    evaluator,
+                    decomp.lb,
+                    decomp.ub,
+                    decomp.int_indices,
+                    x_seed,
+                    nlp_solver,
+                    initial_point=x_seed,
+                )
             x_cut = x_init if x_init is not None else x_seed
             _add_oa_cuts(
                 evaluator,
@@ -1908,9 +2146,8 @@ def solve_oa(
                 oa_cut_relaxable=oa_cut_relaxable,
             )
             if x_init is not None and obj_init is not None:
-                UB = obj_init
-                incumbent = x_init.copy()
-                incumbent_obj = obj_init
+                multipliers = init_attempt.multipliers if init_attempt is not None else None
+                accept_incumbent(x_init, obj_init, multipliers)
 
     # 3. Main OA loop
     for iteration in range(max_iterations):
@@ -2012,6 +2249,14 @@ def solve_oa(
                 regularization_lb += float(decomp.obj_coeffs[1])
             objective_level = (1.0 - level_coef) * float(UB) + level_coef * float(regularization_lb)
             remaining_time = max(0.0, time_limit - (time.perf_counter() - t_start))
+            derivative_data = None
+            if derivative_regularization:
+                if incumbent_derivative_data is None:
+                    raise RuntimeError(
+                        f"OA {add_regularization} regularization requires Lagrangian "
+                        "derivative data from an incumbent NLP solve."
+                    )
+                derivative_data = incumbent_derivative_data
             x_regularized = _solve_regularized_master(
                 decomp,
                 oa_A_rows,
@@ -2026,6 +2271,7 @@ def solve_oa(
                 oa_penalty_factor=oa_penalty_factor,
                 oa_cut_relaxable=oa_cut_relaxable,
                 use_objective_epigraph=(not decomp.obj_is_linear and decomp.oa_objective_is_convex),
+                derivative_data=derivative_data,
             )
             if x_regularized is not None:
                 nlp_initial_point = x_regularized
@@ -2078,21 +2324,34 @@ def solve_oa(
             continue
 
         # c. Fix integers, solve NLP subproblem
-        x_nlp, obj_nlp = _solve_nlp_subproblem(
-            evaluator,
-            decomp.lb,
-            decomp.ub,
-            decomp.int_indices,
-            x_master,
-            nlp_solver,
-            initial_point=nlp_initial_point,
-        )
+        nlp_attempt = None
+        if derivative_regularization:
+            nlp_attempt = _solve_nlp_subproblem(
+                evaluator,
+                decomp.lb,
+                decomp.ub,
+                decomp.int_indices,
+                x_master,
+                nlp_solver,
+                initial_point=nlp_initial_point,
+                return_attempt=True,
+            )
+            x_nlp, obj_nlp = nlp_attempt.x, nlp_attempt.objective
+        else:
+            x_nlp, obj_nlp = _solve_nlp_subproblem(
+                evaluator,
+                decomp.lb,
+                decomp.ub,
+                decomp.int_indices,
+                x_master,
+                nlp_solver,
+                initial_point=nlp_initial_point,
+            )
 
         if x_nlp is not None:
             if obj_nlp < UB:
-                UB = obj_nlp
-                incumbent = x_nlp.copy()
-                incumbent_obj = obj_nlp
+                multipliers = nlp_attempt.multipliers if nlp_attempt is not None else None
+                accept_incumbent(x_nlp, obj_nlp, multipliers)
 
             # Generate OA cuts at NLP solution
             _add_oa_cuts(

--- a/python/discopt/solvers/oa.py
+++ b/python/discopt/solvers/oa.py
@@ -6,6 +6,12 @@ with extensions for feasibility cuts, equality relaxation, and ECP mode.
 Decomposes MINLP into alternating NLP subproblems (with fixed integers)
 and MILP master problems (with accumulated linearization cuts).
 
+The convex-case OA guarantee applies when the minimization objective is
+convex, nonlinear inequalities are written in their convex orientation, and
+equalities are affine. Nonlinear equalities such as process equations make the
+model nonconvex for OA purposes; equality relaxation is a robustness heuristic
+and must not be read as restoring the convex-case convergence guarantee.
+
 References:
     Duran & Grossmann, Math. Prog. 36, 1986. DOI: 10.1007/BF02592064
     Fletcher & Leyffer, Math. Prog. 66, 1994. DOI: 10.1007/BF01581153
@@ -1848,7 +1854,9 @@ def solve_oa(
     equality_relaxation : bool
         Relax nonlinear equalities to inequalities in OA cuts
         (Viswanathan & Grossmann 1990). Helps when nonlinear equalities
-        cause the MILP master to become infeasible.
+        cause the MILP master to become infeasible. This is a robustness
+        heuristic; nonlinear equalities do not satisfy the convex MINLP OA
+        guarantee unless they are affine.
     ecp_mode : bool
         Extended Cutting Plane mode (Westerlund & Pettersson 1995):
         skip NLP subproblems entirely, only add cuts at MILP master

--- a/python/discopt/solvers/oa.py
+++ b/python/discopt/solvers/oa.py
@@ -1548,6 +1548,7 @@ def _solve_regularized_master(
     b_ub_vals.append(level_rhs)
 
     if add_regularization == "level_L1":
+        assert aux_start is not None
         for idx in range(n_vars):
             dev_idx = aux_start + idx
             row = np.zeros(n_master, dtype=np.float64)
@@ -1562,6 +1563,7 @@ def _solve_regularized_master(
             a_ub_rows.append(row)
             b_ub_vals.append(float(-target[idx]))
     elif add_regularization == "level_L_infinity":
+        assert aux_start is not None
         dev_idx = aux_start
         for idx in range(n_vars):
             row = np.zeros(n_master, dtype=np.float64)

--- a/python/tests/test_mip_nlp.py
+++ b/python/tests/test_mip_nlp.py
@@ -58,6 +58,20 @@ def _mindtpy_simple_minlp(name="mindtpy_init_strategy"):
     return m
 
 
+def _mindtpy_simple3_minlp(name="mindtpy_simple3"):
+    """Native port of Pyomo MindtPy's MINLP3_simple fixture."""
+    m = dm.Model(name)
+    x = m.continuous("x", shape=(2,), lb=-0.9, ub=50.0)
+    y = m.binary("y")
+
+    m.subject_to(-x[1] + 5.0 * dm.log(x[0] + 1.0) + 3.0 * y >= 0.0)
+    m.subject_to(-x[1] + x[0] ** 2 - y <= 1.0)
+    m.subject_to(x[0] + x[1] + 20.0 * y <= 24.0)
+    m.subject_to(2.0 * x[1] + 3.0 * x[0] <= 10.0)
+    m.minimize(10.0 * x[0] ** 2 - x[1] + 5.0 * (y - 1.0))
+    return m
+
+
 def _mindtpy_constraint_qualification_example(name="mindtpy_constraint_qualification"):
     """Native port of Pyomo MindtPy's constraint-qualification fixture."""
     m = dm.Model(name)
@@ -1456,6 +1470,28 @@ def test_mip_nlp_regularized_oa_matches_mindtpy_constraint_qualification(
         assert result.gap == pytest.approx(0.0, abs=1e-9)
     assert result.x["x"] == pytest.approx(3.0, abs=1e-3)
     assert result.x["y"] == pytest.approx(1.0, abs=1e-5)
+
+
+@pytest.mark.skipif(not HAS_HIGHS, reason="highspy not installed")
+@pytest.mark.parametrize("add_regularization", _MINDTPY_REGULARIZATION_MODES)
+def test_mip_nlp_regularized_oa_matches_mindtpy_minlp3_simple(add_regularization):
+    result = _mindtpy_simple3_minlp(f"mindtpy_simple3_{add_regularization}").solve(
+        solver="mip-nlp",
+        mip_nlp_method="oa",
+        add_regularization=add_regularization,
+        time_limit=60,
+        max_nodes=100,
+    )
+
+    assert result.status == "optimal"
+    assert result.objective == pytest.approx(-5.5122, abs=1e-3)
+    assert result.bound == pytest.approx(result.objective, abs=1e-3)
+    assert result.gap == pytest.approx(0.0, abs=1e-9)
+    assert np.asarray(result.x["x"]).tolist() == pytest.approx(
+        [0.2071068, 0.9411321],
+        abs=1e-3,
+    )
+    assert result.x["y"] == pytest.approx(0.0, abs=1e-5)
 
 
 @pytest.mark.slow

--- a/python/tests/test_mip_nlp.py
+++ b/python/tests/test_mip_nlp.py
@@ -58,6 +58,106 @@ def _mindtpy_simple_minlp(name="mindtpy_init_strategy"):
     return m
 
 
+def _mindtpy_constraint_qualification_example(name="mindtpy_constraint_qualification"):
+    """Native port of Pyomo MindtPy's constraint-qualification fixture."""
+    m = dm.Model(name)
+    x = m.continuous("x", lb=1.0, ub=10.0)
+    y = m.binary("y")
+
+    m.subject_to((x - 3.0) ** 2 <= 50.0 * (1 - y))
+    m.subject_to(x * dm.log(x) + 5.0 <= 50.0 * y)
+    m.minimize(x)
+    return m
+
+
+def _mindtpy_eight_process_flowsheet(name="mindtpy_eight_process"):
+    """Native port of Pyomo MindtPy's convex eight-process flowsheet fixture."""
+    m = dm.Model(name)
+    stream_ubs = np.full(24, 10.0, dtype=float)
+    for stream, ub in {
+        3: 2.0,
+        5: 2.0,
+        9: 2.0,
+        10: 1.0,
+        14: 1.0,
+        17: 2.0,
+        19: 2.0,
+        21: 2.0,
+        25: 3.0,
+    }.items():
+        stream_ubs[stream - 2] = ub
+
+    x = m.continuous("x", shape=(24,), lb=0.0, ub=stream_ubs)
+    y = m.binary("y", shape=(8,))
+
+    def x_stream(stream):
+        return x[stream - 2]
+
+    def y_unit(unit):
+        return y[unit - 1]
+
+    m.subject_to(1.5 * x_stream(9) + x_stream(10) == x_stream(8))
+    m.subject_to(1.25 * (x_stream(12) + x_stream(14)) == x_stream(13))
+    m.subject_to(x_stream(15) == 2 * x_stream(16))
+
+    m.subject_to(dm.exp(x_stream(3)) - 1 <= x_stream(2))
+    m.subject_to(dm.exp(x_stream(5) / 1.2) - 1 <= x_stream(4))
+    m.subject_to(dm.exp(x_stream(22)) - 1 <= x_stream(21))
+    m.subject_to(dm.exp(x_stream(18)) - 1 <= x_stream(10) + x_stream(17))
+    m.subject_to(dm.exp(x_stream(20) / 1.5) - 1 <= x_stream(19))
+
+    m.subject_to(x_stream(13) == x_stream(19) + x_stream(21))
+    m.subject_to(x_stream(17) == x_stream(9) + x_stream(16) + x_stream(25))
+    m.subject_to(x_stream(11) == x_stream(12) + x_stream(15))
+    m.subject_to(x_stream(3) + x_stream(5) == x_stream(6) + x_stream(11))
+    m.subject_to(x_stream(6) == x_stream(7) + x_stream(8))
+    m.subject_to(x_stream(23) == x_stream(20) + x_stream(22))
+    m.subject_to(x_stream(23) == x_stream(14) + x_stream(24))
+
+    m.subject_to(x_stream(10) <= 0.8 * x_stream(17))
+    m.subject_to(x_stream(10) >= 0.4 * x_stream(17))
+    m.subject_to(x_stream(12) <= 5 * x_stream(14))
+    m.subject_to(x_stream(12) >= 2 * x_stream(14))
+
+    m.subject_to(x_stream(2) <= 10 * y_unit(1))
+    m.subject_to(x_stream(4) <= 10 * y_unit(2))
+    m.subject_to(x_stream(9) <= 10 * y_unit(3))
+    m.subject_to(x_stream(12) + x_stream(14) <= 10 * y_unit(4))
+    m.subject_to(x_stream(15) <= 10 * y_unit(5))
+    m.subject_to(x_stream(19) <= 10 * y_unit(6))
+    m.subject_to(x_stream(21) <= 10 * y_unit(7))
+    m.subject_to(x_stream(10) + x_stream(17) <= 10 * y_unit(8))
+
+    m.subject_to(y_unit(1) + y_unit(2) == 1)
+    m.subject_to(y_unit(4) + y_unit(5) <= 1)
+    m.subject_to(y_unit(6) + y_unit(7) - y_unit(4) == 0)
+    m.subject_to(y_unit(3) - y_unit(8) <= 0)
+
+    fixed_cost = np.array([5.0, 8.0, 6.0, 10.0, 6.0, 7.0, 4.0, 5.0])
+    variable_cost = {
+        2: 1.0,
+        3: -10.0,
+        4: 1.0,
+        5: -15.0,
+        9: -40.0,
+        10: 15.0,
+        14: 15.0,
+        17: 80.0,
+        18: -65.0,
+        19: 25.0,
+        20: -60.0,
+        21: 35.0,
+        22: -80.0,
+        25: -35.0,
+    }
+    m.minimize(
+        122.0
+        + sum(fixed_cost[unit] * y[unit] for unit in range(8))
+        + sum(variable_cost.get(stream, 0.0) * x_stream(stream) for stream in range(2, 26))
+    )
+    return m
+
+
 def _has_disjunctions(model):
     return any(isinstance(c, _DisjunctiveConstraint) for c in model._constraints)
 
@@ -1102,3 +1202,61 @@ def test_mip_nlp_regularized_oa_grad_lag_solves_mindtpy_baseline():
     assert result.bound == pytest.approx(3.5, abs=1e-3)
     assert result.gap == pytest.approx(0.0, abs=1e-9)
     assert np.asarray(result.x["y"]).tolist() == pytest.approx([0.0, 1.0, 0.0])
+
+
+_MINDTPY_REGULARIZATION_MODES = [
+    "level_L1",
+    "level_L2",
+    "level_L_infinity",
+    "grad_lag",
+    "hess_lag",
+    "hess_only_lag",
+    "sqp_lag",
+]
+
+
+@pytest.mark.skipif(not HAS_HIGHS, reason="highspy not installed")
+@pytest.mark.parametrize("add_regularization", _MINDTPY_REGULARIZATION_MODES)
+def test_mip_nlp_regularized_oa_matches_mindtpy_constraint_qualification(
+    add_regularization,
+):
+    result = _mindtpy_constraint_qualification_example(f"mindtpy_cq_{add_regularization}").solve(
+        solver="mip-nlp",
+        mip_nlp_method="oa",
+        add_regularization=add_regularization,
+        time_limit=60,
+        max_nodes=100,
+    )
+
+    assert result.status in ("optimal", "feasible")
+    assert result.objective == pytest.approx(3.0, abs=1e-3)
+    if result.status == "optimal":
+        assert result.bound == pytest.approx(3.0, abs=1e-3)
+        assert result.gap == pytest.approx(0.0, abs=1e-9)
+    assert result.x["x"] == pytest.approx(3.0, abs=1e-3)
+    assert result.x["y"] == pytest.approx(1.0, abs=1e-5)
+
+
+@pytest.mark.slow
+@pytest.mark.skipif(not HAS_HIGHS, reason="highspy not installed")
+@pytest.mark.parametrize("add_regularization", _MINDTPY_REGULARIZATION_MODES)
+def test_mip_nlp_regularized_oa_matches_mindtpy_eight_process_flowsheet(
+    add_regularization,
+):
+    result = _mindtpy_eight_process_flowsheet(f"mindtpy_eight_process_{add_regularization}").solve(
+        solver="mip-nlp",
+        mip_nlp_method="oa",
+        add_regularization=add_regularization,
+        time_limit=120,
+        max_nodes=200,
+    )
+
+    assert result.status in ("optimal", "feasible")
+    assert result.objective == pytest.approx(68.0097, abs=2e-2)
+    if result.status == "optimal":
+        assert result.bound == pytest.approx(result.objective, abs=2e-2)
+        assert result.gap == pytest.approx(0.0, abs=1e-9)
+    assert np.asarray(result.x["y"]).tolist() == pytest.approx(
+        [0.0, 1.0, 0.0, 1.0, 0.0, 1.0, 0.0, 1.0],
+        abs=1e-5,
+    )

--- a/python/tests/test_mip_nlp.py
+++ b/python/tests/test_mip_nlp.py
@@ -502,19 +502,23 @@ def test_oa_max_binary_seed_sets_binaries_and_general_integer_fallback():
         ("level-l2", "level_L2"),
         ("level_Linf", "level_L_infinity"),
         ("level_L_infinity", "level_L_infinity"),
+        ("grad-lag", "grad_lag"),
+        ("hess_lag", "hess_lag"),
+        ("hess-only-lag", "hess_only_lag"),
+        ("sqp_lag", "sqp_lag"),
     ],
 )
-def test_oa_regularization_normalizes_supported_level_modes(raw, expected):
+def test_oa_regularization_normalizes_supported_modes(raw, expected):
     from discopt.solvers.oa import _normalize_regularization
 
     assert _normalize_regularization(raw) == expected
 
 
-def test_oa_regularization_rejects_reserved_future_modes():
+def test_oa_regularization_rejects_unknown_modes():
     from discopt.solvers.oa import _normalize_regularization
 
     with pytest.raises(ValueError, match="Unknown add_regularization"):
-        _normalize_regularization("hess_lag")
+        _normalize_regularization("not_a_regularization")
 
 
 def test_oa_regularization_rejects_ecp_mode():
@@ -617,6 +621,153 @@ def test_oa_regularized_master_builds_l2_qp_distance_objective(monkeypatch):
     assert captured["b_ub"][0] == pytest.approx(2.0)
 
 
+def test_oa_regularized_master_builds_grad_lag_objective(monkeypatch):
+    import discopt.solvers.lp_backend as lp_backend
+    from discopt.solvers import MILPResult, SolveStatus
+    from discopt.solvers.oa import (
+        _decompose_model,
+        _DerivativeRegularizationData,
+        _solve_regularized_master,
+    )
+
+    decomp = _decompose_model(_mixed_discrete_model("regularized_grad_lag"))
+    captured = {}
+    data = _DerivativeRegularizationData(
+        target=np.array([0.5, 1.0, 0.0, 2.0], dtype=float),
+        gradient=np.array([1.0, -2.0, 3.0, -4.0], dtype=float),
+    )
+
+    def fake_milp(**kwargs):
+        captured.update(kwargs)
+        return MILPResult(status=SolveStatus.OPTIMAL, x=np.array([0.0, 1.0, 0.0, 0.0]))
+
+    monkeypatch.setattr(lp_backend, "get_milp_solver", lambda: fake_milp)
+
+    x_regularized = _solve_regularized_master(
+        decomp,
+        [],
+        [],
+        add_regularization="grad_lag",
+        target=data.target,
+        objective_level=2.0,
+        time_limit=10.0,
+        gap_tolerance=1e-4,
+        derivative_data=data,
+    )
+
+    assert x_regularized.tolist() == pytest.approx([0.0, 1.0, 0.0, 0.0])
+    assert captured["c"].tolist() == pytest.approx([1.0, -2.0, 3.0, -4.0])
+    assert captured["integrality"].tolist() == decomp.integrality.tolist()
+    assert captured["A_ub"][0, :4].tolist() == pytest.approx([1.0, 1.0, 1.0, 1.0])
+    assert captured["b_ub"][0] == pytest.approx(2.0)
+
+
+@pytest.mark.parametrize(
+    ("mode", "expected_diag", "expected_c"),
+    [
+        ("hess_lag", [2.0, 4.0, 6.0, 8.0], [0.0, -6.0, 3.0, -20.0]),
+        ("hess_only_lag", [2.0, 4.0, 6.0, 8.0], [-1.0, -4.0, 0.0, -16.0]),
+        ("sqp_lag", [2.0, 2.0, 2.0, 2.0], [0.0, -4.0, 3.0, -8.0]),
+    ],
+)
+def test_oa_regularized_master_builds_derivative_qp_objectives(
+    monkeypatch, mode, expected_diag, expected_c
+):
+    import discopt.solvers.lp_backend as lp_backend
+    from discopt.solvers import QPResult, SolveStatus
+    from discopt.solvers.oa import (
+        _decompose_model,
+        _DerivativeRegularizationData,
+        _solve_regularized_master,
+    )
+
+    decomp = _decompose_model(_mixed_discrete_model(f"regularized_{mode}"))
+    captured = {}
+    data = _DerivativeRegularizationData(
+        target=np.array([0.5, 1.0, 0.0, 2.0], dtype=float),
+        gradient=np.array([1.0, -2.0, 3.0, -4.0], dtype=float),
+        hessian=np.diag([2.0, 4.0, 6.0, 8.0]),
+    )
+
+    def fake_qp(**kwargs):
+        captured.update(kwargs)
+        return QPResult(status=SolveStatus.OPTIMAL, x=np.array([0.0, 1.0, 0.0, 0.0]))
+
+    monkeypatch.setattr(lp_backend, "get_qp_solver", lambda: fake_qp)
+
+    x_regularized = _solve_regularized_master(
+        decomp,
+        [],
+        [],
+        add_regularization=mode,
+        target=data.target,
+        objective_level=2.0,
+        time_limit=10.0,
+        gap_tolerance=1e-4,
+        derivative_data=data,
+    )
+
+    assert x_regularized.tolist() == pytest.approx([0.0, 1.0, 0.0, 0.0])
+    assert captured["Q"].shape == (4, 4)
+    assert np.diag(captured["Q"]).tolist() == pytest.approx(expected_diag)
+    assert captured["c"].tolist() == pytest.approx(expected_c)
+    assert captured["integrality"].tolist() == decomp.integrality.tolist()
+
+
+def test_oa_derivative_regularization_requires_duals_from_initial_incumbent(monkeypatch):
+    import discopt.solvers.oa as oa_module
+
+    model = _binary_model("regularized_missing_duals")
+    y = model._variables[0]
+    model.subject_to(y >= 0)
+
+    def fake_solve_nlp_relaxation(
+        evaluator,
+        lb,
+        ub,
+        nlp_solver,
+        initial_point=None,
+        return_attempt=False,
+    ):
+        attempt = oa_module._NLPAttempt(
+            x=np.array([0.0], dtype=float),
+            objective=0.0,
+            multipliers=None,
+        )
+        if return_attempt:
+            return attempt
+        return attempt.x, attempt.objective
+
+    monkeypatch.setattr(oa_module, "_solve_nlp_relaxation", fake_solve_nlp_relaxation)
+    monkeypatch.setattr(oa_module, "_add_oa_cuts", lambda *args, **kwargs: None)
+
+    with pytest.raises(RuntimeError, match="requires NLP dual multipliers"):
+        oa_module.solve_oa(
+            model,
+            add_regularization="grad_lag",
+            max_iterations=0,
+        )
+
+
+def test_oa_hessian_regularization_requires_hessian_access(monkeypatch):
+    from discopt.solvers.oa import _build_derivative_regularization_data, _decompose_model
+
+    decomp = _decompose_model(_mixed_discrete_model("regularized_missing_hessian"))
+
+    def missing_hessian(*args, **kwargs):
+        raise AttributeError("no hessian")
+
+    monkeypatch.setattr(decomp.evaluator, "evaluate_lagrangian_hessian", missing_hessian)
+
+    with pytest.raises(RuntimeError, match="requires NLP Hessian access"):
+        _build_derivative_regularization_data(
+            decomp,
+            "hess_only_lag",
+            np.array([0.5, 1.0, 0.0, 2.0], dtype=float),
+            np.empty(0, dtype=float),
+        )
+
+
 def test_oa_l2_regularization_requires_miqp_backend(monkeypatch):
     import discopt.solvers.lp_backend as lp_backend
     from discopt.solvers.oa import _decompose_model, _solve_regularized_master
@@ -654,6 +805,24 @@ def test_oa_l2_regularization_checks_backend_before_iterations(monkeypatch):
         solve_oa(
             _binary_model("regularized_l2_no_backend_solve"),
             add_regularization="level_L2",
+            max_iterations=0,
+        )
+
+
+@pytest.mark.parametrize("mode", ["hess_lag", "hess_only_lag", "sqp_lag"])
+def test_oa_derivative_qp_regularization_checks_backend_before_iterations(monkeypatch, mode):
+    import discopt.solvers.lp_backend as lp_backend
+    from discopt.solvers.oa import solve_oa
+
+    def missing_qp():
+        raise ImportError("no qp backend")
+
+    monkeypatch.setattr(lp_backend, "get_qp_solver", missing_qp)
+
+    with pytest.raises(RuntimeError, match="QP/MIQP-capable backend"):
+        solve_oa(
+            _binary_model(f"regularized_{mode}_no_backend_solve"),
+            add_regularization=mode,
             max_iterations=0,
         )
 
@@ -907,6 +1076,23 @@ def test_mip_nlp_regularized_oa_level_variants_solve_mindtpy_baseline(add_regula
         solver="mip-nlp",
         mip_nlp_method="oa",
         add_regularization=add_regularization,
+        time_limit=60,
+        max_nodes=100,
+    )
+
+    assert result.status == "optimal"
+    assert result.objective == pytest.approx(3.5, abs=1e-3)
+    assert result.bound == pytest.approx(3.5, abs=1e-3)
+    assert result.gap == pytest.approx(0.0, abs=1e-9)
+    assert np.asarray(result.x["y"]).tolist() == pytest.approx([0.0, 1.0, 0.0])
+
+
+@pytest.mark.skipif(not HAS_HIGHS, reason="highspy not installed")
+def test_mip_nlp_regularized_oa_grad_lag_solves_mindtpy_baseline():
+    result = _mindtpy_simple_minlp("mindtpy_roa_grad_lag").solve(
+        solver="mip-nlp",
+        mip_nlp_method="oa",
+        add_regularization="grad_lag",
         time_limit=60,
         max_nodes=100,
     )

--- a/python/tests/test_mip_nlp.py
+++ b/python/tests/test_mip_nlp.py
@@ -183,6 +183,19 @@ def _has_disjunctions(model):
     return any(isinstance(c, _DisjunctiveConstraint) for c in model._constraints)
 
 
+def _expr_has_function(expr, func_name):
+    if getattr(expr, "func_name", None) == func_name:
+        return True
+    for child_name in ("left", "right", "operand"):
+        child = getattr(expr, child_name, None)
+        if child is not None and _expr_has_function(child, func_name):
+            return True
+    return any(
+        _expr_has_function(child, func_name)
+        for child in tuple(getattr(expr, "args", ())) + tuple(getattr(expr, "terms", ()))
+    )
+
+
 def test_model_solve_routes_mip_nlp_options(monkeypatch):
     import discopt.solvers.mip_nlp as mip_nlp_module
 
@@ -227,6 +240,44 @@ def test_model_solve_routes_mip_nlp_options(monkeypatch):
     assert calls["level_coef"] == pytest.approx(0.4)
     assert calls["stalling_limit"] == 3
     assert calls["cycling_check"] is False
+
+
+def test_model_solve_mip_nlp_path_runs_entropy_canonicalization(monkeypatch):
+    import discopt._jax.factorable_reform as reform_module
+    import discopt.solvers.oa as oa_module
+
+    real_canonicalize_entropy = reform_module.canonicalize_entropy
+    calls = {}
+
+    def spy_canonicalize_entropy(model):
+        out = real_canonicalize_entropy(model)
+        calls["canonicalize_called"] = True
+        calls["input_had_entropy"] = _expr_has_function(model._objective.expression, "entropy")
+        calls["output_had_entropy"] = _expr_has_function(out._objective.expression, "entropy")
+        return out
+
+    def fake_solve_oa(model, **kwargs):
+        calls["solve_oa_had_entropy"] = _expr_has_function(model._objective.expression, "entropy")
+        return SolveResult(status="optimal", objective=0.0, bound=0.0, gap=0.0)
+
+    monkeypatch.setattr(reform_module, "canonicalize_entropy", spy_canonicalize_entropy)
+    monkeypatch.setattr(oa_module, "solve_oa", fake_solve_oa)
+
+    m = dm.Model("mip_nlp_entropy_canonicalization")
+    x = m.continuous("x", lb=0.1, ub=4.0)
+    y = m.binary("y")
+    m.subject_to(x >= y)
+    m.minimize(x * dm.log(x) + y)
+
+    result = m.solve(solver="mip-nlp", mip_nlp_method="oa")
+
+    assert result.status == "optimal"
+    assert calls == {
+        "canonicalize_called": True,
+        "input_had_entropy": False,
+        "output_had_entropy": True,
+        "solve_oa_had_entropy": True,
+    }
 
 
 def test_model_solve_ecp_alias_derives_method(monkeypatch):

--- a/python/tests/test_mip_nlp.py
+++ b/python/tests/test_mip_nlp.py
@@ -70,8 +70,8 @@ def _mindtpy_constraint_qualification_example(name="mindtpy_constraint_qualifica
     return m
 
 
-def _mindtpy_eight_process_flowsheet(name="mindtpy_eight_process"):
-    """Native port of Pyomo MindtPy's convex eight-process flowsheet fixture."""
+def _mindtpy_eight_process_flowsheet(name="mindtpy_eight_process", *, convex=True):
+    """Native port of Pyomo MindtPy's eight-process flowsheet fixture."""
     m = dm.Model(name)
     stream_ubs = np.full(24, 10.0, dtype=float)
     for stream, ub in {
@@ -100,11 +100,18 @@ def _mindtpy_eight_process_flowsheet(name="mindtpy_eight_process"):
     m.subject_to(1.25 * (x_stream(12) + x_stream(14)) == x_stream(13))
     m.subject_to(x_stream(15) == 2 * x_stream(16))
 
-    m.subject_to(dm.exp(x_stream(3)) - 1 <= x_stream(2))
-    m.subject_to(dm.exp(x_stream(5) / 1.2) - 1 <= x_stream(4))
-    m.subject_to(dm.exp(x_stream(22)) - 1 <= x_stream(21))
-    m.subject_to(dm.exp(x_stream(18)) - 1 <= x_stream(10) + x_stream(17))
-    m.subject_to(dm.exp(x_stream(20) / 1.5) - 1 <= x_stream(19))
+    if convex:
+        m.subject_to(dm.exp(x_stream(3)) - 1 <= x_stream(2))
+        m.subject_to(dm.exp(x_stream(5) / 1.2) - 1 <= x_stream(4))
+        m.subject_to(dm.exp(x_stream(22)) - 1 <= x_stream(21))
+        m.subject_to(dm.exp(x_stream(18)) - 1 <= x_stream(10) + x_stream(17))
+        m.subject_to(dm.exp(x_stream(20) / 1.5) - 1 <= x_stream(19))
+    else:
+        m.subject_to(dm.exp(x_stream(3)) - 1 == x_stream(2))
+        m.subject_to(dm.exp(x_stream(5) / 1.2) - 1 == x_stream(4))
+        m.subject_to(dm.exp(x_stream(22)) - 1 == x_stream(21))
+        m.subject_to(dm.exp(x_stream(18)) - 1 == x_stream(10) + x_stream(17))
+        m.subject_to(dm.exp(x_stream(20) / 1.5) - 1 == x_stream(19))
 
     m.subject_to(x_stream(13) == x_stream(19) + x_stream(21))
     m.subject_to(x_stream(17) == x_stream(9) + x_stream(16) + x_stream(25))
@@ -1213,6 +1220,20 @@ _MINDTPY_REGULARIZATION_MODES = [
     "hess_only_lag",
     "sqp_lag",
 ]
+
+
+def test_mip_nlp_mindtpy_eight_process_convex_flag_controls_oa_guarantee():
+    from discopt._jax.convexity import classify_oa_cut_convexity
+
+    convex = _mindtpy_eight_process_flowsheet("mindtpy_eight_process_convex", convex=True)
+    equality = _mindtpy_eight_process_flowsheet("mindtpy_eight_process_eq", convex=False)
+
+    convex_oa = classify_oa_cut_convexity(convex)
+    equality_oa = classify_oa_cut_convexity(equality)
+
+    assert all(convex_oa.constraint_mask)
+    assert sum(equality_oa.constraint_mask) == len(equality_oa.constraint_mask) - 5
+    assert [equality_oa.constraint_mask[i] for i in range(3, 8)] == [False] * 5
 
 
 @pytest.mark.skipif(not HAS_HIGHS, reason="highspy not installed")

--- a/python/tests/test_mip_nlp.py
+++ b/python/tests/test_mip_nlp.py
@@ -640,6 +640,18 @@ def test_oa_regularization_rejects_ecp_mode():
         )
 
 
+def test_oa_derivative_regularization_rejects_fp_init_on_constrained_models():
+    from discopt.solvers.oa import solve_oa
+
+    with pytest.raises(ValueError, match="init_strategy='fp'.*does not provide"):
+        solve_oa(
+            _mindtpy_simple_minlp("regularized_grad_lag_fp_init"),
+            add_regularization="grad_lag",
+            init_strategy="fp",
+            max_iterations=0,
+        )
+
+
 @pytest.mark.parametrize("level_coef", [0.0, 1.0, 1.5])
 def test_oa_regularization_level_coef_requires_open_unit_interval(level_coef):
     from discopt.solvers.oa import solve_oa
@@ -821,6 +833,73 @@ def test_oa_regularized_master_builds_derivative_qp_objectives(
     assert captured["integrality"].tolist() == decomp.integrality.tolist()
 
 
+def test_oa_derivative_regularization_data_assembles_lagrangian_terms():
+    from discopt.solvers.oa import (
+        _build_derivative_regularization_data,
+        _DecomposedProblem,
+    )
+
+    class FakeEvaluator:
+        def evaluate_gradient(self, x):
+            return np.array([1.0, 2.0, 3.0, 4.0])
+
+        def evaluate_jacobian(self, x):
+            return np.array(
+                [
+                    [1.0, 0.0, 2.0, -1.0],
+                    [0.5, 3.0, 0.0, 2.0],
+                ]
+            )
+
+        def evaluate_lagrangian_hessian(self, x, obj_factor, multipliers):
+            return np.array(
+                [
+                    [1.0, 2.0, 3.0, 4.0],
+                    [0.0, 5.0, 6.0, 7.0],
+                    [0.0, 0.0, 9.0, 8.0],
+                    [0.0, 0.0, 0.0, 13.0],
+                ]
+            )
+
+    decomp = _DecomposedProblem(
+        evaluator=FakeEvaluator(),
+        n_vars=4,
+        n_cons=2,
+        lb=np.zeros(4),
+        ub=np.ones(4),
+        int_indices=[1, 3],
+        binary_indices=[1],
+        general_integer_indices=[3],
+        integrality=np.array([0, 1, 0, 1], dtype=np.int32),
+        linear_A_rows=[],
+        linear_b_rows=[],
+        linear_senses=[],
+        nonlinear_indices=[0, 1],
+        constraint_senses=["<=", "<="],
+    )
+
+    data = _build_derivative_regularization_data(
+        decomp,
+        "hess_lag",
+        np.array([0.25, 1.0, 0.5, 2.0], dtype=float),
+        np.array([10.0, -2.0], dtype=float),
+    )
+
+    assert data.target.tolist() == pytest.approx([0.25, 1.0, 0.5, 2.0])
+    assert data.gradient.tolist() == pytest.approx([0.0, -4.0, 0.0, -10.0])
+    np.testing.assert_allclose(
+        data.hessian,
+        np.array(
+            [
+                [1.0, 1.0, 1.5, 2.0],
+                [1.0, 5.0, 3.0, 3.5],
+                [1.5, 3.0, 9.0, 4.0],
+                [2.0, 3.5, 4.0, 13.0],
+            ]
+        ),
+    )
+
+
 def test_oa_derivative_regularization_requires_duals_from_initial_incumbent(monkeypatch):
     import discopt.solvers.oa as oa_module
 
@@ -897,6 +976,42 @@ def test_oa_l2_regularization_requires_miqp_backend(monkeypatch):
             time_limit=10.0,
             gap_tolerance=1e-4,
         )
+
+
+def test_oa_qp_regularization_reports_backend_rejection_separately(monkeypatch):
+    import discopt.solvers.lp_backend as lp_backend
+    from discopt.solvers.oa import (
+        _decompose_model,
+        _DerivativeRegularizationData,
+        _solve_regularized_master,
+    )
+
+    decomp = _decompose_model(_mixed_discrete_model("regularized_hess_rejected"))
+    data = _DerivativeRegularizationData(
+        target=np.array([0.5, 1.0, 0.0, 2.0], dtype=float),
+        gradient=np.zeros(4),
+        hessian=np.diag([1.0, -1.0, 1.0, 1.0]),
+    )
+
+    def rejected_qp(**kwargs):
+        raise ValueError("Hessian is not positive semidefinite")
+
+    monkeypatch.setattr(lp_backend, "get_qp_solver", lambda: rejected_qp)
+
+    with pytest.raises(RuntimeError, match="rejected by the QP/MIQP backend") as excinfo:
+        _solve_regularized_master(
+            decomp,
+            [],
+            [],
+            add_regularization="hess_lag",
+            target=data.target,
+            objective_level=2.0,
+            time_limit=10.0,
+            gap_tolerance=1e-4,
+            derivative_data=data,
+        )
+
+    assert "requires a QP/MIQP-capable backend" not in str(excinfo.value)
 
 
 def test_oa_l2_regularization_checks_backend_before_iterations(monkeypatch):
@@ -986,6 +1101,91 @@ def test_oa_regularization_seeds_nlp_without_replacing_master_assignment(monkeyp
     )
 
     assert result.status == "feasible"
+    assert len(subproblem_calls) == 1
+    assert subproblem_calls[0][0].tolist() == pytest.approx(master_point.tolist())
+    assert subproblem_calls[0][1].tolist() == pytest.approx(regularized_point.tolist())
+
+
+def test_oa_derivative_regularization_seeds_nlp_from_regularized_point(monkeypatch):
+    import discopt.solvers.oa as oa_module
+    from discopt.solvers import MILPResult, SolveStatus
+
+    model = _mixed_discrete_model("derivative_regularized_seed_only")
+    relaxation_point = np.array([0.0, 1.0, 0.0, 3.0], dtype=float)
+    master_point = np.array([0.25, 0.0, 1.0, -1.0], dtype=float)
+    regularized_point = np.array([1.25, 1.0, 0.0, 2.0], dtype=float)
+    regularized_calls = []
+    subproblem_calls = []
+
+    def fake_solve_nlp_relaxation(
+        evaluator,
+        lb,
+        ub,
+        nlp_solver,
+        initial_point=None,
+        return_attempt=False,
+    ):
+        attempt = oa_module._NLPAttempt(
+            x=relaxation_point,
+            objective=4.0,
+            multipliers=np.empty(0, dtype=float),
+        )
+        if return_attempt:
+            return attempt
+        return attempt.x, attempt.objective
+
+    def fake_add_oa_cuts(*args, **kwargs):
+        return None
+
+    def fake_solve_master_milp(*args, **kwargs):
+        return MILPResult(status=SolveStatus.OPTIMAL, x=master_point, bound=1.0)
+
+    def fake_solve_regularized_master(*args, **kwargs):
+        regularized_calls.append(kwargs)
+        return regularized_point
+
+    def fake_solve_nlp_subproblem(
+        evaluator,
+        lb,
+        ub,
+        int_indices,
+        x_master,
+        nlp_solver,
+        initial_point=None,
+        return_attempt=False,
+    ):
+        subproblem_calls.append(
+            (
+                np.asarray(x_master, dtype=float).copy(),
+                np.asarray(initial_point, dtype=float).copy(),
+            )
+        )
+        attempt = oa_module._NLPAttempt(
+            x=np.asarray(x_master, dtype=float),
+            objective=3.0,
+            multipliers=np.empty(0, dtype=float),
+        )
+        if return_attempt:
+            return attempt
+        return attempt.x, attempt.objective
+
+    monkeypatch.setattr(oa_module, "_solve_nlp_relaxation", fake_solve_nlp_relaxation)
+    monkeypatch.setattr(oa_module, "_add_oa_cuts", fake_add_oa_cuts)
+    monkeypatch.setattr(oa_module, "_solve_master_milp", fake_solve_master_milp)
+    monkeypatch.setattr(oa_module, "_solve_regularized_master", fake_solve_regularized_master)
+    monkeypatch.setattr(oa_module, "_solve_nlp_subproblem", fake_solve_nlp_subproblem)
+
+    result = oa_module.solve_oa(
+        model,
+        add_regularization="grad_lag",
+        max_iterations=1,
+    )
+
+    assert result.status == "feasible"
+    assert len(regularized_calls) == 1
+    assert regularized_calls[0]["derivative_data"].gradient.tolist() == pytest.approx(
+        [0.0, 1.0, 1.0, 1.0]
+    )
     assert len(subproblem_calls) == 1
     assert subproblem_calls[0][0].tolist() == pytest.approx(master_point.tolist())
     assert subproblem_calls[0][1].tolist() == pytest.approx(regularized_point.tolist())


### PR DESCRIPTION
## Summary

- Add opt-in derivative-based OA regularization modes: `grad_lag`, `hess_lag`, `hess_only_lag`, and `sqp_lag`.
- Retain NLP multipliers internally so incumbent NLP solves can provide Lagrangian-gradient and Lagrangian-Hessian data to the regularized master.
- Distinguish missing NLP duals, missing Hessian access, and unsupported QP/MIQP regularization backends with explicit errors.
- Run entropy-family canonicalization through the `solver="mip-nlp"` entry path so raw `x*log(x)` / relative-entropy forms receive the same exact convexity-preserving rewrite as the default solve path.
- Extend MIP-NLP regularization tests for mode normalization, validation paths, master objective construction, MindtPy-derived fixtures, and direct entropy-canonicalization routing.

Closes #117

## Tests

- `PYTHONPATH=python python -m pytest python/tests/test_mip_nlp.py -q` - passed, 89 tests, 7 deselected.
- `PYTHONPATH=python python -m pytest python/tests/test_mip_nlp.py::test_model_solve_mip_nlp_path_runs_entropy_canonicalization python/tests/test_mip_nlp.py::test_mip_nlp_regularized_oa_matches_mindtpy_constraint_qualification -q` - passed, 8 tests.
- `python -m ruff check python/tests/test_mip_nlp.py` - passed.
- `python -m ruff format --check python/tests/test_mip_nlp.py` - passed.
- Earlier in this PR: `PYTHONPATH=python python -m pytest python/tests/test_oa.py -q` - passed, 21 tests, 10 deselected.

Note: the test runs emitted JAX warnings because the sandbox cannot write to `/home/bernalde/.cache/discopt/jax-cache`; the tests still passed.

## Branch Hygiene

- Base branch: `bernalde/discopt:feature/mip-nlp-solver`.
- Source branch: `bernalde/discopt:fix/issue-117-derivative-regularization`.
- Source branch point: `c160547fb71a8b09070d3fd8d8a74c099d47b0de` (`origin/feature/mip-nlp-solver`).
- Stacked status: direct child of the integration branch; not stacked on a parked `fix/*`, `feature/*`, `docs/*`, or `codex/*` branch.
- Prerequisite PRs: none open for this child PR; earlier MIP-NLP child work is already merged into `feature/mip-nlp-solver`.
