### PR TITLE
[codex] Add MIP-NLP global OA method

### DIFF
--- a/python/discopt/modeling/core.py
+++ b/python/discopt/modeling/core.py
@@ -2801,11 +2801,13 @@ class Model:
             ``add_no_good_cuts``, ``feasibility_norm``, ``add_regularization``,
             ``level_coef``, ``stalling_limit``, ``cycling_check``, and
             ``init_strategy`` take precedence over duplicate keys in
-            ``mip_nlp_options``. For ``mip_nlp_method="goa"``, AMP/global-
-            relaxation options such as ``rel_gap``, ``abs_tol``, ``max_iter``,
-            ``n_init_partitions``, ``partition_method``, ``milp_time_limit``,
-            ``milp_gap_tolerance``, ``presolve_bt``, and
-            ``convhull_formulation`` may also be passed as top-level aliases.
+            ``mip_nlp_options``. For ``mip_nlp_method="goa"``,
+            convexity-certified MINLPs use OA's valid master bounds and other
+            models use AMP/global relaxations. AMP options such as ``rel_gap``,
+            ``abs_tol``, ``max_iter``, ``n_init_partitions``,
+            ``partition_method``, ``milp_time_limit``, ``milp_gap_tolerance``,
+            ``presolve_bt``, and ``convhull_formulation`` may also be passed as
+            top-level aliases.
             Supported ``add_regularization`` values are
             ``"level_L1"``, ``"level_L2"``, ``"level_L_infinity"``,
             ``"grad_lag"``, ``"hess_lag"``, ``"hess_only_lag"``, and

--- a/python/discopt/modeling/core.py
+++ b/python/discopt/modeling/core.py
@@ -2807,7 +2807,9 @@ class Model:
             ``abs_tol``, ``max_iter``, ``n_init_partitions``,
             ``partition_method``, ``milp_time_limit``, ``milp_gap_tolerance``,
             ``presolve_bt``, and ``convhull_formulation`` may also be passed as
-            top-level aliases.
+            top-level aliases. AMP-only options apply only on the nonconvex AMP
+            path and are ignored with a warning when GOA automatically hands a
+            convexity-certified model to OA.
             Supported ``add_regularization`` values are
             ``"level_L1"``, ``"level_L2"``, ``"level_L_infinity"``,
             ``"grad_lag"``, ``"hess_lag"``, ``"hess_only_lag"``, and

--- a/python/discopt/modeling/core.py
+++ b/python/discopt/modeling/core.py
@@ -2793,7 +2793,7 @@ class Model:
             ``gurobi_options={...}``.
             Use ``solver="mip-nlp"`` to select the MIP-NLP decomposition
             family. Current implemented ``mip_nlp_method`` values are ``"oa"``,
-            ``"ecp"``, and ``"fp"``; ``"goa"``, ``"roa"``, and
+            ``"ecp"``, ``"fp"``, and ``"goa"``; ``"roa"`` and
             ``"lp_nlp_bb"`` are reserved until their dedicated implementations
             land. Top-level OA/ECP options such as ``equality_relaxation``,
             ``ecp_mode``, ``feasibility_cuts``, ``heuristic_nonconvex``,
@@ -2801,7 +2801,12 @@ class Model:
             ``add_no_good_cuts``, ``feasibility_norm``, ``add_regularization``,
             ``level_coef``, ``stalling_limit``, ``cycling_check``, and
             ``init_strategy`` take precedence over duplicate keys in
-            ``mip_nlp_options``. Supported ``add_regularization`` values are
+            ``mip_nlp_options``. For ``mip_nlp_method="goa"``, AMP/global-
+            relaxation options such as ``rel_gap``, ``abs_tol``, ``max_iter``,
+            ``n_init_partitions``, ``partition_method``, ``milp_time_limit``,
+            ``milp_gap_tolerance``, ``presolve_bt``, and
+            ``convhull_formulation`` may also be passed as top-level aliases.
+            Supported ``add_regularization`` values are
             ``"level_L1"``, ``"level_L2"``, ``"level_L_infinity"``,
             ``"grad_lag"``, ``"hess_lag"``, ``"hess_only_lag"``, and
             ``"sqp_lag"``. Supported initialization strategies are ``"rNLP"``,

--- a/python/discopt/solver.py
+++ b/python/discopt/solver.py
@@ -2435,6 +2435,44 @@ def solve_model(
         if mip_nlp_method is None:
             mip_nlp_method = "ecp" if bool(mip_nlp_kwargs.get("ecp_mode", False)) else "oa"
 
+        mip_nlp_method_key = (
+            mip_nlp_method.strip().lower().replace("-", "_")
+            if isinstance(mip_nlp_method, str)
+            else mip_nlp_method
+        )
+        if mip_nlp_method_key == "goa":
+            for key in (
+                "rel_gap",
+                "abs_tol",
+                "max_iter",
+                "n_init_partitions",
+                "partition_method",
+                "iteration_callback",
+                "milp_time_limit",
+                "milp_gap_tolerance",
+                "presolve_bt",
+                "presolve_bt_algo",
+                "presolve_bt_time_limit",
+                "presolve_bt_mip_time_limit",
+                "apply_partitioning",
+                "disc_var_pick",
+                "partition_scaling_factor",
+                "partition_scaling_factor_update",
+                "disc_add_partition_method",
+                "disc_abs_width_tol",
+                "convhull_formulation",
+                "convhull_ebd",
+                "convhull_ebd_encoding",
+                "use_start_as_incumbent",
+                "obbt_at_root",
+                "obbt_with_cutoff",
+                "alphabb_cutoff_obbt",
+                "obbt_time_limit",
+                "milp_solver",
+            ):
+                if key in kwargs:
+                    mip_nlp_kwargs[key] = kwargs.pop(key)
+
         gdp_methods = {"big-m", "hull", "mbigm", "auto"}
         native_gdp_methods = {"loa"}
         if gdp_method == "oa":

--- a/python/discopt/solver.py
+++ b/python/discopt/solver.py
@@ -2239,11 +2239,12 @@ def solve_model(
         ``stalling_limit``, ``cycling_check``, and ``milp_solver`` plus
         initialization option ``init_strategy`` may be passed as top-level
         aliases and take precedence over duplicate keys in ``mip_nlp_options``.
-        For ``mip_nlp_method="goa"``, AMP/global-relaxation options such as
-        ``rel_gap``, ``abs_tol``, ``max_iter``, ``n_init_partitions``,
-        ``partition_method``, ``milp_time_limit``, ``milp_gap_tolerance``,
-        ``presolve_bt``, and ``convhull_formulation`` may also be passed as
-        top-level aliases.
+        For ``mip_nlp_method="goa"``, convexity-certified MINLPs use OA's
+        valid master bounds and other models use AMP/global relaxations.
+        AMP options such as ``rel_gap``, ``abs_tol``, ``max_iter``,
+        ``n_init_partitions``, ``partition_method``, ``milp_time_limit``,
+        ``milp_gap_tolerance``, ``presolve_bt``, and
+        ``convhull_formulation`` may also be passed as top-level aliases.
         Supported ``add_regularization`` values are ``"level_L1"``,
         ``"level_L2"``, ``"level_L_infinity"``, ``"grad_lag"``,
         ``"hess_lag"``, ``"hess_only_lag"``, and ``"sqp_lag"``.

--- a/python/discopt/solver.py
+++ b/python/discopt/solver.py
@@ -2244,7 +2244,10 @@ def solve_model(
         AMP options such as ``rel_gap``, ``abs_tol``, ``max_iter``,
         ``n_init_partitions``, ``partition_method``, ``milp_time_limit``,
         ``milp_gap_tolerance``, ``presolve_bt``, and
-        ``convhull_formulation`` may also be passed as top-level aliases.
+        ``convhull_formulation`` may also be passed as top-level aliases;
+        AMP-only options apply only on the nonconvex AMP path and are ignored
+        with a warning when GOA automatically hands a convexity-certified model
+        to OA.
         Supported ``add_regularization`` values are ``"level_L1"``,
         ``"level_L2"``, ``"level_L_infinity"``, ``"grad_lag"``,
         ``"hess_lag"``, ``"hess_only_lag"``, and ``"sqp_lag"``.
@@ -2414,6 +2417,7 @@ def solve_model(
         import warnings
 
         from discopt.solvers.mip_nlp import solve_mip_nlp
+        from discopt.solvers.mip_nlp_options import GOA_OPTION_KEYS
 
         mip_nlp_method = kwargs.pop("mip_nlp_method", None)
         mip_nlp_options = kwargs.pop("mip_nlp_options", None)
@@ -2447,35 +2451,7 @@ def solve_model(
             else mip_nlp_method
         )
         if mip_nlp_method_key == "goa":
-            for key in (
-                "rel_gap",
-                "abs_tol",
-                "max_iter",
-                "n_init_partitions",
-                "partition_method",
-                "iteration_callback",
-                "milp_time_limit",
-                "milp_gap_tolerance",
-                "presolve_bt",
-                "presolve_bt_algo",
-                "presolve_bt_time_limit",
-                "presolve_bt_mip_time_limit",
-                "apply_partitioning",
-                "disc_var_pick",
-                "partition_scaling_factor",
-                "partition_scaling_factor_update",
-                "disc_add_partition_method",
-                "disc_abs_width_tol",
-                "convhull_formulation",
-                "convhull_ebd",
-                "convhull_ebd_encoding",
-                "use_start_as_incumbent",
-                "obbt_at_root",
-                "obbt_with_cutoff",
-                "alphabb_cutoff_obbt",
-                "obbt_time_limit",
-                "milp_solver",
-            ):
+            for key in sorted(GOA_OPTION_KEYS):
                 if key in kwargs:
                     mip_nlp_kwargs[key] = kwargs.pop(key)
 

--- a/python/discopt/solver.py
+++ b/python/discopt/solver.py
@@ -2201,7 +2201,7 @@ def solve_model(
         AMP algorithm with Gurobi as the MILP-master subsolver, use
         ``solver="amp", milp_solver="gurobi"``.
         Use ``"mip-nlp"`` to dispatch to the MIP-NLP decomposition family
-        (OA/ECP/FP now; GOA/ROA/LP-NLP-BB are reserved method selectors).
+        (OA/ECP/FP/GOA now; ROA/LP-NLP-BB are reserved method selectors).
         Use ``"gp"`` to dispatch to the geometric-programming fast path:
         the model is checked for GP structure (posynomial/monomial
         objective and constraints over strictly-positive continuous
@@ -2230,7 +2230,7 @@ def solve_model(
     solver="mip-nlp" options
         The MIP-NLP backend accepts ``mip_nlp_method`` and
         ``mip_nlp_options``. Current implemented methods are ``"oa"``,
-        ``"ecp"``, and ``"fp"``; ``"goa"``, ``"roa"``, and ``"lp_nlp_bb"`` raise
+        ``"ecp"``, ``"fp"``, and ``"goa"``; ``"roa"`` and ``"lp_nlp_bb"`` raise
         ``NotImplementedError`` until their dedicated implementations land.
         Existing OA options ``equality_relaxation``, ``ecp_mode``,
         ``feasibility_cuts``, ``heuristic_nonconvex``, ``add_slack``,
@@ -2239,6 +2239,11 @@ def solve_model(
         ``stalling_limit``, ``cycling_check``, and ``milp_solver`` plus
         initialization option ``init_strategy`` may be passed as top-level
         aliases and take precedence over duplicate keys in ``mip_nlp_options``.
+        For ``mip_nlp_method="goa"``, AMP/global-relaxation options such as
+        ``rel_gap``, ``abs_tol``, ``max_iter``, ``n_init_partitions``,
+        ``partition_method``, ``milp_time_limit``, ``milp_gap_tolerance``,
+        ``presolve_bt``, and ``convhull_formulation`` may also be passed as
+        top-level aliases.
         Supported ``add_regularization`` values are ``"level_L1"``,
         ``"level_L2"``, ``"level_L_infinity"``, ``"grad_lag"``,
         ``"hess_lag"``, ``"hess_only_lag"``, and ``"sqp_lag"``.

--- a/python/discopt/solvers/mip_nlp.py
+++ b/python/discopt/solvers/mip_nlp.py
@@ -6,10 +6,9 @@ from typing import Any, Optional
 
 from discopt.modeling.core import Model, SolveResult
 
-_IMPLEMENTED_METHODS = frozenset({"oa", "ecp", "fp"})
+_IMPLEMENTED_METHODS = frozenset({"oa", "ecp", "fp", "goa"})
 _RESERVED_METHOD_ISSUES = {
     "roa": "#116/#117",
-    "goa": "#118",
     "lp_nlp_bb": "#119",
 }
 SUPPORTED_METHODS = _IMPLEMENTED_METHODS | frozenset(_RESERVED_METHOD_ISSUES)
@@ -41,6 +40,38 @@ _FP_OPTION_KEYS = {
     "feasibility_norm",
     "init_strategy",
 }
+_GOA_OPTION_KEYS = {
+    "abs_tol",
+    "add_no_good_cuts",
+    "alphabb_cutoff_obbt",
+    "apply_partitioning",
+    "convhull_ebd",
+    "convhull_ebd_encoding",
+    "convhull_formulation",
+    "disc_abs_width_tol",
+    "disc_add_partition_method",
+    "disc_var_pick",
+    "feasibility_norm",
+    "init_strategy",
+    "iteration_callback",
+    "max_iter",
+    "milp_gap_tolerance",
+    "milp_solver",
+    "milp_time_limit",
+    "n_init_partitions",
+    "obbt_at_root",
+    "obbt_time_limit",
+    "obbt_with_cutoff",
+    "partition_method",
+    "partition_scaling_factor",
+    "partition_scaling_factor_update",
+    "presolve_bt",
+    "presolve_bt_algo",
+    "presolve_bt_mip_time_limit",
+    "presolve_bt_time_limit",
+    "rel_gap",
+    "use_start_as_incumbent",
+}
 
 
 def _normalize_method(method: Any) -> str:
@@ -48,10 +79,16 @@ def _normalize_method(method: Any) -> str:
         raise ValueError(f"mip_nlp_method must be a string, got {type(method).__name__}.")
     raw = method.strip().lower()
     normalized = _METHOD_ALIASES.get(raw, raw.replace("-", "_"))
+    if normalized == "gloa":
+        raise ValueError(
+            "mip_nlp_method='gloa' is reserved for future GDP logic-based global "
+            "outer approximation. Use mip_nlp_method='goa' for MIP-NLP global "
+            "outer approximation, and use gdp_method only for GDP reformulation."
+        )
     if normalized not in SUPPORTED_METHODS:
         reserved = ", ".join(sorted(_RESERVED_METHOD_ISSUES))
         raise ValueError(
-            f"Unknown mip_nlp_method={method!r}. Choose 'oa', 'ecp', or 'fp'. "
+            f"Unknown mip_nlp_method={method!r}. Choose 'oa', 'ecp', 'fp', or 'goa'. "
             f"Reserved future methods are: {reserved}."
         )
     return normalized
@@ -90,7 +127,12 @@ def solve_mip_nlp(
             del options[alias]
 
     if method in _IMPLEMENTED_METHODS:
-        supported_keys = _FP_OPTION_KEYS if method == "fp" else _OA_OPTION_KEYS
+        if method == "fp":
+            supported_keys = _FP_OPTION_KEYS
+        elif method == "goa":
+            supported_keys = _GOA_OPTION_KEYS
+        else:
+            supported_keys = _OA_OPTION_KEYS
         unexpected = sorted(set(options) - supported_keys)
         if unexpected:
             raise ValueError(
@@ -122,6 +164,20 @@ def solve_mip_nlp(
                 feasibility_norm=options.get("feasibility_norm", "L_infinity"),
             )
 
+        if method == "goa":
+            from discopt.solvers.oa import solve_goa
+
+            return solve_goa(
+                model,
+                time_limit=time_limit,
+                gap_tolerance=gap_tolerance,
+                max_iterations=max_iterations,
+                nlp_solver=nlp_solver,
+                initial_point=initial_point,
+                add_no_good_cuts=bool(options.pop("add_no_good_cuts", True)),
+                **options,
+            )
+
         from discopt.solvers.oa import _normalize_init_strategy, solve_oa
 
         if "ecp_mode" in kwargs:
@@ -147,5 +203,5 @@ def solve_mip_nlp(
     raise NotImplementedError(
         f"mip_nlp_method={method!r} is reserved for a future MIP-NLP "
         f"implementation tracked in {_RESERVED_METHOD_ISSUES[method]}; currently "
-        "implemented methods are 'oa', 'ecp', and 'fp'."
+        "implemented methods are 'oa', 'ecp', 'fp', and 'goa'."
     )

--- a/python/discopt/solvers/mip_nlp.py
+++ b/python/discopt/solvers/mip_nlp.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from typing import Any, Optional
 
 from discopt.modeling.core import Model, SolveResult
+from discopt.solvers.mip_nlp_options import GOA_OPTION_KEYS
 
 _IMPLEMENTED_METHODS = frozenset({"oa", "ecp", "fp", "goa"})
 _RESERVED_METHOD_ISSUES = {
@@ -15,63 +16,35 @@ SUPPORTED_METHODS = _IMPLEMENTED_METHODS | frozenset(_RESERVED_METHOD_ISSUES)
 _METHOD_ALIASES = {
     "lp/nlp-bb": "lp_nlp_bb",
 }
-_OA_OPTION_KEYS = {
-    "equality_relaxation",
-    "ecp_mode",
-    "feasibility_cuts",
-    "init_strategy",
-    "heuristic_nonconvex",
-    "add_slack",
-    "max_slack",
-    "oa_penalty_factor",
-    "add_no_good_cuts",
-    "feasibility_norm",
-    "add_regularization",
-    "level_coef",
-    "stalling_limit",
-    "cycling_check",
-    "milp_solver",
-}
+_OA_OPTION_KEYS = frozenset(
+    {
+        "equality_relaxation",
+        "ecp_mode",
+        "feasibility_cuts",
+        "init_strategy",
+        "heuristic_nonconvex",
+        "add_slack",
+        "max_slack",
+        "oa_penalty_factor",
+        "add_no_good_cuts",
+        "feasibility_norm",
+        "add_regularization",
+        "level_coef",
+        "stalling_limit",
+        "cycling_check",
+        "milp_solver",
+    }
+)
 _OA_OPTION_ALIASES = {
     "OA_penalty_factor": "oa_penalty_factor",
 }
-_FP_OPTION_KEYS = {
-    "add_no_good_cuts",
-    "feasibility_norm",
-    "init_strategy",
-}
-_GOA_OPTION_KEYS = {
-    "abs_tol",
-    "add_no_good_cuts",
-    "alphabb_cutoff_obbt",
-    "apply_partitioning",
-    "convhull_ebd",
-    "convhull_ebd_encoding",
-    "convhull_formulation",
-    "disc_abs_width_tol",
-    "disc_add_partition_method",
-    "disc_var_pick",
-    "feasibility_norm",
-    "init_strategy",
-    "iteration_callback",
-    "max_iter",
-    "milp_gap_tolerance",
-    "milp_solver",
-    "milp_time_limit",
-    "n_init_partitions",
-    "obbt_at_root",
-    "obbt_time_limit",
-    "obbt_with_cutoff",
-    "partition_method",
-    "partition_scaling_factor",
-    "partition_scaling_factor_update",
-    "presolve_bt",
-    "presolve_bt_algo",
-    "presolve_bt_mip_time_limit",
-    "presolve_bt_time_limit",
-    "rel_gap",
-    "use_start_as_incumbent",
-}
+_FP_OPTION_KEYS = frozenset(
+    {
+        "add_no_good_cuts",
+        "feasibility_norm",
+        "init_strategy",
+    }
+)
 
 
 def _normalize_method(method: Any) -> str:
@@ -130,7 +103,7 @@ def solve_mip_nlp(
         if method == "fp":
             supported_keys = _FP_OPTION_KEYS
         elif method == "goa":
-            supported_keys = _GOA_OPTION_KEYS
+            supported_keys = GOA_OPTION_KEYS
         else:
             supported_keys = _OA_OPTION_KEYS
         unexpected = sorted(set(options) - supported_keys)

--- a/python/discopt/solvers/mip_nlp_options.py
+++ b/python/discopt/solvers/mip_nlp_options.py
@@ -1,0 +1,45 @@
+"""Shared option names for the MIP-NLP solver-family facade."""
+
+from __future__ import annotations
+
+from typing import Any
+
+GOA_OA_FORWARD_OPTION_KEYS = (
+    "rel_gap",
+    "max_iter",
+    "init_strategy",
+    "feasibility_norm",
+)
+
+GOA_AMP_OPTION_DEFAULTS: dict[str, Any] = {
+    "abs_tol": 1e-6,
+    "use_start_as_incumbent": False,
+    "n_init_partitions": 2,
+    "partition_method": "auto",
+    "iteration_callback": None,
+    "milp_time_limit": None,
+    "milp_gap_tolerance": None,
+    "apply_partitioning": True,
+    "disc_var_pick": None,
+    "partition_scaling_factor": 10.0,
+    "partition_scaling_factor_update": None,
+    "disc_add_partition_method": "adaptive",
+    "disc_abs_width_tol": 1e-3,
+    "convhull_formulation": "disaggregated",
+    "convhull_ebd": False,
+    "convhull_ebd_encoding": "gray",
+    "presolve_bt": True,
+    "presolve_bt_algo": 1,
+    "presolve_bt_time_limit": None,
+    "presolve_bt_mip_time_limit": None,
+    "obbt_at_root": False,
+    "obbt_time_limit": 30.0,
+    "obbt_with_cutoff": False,
+    "alphabb_cutoff_obbt": True,
+    "milp_solver": "auto",
+}
+
+GOA_AMP_ONLY_OPTION_KEYS = tuple(GOA_AMP_OPTION_DEFAULTS)
+GOA_OPTION_KEYS = frozenset(
+    ("add_no_good_cuts", *GOA_OA_FORWARD_OPTION_KEYS, *GOA_AMP_ONLY_OPTION_KEYS)
+)

--- a/python/discopt/solvers/oa.py
+++ b/python/discopt/solvers/oa.py
@@ -23,12 +23,14 @@ from __future__ import annotations
 
 import logging
 import time
+import warnings
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Optional
 
 import numpy as np
 
 from discopt.modeling.core import Constraint, Model, ObjectiveSense, SolveResult, VarType
+from discopt.solvers.mip_nlp_options import GOA_AMP_ONLY_OPTION_KEYS, GOA_AMP_OPTION_DEFAULTS
 
 if TYPE_CHECKING:
     from discopt._jax.nlp_evaluator import NLPEvaluator
@@ -1826,40 +1828,23 @@ def solve_goa(
     AMP/McCormick global-relaxation path. The MIP-NLP feasibility pump, with
     no-good cuts enabled by default, is only an incumbent-start heuristic for
     the nonconvex AMP path, so its exclusions never taint certified bounds.
+    AMP-only options are honored on the nonconvex path; if supplied for a model
+    that certifies convex and is handed to OA, they are ignored with a warning.
     """
     t_start = time.perf_counter()
+    provided_option_keys = frozenset(amp_options)
 
     rel_gap = amp_options.pop("rel_gap", gap_tolerance)
-    abs_tol = amp_options.pop("abs_tol", 1e-6)
     max_iter = amp_options.pop("max_iter", max_iterations)
     init_strategy = _normalize_init_strategy(amp_options.pop("init_strategy", "fp"))
     feasibility_norm = _normalize_feasibility_norm(
         amp_options.pop("feasibility_norm", "L_infinity")
     )
-    use_start_as_incumbent = bool(amp_options.pop("use_start_as_incumbent", False))
-    n_init_partitions = amp_options.pop("n_init_partitions", 2)
-    partition_method = amp_options.pop("partition_method", "auto")
-    iteration_callback = amp_options.pop("iteration_callback", None)
-    milp_time_limit = amp_options.pop("milp_time_limit", None)
-    milp_gap_tolerance = amp_options.pop("milp_gap_tolerance", None)
-    apply_partitioning = amp_options.pop("apply_partitioning", True)
-    disc_var_pick = amp_options.pop("disc_var_pick", None)
-    partition_scaling_factor = amp_options.pop("partition_scaling_factor", 10.0)
-    partition_scaling_factor_update = amp_options.pop("partition_scaling_factor_update", None)
-    disc_add_partition_method = amp_options.pop("disc_add_partition_method", "adaptive")
-    disc_abs_width_tol = amp_options.pop("disc_abs_width_tol", 1e-3)
-    convhull_formulation = amp_options.pop("convhull_formulation", "disaggregated")
-    convhull_ebd = amp_options.pop("convhull_ebd", False)
-    convhull_ebd_encoding = amp_options.pop("convhull_ebd_encoding", "gray")
-    presolve_bt = amp_options.pop("presolve_bt", True)
-    presolve_bt_algo = amp_options.pop("presolve_bt_algo", 1)
-    presolve_bt_time_limit = amp_options.pop("presolve_bt_time_limit", None)
-    presolve_bt_mip_time_limit = amp_options.pop("presolve_bt_mip_time_limit", None)
-    obbt_at_root = amp_options.pop("obbt_at_root", False)
-    obbt_with_cutoff = amp_options.pop("obbt_with_cutoff", False)
-    alphabb_cutoff_obbt = amp_options.pop("alphabb_cutoff_obbt", True)
-    obbt_time_limit = amp_options.pop("obbt_time_limit", 30.0)
-    milp_solver = amp_options.pop("milp_solver", "auto")
+    amp_kwargs = dict(GOA_AMP_OPTION_DEFAULTS)
+    for key in GOA_AMP_OPTION_DEFAULTS:
+        if key in amp_options:
+            amp_kwargs[key] = amp_options.pop(key)
+    use_start_as_incumbent = bool(amp_kwargs["use_start_as_incumbent"])
     if amp_options:
         raise ValueError(
             "Unsupported GOA option(s): "
@@ -1871,6 +1856,14 @@ def solve_goa(
 
     oa_convexity = classify_oa_cut_convexity(model)
     if oa_convexity.objective_is_convex and all(oa_convexity.constraint_mask):
+        ignored_amp_options = sorted(provided_option_keys.intersection(GOA_AMP_ONLY_OPTION_KEYS))
+        if ignored_amp_options:
+            warnings.warn(
+                "GOA routed a convexity-certified model to OA; AMP-only GOA "
+                "option(s) are ignored on this path: " + ", ".join(ignored_amp_options),
+                UserWarning,
+                stacklevel=2,
+            )
         elapsed = time.perf_counter() - t_start
         remaining_time = max(0.0, float(time_limit) - elapsed)
         result = solve_oa(
@@ -1963,38 +1956,15 @@ def solve_goa(
 
     from discopt.solvers.amp import solve_amp
 
+    amp_kwargs["use_start_as_incumbent"] = use_start_as_incumbent
     result = solve_amp(
         model,
         rel_gap=rel_gap,
-        abs_tol=abs_tol,
         time_limit=remaining_time,
         max_iter=max_iter,
-        n_init_partitions=n_init_partitions,
-        partition_method=partition_method,
         nlp_solver=nlp_solver,
-        iteration_callback=iteration_callback,
-        milp_time_limit=milp_time_limit,
-        milp_gap_tolerance=milp_gap_tolerance,
-        apply_partitioning=apply_partitioning,
-        disc_var_pick=disc_var_pick,
-        partition_scaling_factor=partition_scaling_factor,
-        partition_scaling_factor_update=partition_scaling_factor_update,
-        disc_add_partition_method=disc_add_partition_method,
-        disc_abs_width_tol=disc_abs_width_tol,
-        convhull_formulation=convhull_formulation,
-        convhull_ebd=convhull_ebd,
-        convhull_ebd_encoding=convhull_ebd_encoding,
-        presolve_bt=presolve_bt,
-        presolve_bt_algo=presolve_bt_algo,
-        presolve_bt_time_limit=presolve_bt_time_limit,
-        presolve_bt_mip_time_limit=presolve_bt_mip_time_limit,
         initial_point=goa_initial_point,
-        use_start_as_incumbent=use_start_as_incumbent,
-        obbt_at_root=obbt_at_root,
-        obbt_with_cutoff=obbt_with_cutoff,
-        alphabb_cutoff_obbt=alphabb_cutoff_obbt,
-        obbt_time_limit=obbt_time_limit,
-        milp_solver=milp_solver,
+        **amp_kwargs,
     )
     result.wall_time += elapsed
     result.mip_count += pre_amp_mip_count

--- a/python/discopt/solvers/oa.py
+++ b/python/discopt/solvers/oa.py
@@ -1819,12 +1819,13 @@ def solve_goa(
     add_no_good_cuts: bool = True,
     **amp_options,
 ) -> SolveResult:
-    """Solve a nonconvex MINLP through the global OA/relaxation stack.
+    """Solve a MINLP through the global OA/relaxation stack.
 
-    GOA uses the MIP-NLP feasibility pump, with no-good cuts enabled by
-    default, only as an incumbent-start heuristic. Certified bounds and gaps
-    come from AMP's McCormick/global-relaxation MILP solves, which do not carry
-    those no-good exclusions and therefore remain valid for the original model.
+    Convexity-certified MINLPs are handed to the OA algorithm, whose master
+    lower bounds are globally valid in that case. Other models use the
+    AMP/McCormick global-relaxation path. The MIP-NLP feasibility pump, with
+    no-good cuts enabled by default, is only an incumbent-start heuristic for
+    the nonconvex AMP path, so its exclusions never taint certified bounds.
     """
     t_start = time.perf_counter()
 
@@ -1865,6 +1866,26 @@ def solve_goa(
             + ", ".join(sorted(amp_options))
             + ". Pass AMP/global-relaxation options supported by solve_goa."
         )
+
+    from discopt._jax.convexity import classify_oa_cut_convexity
+
+    oa_convexity = classify_oa_cut_convexity(model)
+    if oa_convexity.objective_is_convex and all(oa_convexity.constraint_mask):
+        elapsed = time.perf_counter() - t_start
+        remaining_time = max(0.0, float(time_limit) - elapsed)
+        result = solve_oa(
+            model,
+            time_limit=remaining_time,
+            gap_tolerance=rel_gap,
+            max_iterations=max_iter,
+            nlp_solver=nlp_solver,
+            init_strategy=init_strategy,
+            initial_point=initial_point,
+            add_no_good_cuts=bool(add_no_good_cuts),
+            feasibility_norm=feasibility_norm,
+        )
+        result.wall_time += elapsed
+        return result
 
     goa_initial_point = initial_point
     pre_amp_mip_count = 0

--- a/python/discopt/solvers/oa.py
+++ b/python/discopt/solvers/oa.py
@@ -1809,6 +1809,177 @@ def solve_feasibility_pump(
     )
 
 
+def solve_goa(
+    model: Model,
+    time_limit: float = 3600.0,
+    gap_tolerance: float = 1e-4,
+    max_iterations: int = 100,
+    nlp_solver: str = "ipm",
+    initial_point: Optional[np.ndarray] = None,
+    add_no_good_cuts: bool = True,
+    **amp_options,
+) -> SolveResult:
+    """Solve a nonconvex MINLP through the global OA/relaxation stack.
+
+    GOA uses the MIP-NLP feasibility pump, with no-good cuts enabled by
+    default, only as an incumbent-start heuristic. Certified bounds and gaps
+    come from AMP's McCormick/global-relaxation MILP solves, which do not carry
+    those no-good exclusions and therefore remain valid for the original model.
+    """
+    t_start = time.perf_counter()
+
+    rel_gap = amp_options.pop("rel_gap", gap_tolerance)
+    abs_tol = amp_options.pop("abs_tol", 1e-6)
+    max_iter = amp_options.pop("max_iter", max_iterations)
+    init_strategy = _normalize_init_strategy(amp_options.pop("init_strategy", "fp"))
+    feasibility_norm = _normalize_feasibility_norm(
+        amp_options.pop("feasibility_norm", "L_infinity")
+    )
+    use_start_as_incumbent = bool(amp_options.pop("use_start_as_incumbent", False))
+    n_init_partitions = amp_options.pop("n_init_partitions", 2)
+    partition_method = amp_options.pop("partition_method", "auto")
+    iteration_callback = amp_options.pop("iteration_callback", None)
+    milp_time_limit = amp_options.pop("milp_time_limit", None)
+    milp_gap_tolerance = amp_options.pop("milp_gap_tolerance", None)
+    apply_partitioning = amp_options.pop("apply_partitioning", True)
+    disc_var_pick = amp_options.pop("disc_var_pick", None)
+    partition_scaling_factor = amp_options.pop("partition_scaling_factor", 10.0)
+    partition_scaling_factor_update = amp_options.pop("partition_scaling_factor_update", None)
+    disc_add_partition_method = amp_options.pop("disc_add_partition_method", "adaptive")
+    disc_abs_width_tol = amp_options.pop("disc_abs_width_tol", 1e-3)
+    convhull_formulation = amp_options.pop("convhull_formulation", "disaggregated")
+    convhull_ebd = amp_options.pop("convhull_ebd", False)
+    convhull_ebd_encoding = amp_options.pop("convhull_ebd_encoding", "gray")
+    presolve_bt = amp_options.pop("presolve_bt", True)
+    presolve_bt_algo = amp_options.pop("presolve_bt_algo", 1)
+    presolve_bt_time_limit = amp_options.pop("presolve_bt_time_limit", None)
+    presolve_bt_mip_time_limit = amp_options.pop("presolve_bt_mip_time_limit", None)
+    obbt_at_root = amp_options.pop("obbt_at_root", False)
+    obbt_with_cutoff = amp_options.pop("obbt_with_cutoff", False)
+    alphabb_cutoff_obbt = amp_options.pop("alphabb_cutoff_obbt", True)
+    obbt_time_limit = amp_options.pop("obbt_time_limit", 30.0)
+    milp_solver = amp_options.pop("milp_solver", "auto")
+    if amp_options:
+        raise ValueError(
+            "Unsupported GOA option(s): "
+            + ", ".join(sorted(amp_options))
+            + ". Pass AMP/global-relaxation options supported by solve_goa."
+        )
+
+    goa_initial_point = initial_point
+    pre_amp_mip_count = 0
+
+    decomp: Optional[_DecomposedProblem] = None
+    if init_strategy in {"fp", "initial_binary", "max_binary"}:
+        decomp = _decompose_model(model)
+
+    if init_strategy == "fp" and decomp is not None and decomp.int_indices:
+        elapsed = time.perf_counter() - t_start
+        remaining = max(0.0, float(time_limit) - elapsed)
+        if np.isfinite(remaining) and np.isfinite(time_limit):
+            pump_budget = min(remaining, max(0.0, 0.1 * float(time_limit)), 10.0)
+        else:
+            pump_budget = 10.0
+        fp_iterations = max(1, min(int(max_iterations) if max_iterations > 0 else 1, 10))
+        if pump_budget > 0.0:
+            fp_result = _run_feasibility_pump(
+                model,
+                decomp,
+                nlp_solver=nlp_solver,
+                initial_point=initial_point,
+                time_limit=pump_budget,
+                gap_tolerance=gap_tolerance,
+                max_iterations=fp_iterations,
+                feasibility_norm=feasibility_norm,
+                add_no_good_cuts=bool(add_no_good_cuts),
+            )
+            pre_amp_mip_count += fp_result.mip_count
+            if fp_result.best_x is not None:
+                goa_initial_point = fp_result.best_x
+                use_start_as_incumbent = True
+            elif fp_result.best_near_x is not None:
+                goa_initial_point = fp_result.best_near_x
+    elif init_strategy in {"initial_binary", "max_binary"} and decomp is not None:
+        goa_initial_point = _build_initial_strategy_point(decomp, init_strategy, initial_point)
+
+    elapsed = time.perf_counter() - t_start
+    remaining_time = max(0.0, float(time_limit) - elapsed)
+    if remaining_time <= 0.0:
+        if goa_initial_point is not None and decomp is not None:
+            candidate = np.asarray(goa_initial_point, dtype=np.float64)
+            if _is_integer_feasible(decomp, candidate) and _is_primal_feasible(
+                decomp.evaluator, candidate
+            ):
+                obj = float(decomp.evaluator.evaluate_objective(candidate))
+                obj_sign = (
+                    -1.0
+                    if (
+                        model._objective is not None
+                        and model._objective.sense == ObjectiveSense.MAXIMIZE
+                    )
+                    else 1.0
+                )
+                return SolveResult(
+                    status="feasible",
+                    objective=obj_sign * obj,
+                    bound=None,
+                    gap=None,
+                    x=_build_x_dict(candidate, model),
+                    wall_time=elapsed,
+                    mip_count=pre_amp_mip_count,
+                    gap_certified=False,
+                )
+        return SolveResult(
+            status="time_limit",
+            objective=None,
+            bound=None,
+            gap=None,
+            x=None,
+            wall_time=elapsed,
+            mip_count=pre_amp_mip_count,
+            gap_certified=False,
+        )
+
+    from discopt.solvers.amp import solve_amp
+
+    result = solve_amp(
+        model,
+        rel_gap=rel_gap,
+        abs_tol=abs_tol,
+        time_limit=remaining_time,
+        max_iter=max_iter,
+        n_init_partitions=n_init_partitions,
+        partition_method=partition_method,
+        nlp_solver=nlp_solver,
+        iteration_callback=iteration_callback,
+        milp_time_limit=milp_time_limit,
+        milp_gap_tolerance=milp_gap_tolerance,
+        apply_partitioning=apply_partitioning,
+        disc_var_pick=disc_var_pick,
+        partition_scaling_factor=partition_scaling_factor,
+        partition_scaling_factor_update=partition_scaling_factor_update,
+        disc_add_partition_method=disc_add_partition_method,
+        disc_abs_width_tol=disc_abs_width_tol,
+        convhull_formulation=convhull_formulation,
+        convhull_ebd=convhull_ebd,
+        convhull_ebd_encoding=convhull_ebd_encoding,
+        presolve_bt=presolve_bt,
+        presolve_bt_algo=presolve_bt_algo,
+        presolve_bt_time_limit=presolve_bt_time_limit,
+        presolve_bt_mip_time_limit=presolve_bt_mip_time_limit,
+        initial_point=goa_initial_point,
+        use_start_as_incumbent=use_start_as_incumbent,
+        obbt_at_root=obbt_at_root,
+        obbt_with_cutoff=obbt_with_cutoff,
+        alphabb_cutoff_obbt=alphabb_cutoff_obbt,
+        obbt_time_limit=obbt_time_limit,
+        milp_solver=milp_solver,
+    )
+    result.wall_time += elapsed
+    result.mip_count += pre_amp_mip_count
+    return result
+
+
 # ── Main Algorithm ────────────────────────────────────────────
 
 

--- a/python/tests/test_convexity.py
+++ b/python/tests/test_convexity.py
@@ -97,6 +97,27 @@ class TestConvexExpressions:
         expr = dm.exp(2.0 * x) * (y ** (-4.0))
         assert classify_expr(expr, m) == Curvature.CONVEX
 
+    def test_exp_affine_times_positive_power_not_classified_convex(self):
+        m = Model("test")
+        x = m.continuous("x", lb=-5, ub=5)
+        y = m.continuous("y", lb=1, ub=10)
+        expr = dm.exp(2.0 * x) * (y**2.0)
+        assert classify_expr(expr, m) != Curvature.CONVEX
+
+    def test_exp_affine_times_power_without_positive_base_not_classified_convex(self):
+        m = Model("test")
+        x = m.continuous("x", lb=-5, ub=5)
+        y = m.continuous("y", lb=-1, ub=10)
+        expr = dm.exp(2.0 * x) * (y ** (-4.0))
+        assert classify_expr(expr, m) != Curvature.CONVEX
+
+    def test_exp_affine_times_nonaffine_reciprocal_not_classified_convex(self):
+        m = Model("test")
+        x = m.continuous("x", lb=-5, ub=5)
+        y = m.continuous("y", lb=-2, ub=2)
+        expr = dm.exp(2.0 * x) * ((y**2 + 1.0) ** (-1.0))
+        assert classify_expr(expr, m) != Curvature.CONVEX
+
     def test_exp_of_convex(self):
         """exp(convex) = convex because exp is convex & nondecreasing."""
         m = Model("test")

--- a/python/tests/test_mip_nlp.py
+++ b/python/tests/test_mip_nlp.py
@@ -72,6 +72,19 @@ def _mindtpy_simple3_minlp(name="mindtpy_simple3"):
     return m
 
 
+def _mindtpy_simple5_minlp(name="mindtpy_simple5"):
+    """Native port of Pyomo MindtPy's MINLP5_simple convex MINLP fixture."""
+    m = dm.Model(name)
+    x = m.continuous("x", lb=1.0, ub=20.0)
+    y = m.integer("y", lb=1, ub=20)
+
+    m.subject_to(6.0 * x + y <= 60.0)
+    m.subject_to(1.0 / x + 1.0 / x - (x**0.5) * (y**0.5) <= -1.0)
+    m.subject_to(2.0 * x - 5.0 * y <= -1.0)
+    m.minimize(0.3 * (x - 8.0) ** 2 + 0.04 * (y - 6.0) ** 4 + 0.1 * dm.exp(2.0 * x) * (y ** (-4.0)))
+    return m
+
+
 def _mindtpy_constraint_qualification_example(name="mindtpy_constraint_qualification"):
     """Native port of Pyomo MindtPy's constraint-qualification fixture."""
     m = dm.Model(name)
@@ -592,11 +605,15 @@ def test_goa_fp_seed_uses_no_good_cuts_without_certifying_seed_bound(monkeypatch
     import discopt.solvers.oa as oa_module
 
     calls = {}
+    m = dm.Model("goa_fp_seed_nonconvex")
+    x = m.continuous("x", lb=0.0, ub=2.0)
+    y = m.binary("y")
+    m.minimize(x * y - x)
 
     def fake_run_fp(model, decomp, **kwargs):
         calls["fp"] = kwargs
         return oa_module._FeasibilityPumpResult(
-            best_x=np.array([1.0]),
+            best_x=np.array([1.0, 1.0]),
             best_obj=1.0,
             best_near_x=None,
             best_near_merit=0.0,
@@ -619,10 +636,10 @@ def test_goa_fp_seed_uses_no_good_cuts_without_certifying_seed_bound(monkeypatch
     monkeypatch.setattr(oa_module, "_run_feasibility_pump", fake_run_fp)
     monkeypatch.setattr(amp_module, "solve_amp", fake_solve_amp)
 
-    result = oa_module.solve_goa(_binary_model("goa_fp_seed"), time_limit=10, max_iterations=5)
+    result = oa_module.solve_goa(m, time_limit=10, max_iterations=5)
 
     assert calls["fp"]["add_no_good_cuts"] is True
-    assert calls["amp"]["initial_point"].tolist() == pytest.approx([1.0])
+    assert calls["amp"]["initial_point"].tolist() == pytest.approx([1.0, 1.0])
     assert calls["amp"]["use_start_as_incumbent"] is True
     assert result.mip_count == 5
     assert result.gap_certified is False
@@ -1512,6 +1529,25 @@ def test_mip_nlp_goa_certifies_native_bilinear_minlp():
     assert result.gap_certified is True
     assert result.x["x"] == pytest.approx(2.0, abs=1e-6)
     assert result.x["y"] == pytest.approx(0.0, abs=1e-6)
+
+
+@pytest.mark.smoke
+@pytest.mark.skipif(not HAS_HIGHS, reason="highspy not installed")
+def test_mip_nlp_goa_certifies_mindtpy_minlp5_convex_fixture():
+    result = _mindtpy_simple5_minlp("goa_mindtpy_minlp5").solve(
+        solver="mip-nlp",
+        mip_nlp_method="goa",
+        time_limit=30,
+        rel_gap=1e-4,
+    )
+
+    assert result.status == "optimal"
+    assert result.objective == pytest.approx(3.6572, abs=5e-4)
+    assert result.bound == pytest.approx(result.objective, abs=5e-4)
+    assert result.gap == pytest.approx(0.0, abs=1e-4)
+    assert result.gap_certified is True
+    assert result.x["x"] == pytest.approx(4.99179784, abs=1e-4)
+    assert result.x["y"] == pytest.approx(7.0, abs=1e-6)
 
 
 @pytest.mark.skipif(not HAS_HIGHS, reason="highspy not installed")

--- a/python/tests/test_mip_nlp.py
+++ b/python/tests/test_mip_nlp.py
@@ -600,6 +600,39 @@ def test_mip_nlp_method_goa_routes_to_global_relaxation(monkeypatch):
     assert calls["rel_gap"] == pytest.approx(0.05)
 
 
+def test_goa_warns_when_amp_only_options_ignored_on_convex_handoff(monkeypatch):
+    import discopt.solvers.oa as oa_module
+
+    calls = {}
+
+    def fake_solve_oa(model, **kwargs):
+        calls.update(kwargs)
+        return SolveResult(
+            status="optimal",
+            objective=0.0,
+            bound=0.0,
+            gap=0.0,
+            x={"x": np.array(0.0)},
+            gap_certified=True,
+        )
+
+    monkeypatch.setattr(oa_module, "solve_oa", fake_solve_oa)
+
+    with pytest.warns(
+        UserWarning,
+        match="AMP-only GOA option\\(s\\).*n_init_partitions.*presolve_bt",
+    ):
+        result = oa_module.solve_goa(
+            _binary_model("goa_convex_ignores_amp_options"),
+            rel_gap=0.05,
+            n_init_partitions=3,
+            presolve_bt=False,
+        )
+
+    assert result.status == "optimal"
+    assert calls["gap_tolerance"] == pytest.approx(0.05)
+
+
 def test_goa_fp_seed_uses_no_good_cuts_without_certifying_seed_bound(monkeypatch):
     import discopt.solvers.amp as amp_module
     import discopt.solvers.oa as oa_module

--- a/python/tests/test_mip_nlp.py
+++ b/python/tests/test_mip_nlp.py
@@ -511,7 +511,6 @@ def test_mip_nlp_and_deprecated_oa_alias_reformulate_gdp(monkeypatch):
     ("method", "issue"),
     [
         ("roa", "#116/#117"),
-        ("goa", "#118"),
         ("lp_nlp_bb", "#119"),
         ("lp/nlp-bb", "#119"),
     ],
@@ -521,6 +520,13 @@ def test_mip_nlp_reserved_methods_raise(method, issue):
 
     with pytest.raises(NotImplementedError, match=issue):
         solve_mip_nlp(_binary_model(f"{method}_reserved"), method=method)
+
+
+def test_mip_nlp_method_gloa_is_reserved_for_gdp_axis():
+    from discopt.solvers.mip_nlp import solve_mip_nlp
+
+    with pytest.raises(ValueError, match="GDP logic-based global outer approximation"):
+        solve_mip_nlp(_binary_model("gloa_reserved"), method="gloa")
 
 
 def test_mip_nlp_method_fp_routes_to_standalone_feasibility_pump(monkeypatch):
@@ -546,6 +552,80 @@ def test_mip_nlp_method_fp_routes_to_standalone_feasibility_pump(monkeypatch):
     assert result.status == "feasible"
     assert calls["feasibility_norm"] == "L1"
     assert calls["add_no_good_cuts"] is False
+
+
+def test_mip_nlp_method_goa_routes_to_global_relaxation(monkeypatch):
+    import discopt.solvers.oa as oa_module
+    from discopt.solvers.mip_nlp import solve_mip_nlp
+
+    calls = {}
+
+    def fake_solve_goa(model, **kwargs):
+        calls.update(kwargs)
+        return SolveResult(
+            status="feasible",
+            objective=1.0,
+            bound=0.0,
+            gap=1.0,
+            x={"x": np.array(1.0)},
+            gap_certified=False,
+        )
+
+    monkeypatch.setattr(oa_module, "solve_goa", fake_solve_goa)
+
+    result = solve_mip_nlp(
+        _binary_model("goa_route"),
+        method="goa",
+        add_no_good_cuts=False,
+        n_init_partitions=3,
+        rel_gap=0.05,
+    )
+
+    assert result.status == "feasible"
+    assert calls["add_no_good_cuts"] is False
+    assert calls["n_init_partitions"] == 3
+    assert calls["rel_gap"] == pytest.approx(0.05)
+
+
+def test_goa_fp_seed_uses_no_good_cuts_without_certifying_seed_bound(monkeypatch):
+    import discopt.solvers.amp as amp_module
+    import discopt.solvers.oa as oa_module
+
+    calls = {}
+
+    def fake_run_fp(model, decomp, **kwargs):
+        calls["fp"] = kwargs
+        return oa_module._FeasibilityPumpResult(
+            best_x=np.array([1.0]),
+            best_obj=1.0,
+            best_near_x=None,
+            best_near_merit=0.0,
+            mip_count=2,
+        )
+
+    def fake_solve_amp(model, **kwargs):
+        calls["amp"] = kwargs
+        return SolveResult(
+            status="feasible",
+            objective=1.0,
+            bound=0.0,
+            gap=1.0,
+            x={"x": np.array(1.0)},
+            wall_time=0.1,
+            mip_count=3,
+            gap_certified=False,
+        )
+
+    monkeypatch.setattr(oa_module, "_run_feasibility_pump", fake_run_fp)
+    monkeypatch.setattr(amp_module, "solve_amp", fake_solve_amp)
+
+    result = oa_module.solve_goa(_binary_model("goa_fp_seed"), time_limit=10, max_iterations=5)
+
+    assert calls["fp"]["add_no_good_cuts"] is True
+    assert calls["amp"]["initial_point"].tolist() == pytest.approx([1.0])
+    assert calls["amp"]["use_start_as_incumbent"] is True
+    assert result.mip_count == 5
+    assert result.gap_certified is False
 
 
 def test_mip_nlp_feasibility_pump_continuous_only_is_uncertified():
@@ -1405,6 +1485,33 @@ def test_mip_nlp_init_strategies_solve_mindtpy_baseline_to_optimum(method, strat
     assert result.bound == pytest.approx(3.5, abs=1e-3)
     assert result.gap == pytest.approx(0.0, abs=1e-9)
     assert np.asarray(result.x["y"]).tolist() == pytest.approx([0.0, 1.0, 0.0])
+
+
+@pytest.mark.smoke
+@pytest.mark.skipif(not HAS_HIGHS, reason="highspy not installed")
+def test_mip_nlp_goa_certifies_native_bilinear_minlp():
+    m = dm.Model("goa_bilinear_minlp")
+    x = m.continuous("x", lb=0.0, ub=2.0)
+    y = m.binary("y")
+
+    m.minimize(x * y - 2.0 * x)
+
+    result = m.solve(
+        solver="mip-nlp",
+        mip_nlp_method="goa",
+        time_limit=30,
+        max_nodes=20,
+        rel_gap=1e-6,
+        presolve_bt=False,
+    )
+
+    assert result.status == "optimal"
+    assert result.objective == pytest.approx(-4.0, abs=1e-6)
+    assert result.bound == pytest.approx(-4.0, abs=1e-6)
+    assert result.gap == pytest.approx(0.0, abs=1e-9)
+    assert result.gap_certified is True
+    assert result.x["x"] == pytest.approx(2.0, abs=1e-6)
+    assert result.x["y"] == pytest.approx(0.0, abs=1e-6)
 
 
 @pytest.mark.skipif(not HAS_HIGHS, reason="highspy not installed")

--- a/python/tests/test_power_certification.py
+++ b/python/tests/test_power_certification.py
@@ -46,6 +46,31 @@ def test_affine_base_fractional_power_certifies():
     assert r.bound <= 1.0 + 1e-3, "dual bound must not exceed the true optimum"
 
 
+def test_shifted_integer_power_lift_guards():
+    from discopt._jax.milp_relaxation import _should_claim_composite
+
+    m = dm.Model()
+    x = m.continuous("x", lb=-2.0, ub=3.0)
+    n_orig = 1
+
+    assert _should_claim_composite((x - 1.0) ** 4, m, n_orig)
+    assert not _should_claim_composite((x - 1.0) ** 2, m, n_orig)
+    assert not _should_claim_composite(x**4, m, n_orig)
+
+
+def test_affine_power_curvature_guards_crossing_zero_base():
+    from discopt._jax.milp_relaxation import _affine_base_power_curvature
+
+    m = dm.Model()
+    x = m.continuous("x", lb=-2.0, ub=3.0)
+    box = {}
+
+    assert _affine_base_power_curvature((x - 1.0) ** 4, m, box) == "convex"
+    assert _affine_base_power_curvature((x - 1.0) ** 3, m, box) is None
+    assert _affine_base_power_curvature((x - 1.0) ** 1.5, m, box) is None
+    assert _affine_base_power_curvature((x - 1.0) ** (-1.0), m, box) is None
+
+
 @pytest.mark.correctness
 def test_shifted_even_integer_power_certifies():
     """``(x - 1)**4`` uses the composite power lift and certifies soundly."""


### PR DESCRIPTION
## Summary

Adds `mip_nlp_method="goa"` to the MIP-NLP facade for issue #118.

The GOA entry point now distinguishes convexity-certified MINLPs from genuinely nonconvex cases:

- Convexity-certified MINLPs are routed to OA so reported master bounds and gaps remain globally valid.
- Other models use discopt's AMP/McCormick global-relaxation stack.
- The MIP-NLP feasibility pump and no-good cuts are only used as incumbent-start machinery for the nonconvex AMP path, so those heuristic exclusions do not taint certified bounds.

This also extends the existing convexity/relaxation machinery needed by the MindtPy MINLP5-style convex fixture:

- recognizes `exp(affine) * prod_i positive_affine_i**a_i` as convex when all `a_i <= 0`;
- lifts non-bare affine integer powers such as `(y - 6)**4`;
- preserves the existing nonconvex GOA/AMP path and its no-good feasibility-pump seeding behavior.

Also forwards GOA-specific global-relaxation options through `solver="mip-nlp"`, keeps OA/ECP option handling separate, rejects reserved `mip_nlp_method="gloa"` with a GDP-axis explanation, and adds native coverage for routing, no-good seeding, certified nonconvex bound reporting, and the MindtPy MINLP5 convex benchmark.

Closes #118.

## Tests

- `PYTHONPATH=python python -m ruff check python/discopt/solvers/mip_nlp.py python/discopt/solvers/oa.py python/discopt/solver.py python/tests/test_mip_nlp.py`
- `PYTHONPATH=python python -m ruff format --check python/discopt/solvers/mip_nlp.py python/discopt/solvers/oa.py python/discopt/solver.py python/tests/test_mip_nlp.py`
- `PYTHONPATH=python pytest python/tests/test_mip_nlp.py python/tests/test_oa.py -q`
- `PYTHONPATH=python pytest python/tests/test_convexity.py::TestConvexExpressions::test_exp_affine_times_reciprocal_power python/tests/test_mip_nlp.py::test_mip_nlp_goa_certifies_mindtpy_minlp5_convex_fixture python/tests/test_mip_nlp.py::test_mip_nlp_goa_certifies_native_bilinear_minlp -q`
- `PYTHONPATH=python pytest python/tests/test_mip_nlp.py python/tests/test_oa.py python/tests/test_convexity.py -q`
- `PYTHONPATH=python pytest python/tests/test_power_certification.py python/tests/test_factorable_reform.py python/tests/test_monomial_lp_bound.py python/tests/test_relaxation_theorems.py -q`
- `python -m ruff check python/discopt/_jax/convexity/patterns.py python/discopt/_jax/milp_relaxation.py python/discopt/modeling/core.py python/discopt/solver.py python/discopt/solvers/oa.py python/tests/test_convexity.py python/tests/test_mip_nlp.py`
- `git diff --check`
- `pre-commit run --files python/discopt/_jax/convexity/patterns.py python/discopt/_jax/milp_relaxation.py python/discopt/modeling/core.py python/discopt/solver.py python/discopt/solvers/oa.py python/tests/test_convexity.py python/tests/test_mip_nlp.py`

Local pytest emitted JAX persistent-cache warnings because `/home/bernalde/.cache/discopt/jax-cache` is read-only in this environment. The tests passed. `pre-commit` is installed locally and passed on the PR-touched files.

## Branch Hygiene

- Base branch: `bernalde/discopt:feature/mip-nlp-solver` per the owner-authored issue branch policy, not repository default `main`.
- Head branch: `bernalde/discopt:fix/issue-118-goa`.
- Source branch point: `origin/feature/mip-nlp-solver@770bba2fa64d97111894ed8a04c6e39c1a77c7f2`.
- Stacked status: not stacked on a previous child PR branch; this branch has issue-specific commits on the integration branch.
- Prerequisite PRs: previous MIP-NLP issue-series changes are already merged into the integration branch through PR #128; no separate open prerequisite PR is required for this child PR.
