### PR TITLE
Add LP/NLP BB MIP-NLP method

### DIFF
--- a/python/discopt/modeling/core.py
+++ b/python/discopt/modeling/core.py
@@ -2793,9 +2793,11 @@ class Model:
             ``gurobi_options={...}``.
             Use ``solver="mip-nlp"`` to select the MIP-NLP decomposition
             family. Current implemented ``mip_nlp_method`` values are ``"oa"``,
-            ``"ecp"``, ``"fp"``, and ``"goa"``; ``"roa"`` and
-            ``"lp_nlp_bb"`` are reserved until their dedicated implementations
-            land. Top-level OA/ECP options such as ``equality_relaxation``,
+            ``"ecp"``, ``"fp"``, ``"goa"``, and ``"lp_nlp_bb"``; ``"roa"``
+            is reserved until its dedicated implementation lands. The
+            LP/NLP-BB method uses single-tree lazy OA cuts and currently
+            requires ``milp_solver="gurobi"``. Top-level OA/ECP options such
+            as ``equality_relaxation``,
             ``ecp_mode``, ``feasibility_cuts``, ``heuristic_nonconvex``,
             ``add_slack``, ``max_slack``, ``oa_penalty_factor``,
             ``add_no_good_cuts``, ``feasibility_norm``, ``add_regularization``,

--- a/python/discopt/solvers/gurobi.py
+++ b/python/discopt/solvers/gurobi.py
@@ -12,7 +12,7 @@ delegate nonconvex quadratic handling to Gurobi.
 
 from __future__ import annotations
 
-from typing import Optional, Union
+from typing import Callable, Optional, Union
 
 import numpy as np
 import scipy.sparse as sp
@@ -211,12 +211,18 @@ def _status_map(GRB) -> dict[int, SolveStatus]:
     return mapping
 
 
-def _optimize(model, GRB) -> int:
-    model.optimize()
+def _optimize(model, GRB, callback: Optional[Callable] = None) -> int:
+    if callback is None:
+        model.optimize()
+    else:
+        model.optimize(callback)
     status = int(model.Status)
     if status == GRB.INF_OR_UNBD:
         model.setParam("DualReductions", 0)
-        model.optimize()
+        if callback is None:
+            model.optimize()
+        else:
+            model.optimize(callback)
         status = int(model.Status)
     return status
 
@@ -410,6 +416,108 @@ def solve_milp(
     )
     try:
         status_code = _optimize(model, GRB)
+        status = _status_map(GRB).get(status_code, SolveStatus.ERROR)
+        node_count = int(_safe_attr(model, "NodeCount") or 0)
+        wall_time = float(_safe_attr(model, "Runtime") or 0.0)
+
+        objective = None
+        x_val = None
+        if int(_safe_attr(model, "SolCount") or 0) > 0:
+            objective = float(model.ObjVal)
+            x_val = np.asarray(x.X, dtype=np.float64).ravel()
+
+        bound = _safe_attr(model, "ObjBound")
+        bound = float(bound) if bound is not None and np.isfinite(bound) else None
+        gap = _safe_attr(model, "MIPGap")
+        gap = float(gap) if gap is not None and np.isfinite(gap) else None
+
+        if status == SolveStatus.OPTIMAL:
+            assert objective is not None and x_val is not None
+            return MILPResult(
+                status=status,
+                x=x_val,
+                objective=objective,
+                bound=objective,
+                gap=0.0,
+                node_count=node_count,
+                wall_time=wall_time,
+            )
+
+        return MILPResult(
+            status=status,
+            x=x_val,
+            objective=objective,
+            bound=bound,
+            gap=gap,
+            node_count=node_count,
+            wall_time=wall_time,
+        )
+    finally:
+        model.dispose()
+        env.dispose()
+
+
+def solve_milp_with_lazy_cuts(
+    c: np.ndarray,
+    A_ub: Optional[Union[np.ndarray, sp.spmatrix]] = None,
+    b_ub: Optional[np.ndarray] = None,
+    A_eq: Optional[Union[np.ndarray, sp.spmatrix]] = None,
+    b_eq: Optional[np.ndarray] = None,
+    bounds: Optional[list[tuple[float, float]]] = None,
+    integrality: Optional[np.ndarray] = None,
+    time_limit: Optional[float] = None,
+    gap_tolerance: float = 1e-4,
+    threads: Optional[int] = None,
+    options: Optional[dict] = None,
+    lazy_callback: Optional[Callable[[np.ndarray], object]] = None,
+) -> MILPResult:
+    """Solve a MILP using Gurobi lazy constraints.
+
+    ``lazy_callback`` is called at integer incumbents with the current solution
+    vector. It should return an iterable of ``(coefficients, rhs)`` rows in
+    ``coefficients @ x <= rhs`` form. The callback may return ``None`` or an
+    empty iterable when no lazy rows are violated.
+    """
+    c_arr, _n = _validate_linear_data(c, A_ub, b_ub, A_eq, b_eq, bounds)
+    gp, GRB = _load_gurobi()
+
+    merged_options = dict(options or {})
+    merged_options["LazyConstraints"] = 1
+
+    env, model, x, _ub_con, _eq_con = _build_model(
+        gp,
+        GRB,
+        name="discopt_milp_lazy",
+        c=c_arr,
+        A_ub=A_ub,
+        b_ub=b_ub,
+        A_eq=A_eq,
+        b_eq=b_eq,
+        bounds=bounds,
+        integrality=integrality,
+        time_limit=time_limit,
+        gap_tolerance=gap_tolerance,
+        threads=threads,
+        options=merged_options,
+    )
+
+    def _callback(grb_model, where):
+        if lazy_callback is None or where != GRB.Callback.MIPSOL:
+            return
+        incumbent = np.asarray(grb_model.cbGetSolution(x), dtype=np.float64).ravel()
+        cuts = lazy_callback(incumbent)
+        if cuts is None:
+            return
+        for coeffs, rhs in cuts:
+            row = np.asarray(coeffs, dtype=np.float64).ravel()
+            if row.shape[0] != len(c_arr):
+                raise ValueError(
+                    f"lazy cut has {row.shape[0]} coefficients but model has {len(c_arr)} variables"
+                )
+            grb_model.cbLazy(row @ x <= float(rhs))
+
+    try:
+        status_code = _optimize(model, GRB, _callback if lazy_callback is not None else None)
         status = _status_map(GRB).get(status_code, SolveStatus.ERROR)
         node_count = int(_safe_attr(model, "NodeCount") or 0)
         wall_time = float(_safe_attr(model, "Runtime") or 0.0)

--- a/python/discopt/solvers/mip_nlp.py
+++ b/python/discopt/solvers/mip_nlp.py
@@ -7,10 +7,9 @@ from typing import Any, Optional
 from discopt.modeling.core import Model, SolveResult
 from discopt.solvers.mip_nlp_options import GOA_OPTION_KEYS
 
-_IMPLEMENTED_METHODS = frozenset({"oa", "ecp", "fp", "goa"})
+_IMPLEMENTED_METHODS = frozenset({"oa", "ecp", "fp", "goa", "lp_nlp_bb"})
 _RESERVED_METHOD_ISSUES = {
     "roa": "#116/#117",
-    "lp_nlp_bb": "#119",
 }
 SUPPORTED_METHODS = _IMPLEMENTED_METHODS | frozenset(_RESERVED_METHOD_ISSUES)
 _METHOD_ALIASES = {
@@ -45,6 +44,20 @@ _FP_OPTION_KEYS = frozenset(
         "init_strategy",
     }
 )
+_LP_NLP_BB_OPTION_KEYS = frozenset(
+    {
+        "equality_relaxation",
+        "feasibility_cuts",
+        "init_strategy",
+        "heuristic_nonconvex",
+        "add_slack",
+        "max_slack",
+        "oa_penalty_factor",
+        "add_no_good_cuts",
+        "feasibility_norm",
+        "milp_solver",
+    }
+)
 
 
 def _normalize_method(method: Any) -> str:
@@ -61,7 +74,8 @@ def _normalize_method(method: Any) -> str:
     if normalized not in SUPPORTED_METHODS:
         reserved = ", ".join(sorted(_RESERVED_METHOD_ISSUES))
         raise ValueError(
-            f"Unknown mip_nlp_method={method!r}. Choose 'oa', 'ecp', 'fp', or 'goa'. "
+            f"Unknown mip_nlp_method={method!r}. Choose 'oa', 'ecp', 'fp', "
+            "'goa', or 'lp_nlp_bb'. "
             f"Reserved future methods are: {reserved}."
         )
     return normalized
@@ -102,6 +116,8 @@ def solve_mip_nlp(
     if method in _IMPLEMENTED_METHODS:
         if method == "fp":
             supported_keys = _FP_OPTION_KEYS
+        elif method == "lp_nlp_bb":
+            supported_keys = _LP_NLP_BB_OPTION_KEYS
         elif method == "goa":
             supported_keys = GOA_OPTION_KEYS
         else:
@@ -151,6 +167,22 @@ def solve_mip_nlp(
                 **options,
             )
 
+        if method == "lp_nlp_bb":
+            from discopt.solvers.oa import _normalize_init_strategy, solve_lp_nlp_bb
+
+            options["init_strategy"] = _normalize_init_strategy(
+                options.get("init_strategy", "rNLP")
+            )
+            return solve_lp_nlp_bb(
+                model,
+                time_limit=time_limit,
+                gap_tolerance=gap_tolerance,
+                max_iterations=max_iterations,
+                nlp_solver=nlp_solver,
+                initial_point=initial_point,
+                **options,
+            )
+
         from discopt.solvers.oa import _normalize_init_strategy, solve_oa
 
         if "ecp_mode" in kwargs:
@@ -176,5 +208,5 @@ def solve_mip_nlp(
     raise NotImplementedError(
         f"mip_nlp_method={method!r} is reserved for a future MIP-NLP "
         f"implementation tracked in {_RESERVED_METHOD_ISSUES[method]}; currently "
-        "implemented methods are 'oa', 'ecp', 'fp', and 'goa'."
+        "implemented methods are 'oa', 'ecp', 'fp', 'goa', and 'lp_nlp_bb'."
     )

--- a/python/discopt/solvers/oa.py
+++ b/python/discopt/solvers/oa.py
@@ -310,6 +310,21 @@ class _DerivativeRegularizationData:
     hessian: Optional[np.ndarray] = None
 
 
+@dataclass
+class _MasterMILPData:
+    """Matrix data for an OA-style MILP master."""
+
+    c: np.ndarray
+    A_ub: Optional[np.ndarray]
+    b_ub: Optional[np.ndarray]
+    A_eq: Optional[np.ndarray]
+    b_eq: Optional[np.ndarray]
+    bounds: list[tuple[float, float]]
+    integrality: np.ndarray
+    use_objective_epigraph: bool
+    slack_index: Optional[int]
+
+
 # ── Problem Decomposition ─────────────────────────────────────
 
 
@@ -1311,7 +1326,7 @@ def _add_feasibility_cuts(
 # ── MILP Master Problem ──────────────────────────────────────
 
 
-def _solve_master_milp(
+def _build_master_milp_data(
     linear_A_rows,
     linear_b_rows,
     linear_senses,
@@ -1324,26 +1339,13 @@ def _solve_master_milp(
     obj_coeffs,
     obj_is_linear,
     objective_bound_valid,
-    time_limit,
-    gap_tolerance,
     add_slack=False,
     max_slack=1000.0,
     oa_penalty_factor=1000.0,
     oa_cut_relaxable=None,
     use_objective_epigraph=None,
-    milp_solver="auto",
-):
-    """Build and solve the master MILP."""
-    try:
-        from discopt.solvers.lp_backend import get_milp_solver
-
-        solve_milp = get_milp_solver(backend=milp_solver)
-    except ImportError as e:
-        raise ImportError(
-            "OA solver requires a MILP backend for the master. Install one of: "
-            "pip install highspy  |  pip install pounce-solver  |  pip install gurobipy"
-        ) from e
-
+) -> _MasterMILPData:
+    """Build matrix data for an OA-style MILP master."""
     # ``use_objective_epigraph`` controls master layout when supplied; the
     # certification flag remains only as the compatibility fallback.
     if use_objective_epigraph is None:
@@ -1438,7 +1440,7 @@ def _solve_master_milp(
     int_vec = np.zeros(n_master, dtype=np.int32)
     int_vec[:n_vars] = integrality
 
-    return solve_milp(
+    return _MasterMILPData(
         c=c,
         A_ub=A_ub,
         b_ub=b_ub,
@@ -1446,6 +1448,72 @@ def _solve_master_milp(
         b_eq=b_eq,
         bounds=bounds_list,
         integrality=int_vec,
+        use_objective_epigraph=bool(use_objective_epigraph),
+        slack_index=slack_index,
+    )
+
+
+def _solve_master_milp(
+    linear_A_rows,
+    linear_b_rows,
+    linear_senses,
+    oa_A_rows,
+    oa_b_rows,
+    n_vars,
+    integrality,
+    lb,
+    ub,
+    obj_coeffs,
+    obj_is_linear,
+    objective_bound_valid,
+    time_limit,
+    gap_tolerance,
+    add_slack=False,
+    max_slack=1000.0,
+    oa_penalty_factor=1000.0,
+    oa_cut_relaxable=None,
+    use_objective_epigraph=None,
+    milp_solver="auto",
+):
+    """Build and solve the master MILP."""
+    try:
+        from discopt.solvers.lp_backend import get_milp_solver
+
+        solve_milp = get_milp_solver(backend=milp_solver)
+    except ImportError as e:
+        raise ImportError(
+            "OA solver requires a MILP backend for the master. Install one of: "
+            "pip install highspy  |  pip install pounce-solver  |  pip install gurobipy"
+        ) from e
+
+    master = _build_master_milp_data(
+        linear_A_rows,
+        linear_b_rows,
+        linear_senses,
+        oa_A_rows,
+        oa_b_rows,
+        n_vars,
+        integrality,
+        lb,
+        ub,
+        obj_coeffs,
+        obj_is_linear,
+        objective_bound_valid,
+        add_slack=add_slack,
+        max_slack=max_slack,
+        oa_penalty_factor=oa_penalty_factor,
+        oa_cut_relaxable=oa_cut_relaxable,
+        use_objective_epigraph=use_objective_epigraph,
+    )
+
+    return solve_milp(
+        c=master.c,
+        A_ub=master.A_ub,
+        b_ub=master.b_ub,
+        A_eq=master.A_eq,
+        b_eq=master.b_eq,
+        bounds=master.bounds,
+        integrality=master.integrality,
         time_limit=time_limit,
         gap_tolerance=gap_tolerance,
     )
@@ -1808,6 +1876,365 @@ def solve_feasibility_pump(
         wall_time=wall_time,
         mip_count=fp.mip_count,
         gap_certified=False,
+    )
+
+
+def _require_lp_nlp_bb_gurobi_backend(milp_solver: str) -> None:
+    if not isinstance(milp_solver, str) or milp_solver.strip().lower() != "gurobi":
+        raise RuntimeError(
+            "mip_nlp_method='lp_nlp_bb' requires milp_solver='gurobi' because "
+            "LP/NLP branch-and-bound uses single-tree lazy constraint callbacks. "
+            "Backends 'auto', 'highs', 'pounce', and 'simplex' do not expose the "
+            "required persistent lazy-cut capability."
+        )
+
+
+def _format_lazy_master_cut(
+    row,
+    *,
+    n_vars: int,
+    master: _MasterMILPData,
+    relaxable: bool,
+) -> np.ndarray:
+    """Extend an OA cut row to the active master layout for Gurobi cbLazy."""
+    cut = np.asarray(row, dtype=np.float64).ravel()
+    if master.use_objective_epigraph and len(cut) == n_vars:
+        cut = np.append(cut, 0.0)
+    if master.slack_index is not None:
+        cut = np.append(cut, -1.0 if relaxable else 0.0)
+    if len(cut) != len(master.c):
+        raise ValueError(
+            f"lazy OA cut has {len(cut)} coefficients but master has {len(master.c)} variables"
+        )
+    return cut
+
+
+def solve_lp_nlp_bb(
+    model: Model,
+    time_limit: float = 3600.0,
+    gap_tolerance: float = 1e-4,
+    max_iterations: int = 100,
+    nlp_solver: str = "ipm",
+    init_strategy: str = "rNLP",
+    initial_point: Optional[np.ndarray] = None,
+    equality_relaxation: bool = False,
+    feasibility_cuts: bool = True,
+    heuristic_nonconvex: bool = False,
+    add_slack: bool = False,
+    max_slack: float = 1000.0,
+    oa_penalty_factor: float = 1000.0,
+    add_no_good_cuts: bool = False,
+    feasibility_norm: str = "L_infinity",
+    milp_solver: str = "gurobi",
+    **kwargs,
+) -> SolveResult:
+    """Solve a convex MINLP with the LP/NLP branch-and-bound variant.
+
+    This is a single-tree OA method: the MILP master is solved once, and each
+    integer incumbent triggers a fixed-integer NLP solve inside a Gurobi lazy
+    constraint callback. Lazy rows are generated through the same OA and
+    feasibility-cut helpers used by the multi-tree OA method.
+    """
+    if kwargs:
+        raise ValueError(
+            "Unsupported LP/NLP BB option(s): "
+            + ", ".join(sorted(kwargs))
+            + ". Supported options are: add_no_good_cuts, add_slack, equality_relaxation, "
+            "feasibility_cuts, feasibility_norm, heuristic_nonconvex, init_strategy, "
+            "max_slack, milp_solver, oa_penalty_factor."
+        )
+    _require_lp_nlp_bb_gurobi_backend(milp_solver)
+    t_start = time.perf_counter()
+    init_strategy = _normalize_init_strategy(init_strategy)
+    feasibility_norm = _normalize_feasibility_norm(feasibility_norm)
+    max_slack = _normalize_positive_float("max_slack", max_slack)
+    oa_penalty_factor = _normalize_positive_float("oa_penalty_factor", oa_penalty_factor)
+    heuristic_nonconvex = bool(heuristic_nonconvex)
+    if heuristic_nonconvex:
+        equality_relaxation = True
+        add_slack = True
+    add_slack = bool(add_slack)
+    add_no_good_cuts = bool(add_no_good_cuts)
+
+    decomp = _decompose_model(model)
+    evaluator = decomp.evaluator
+    n_vars = decomp.n_vars
+    n_cons = decomp.n_cons
+    obj_sign = (
+        -1.0
+        if (model._objective is not None and model._objective.sense == ObjectiveSense.MAXIMIZE)
+        else 1.0
+    )
+    if decomp.oa_constraint_mask is not None and not all(decomp.oa_constraint_mask):
+        logger.warning(
+            "LP/NLP BB: generating OA cuts only for %d of %d constraints classified convex",
+            sum(1 for is_convex in decomp.oa_constraint_mask if is_convex),
+            len(decomp.oa_constraint_mask),
+        )
+    if not decomp.obj_is_linear and not decomp.oa_objective_is_convex:
+        logger.warning(
+            "LP/NLP BB: nonlinear objective is not convex in the optimization sense; "
+            "disabling certified bound/gap reporting and skipping objective OA cuts"
+        )
+    master_bound_valid = decomp.master_bound_valid and not heuristic_nonconvex
+
+    if len(decomp.int_indices) == 0:
+        x_sol, obj = _solve_nlp_relaxation(
+            evaluator,
+            decomp.lb,
+            decomp.ub,
+            nlp_solver,
+            initial_point=initial_point,
+        )
+        wall_time = time.perf_counter() - t_start
+        if x_sol is not None:
+            return SolveResult(
+                status="optimal",
+                objective=obj_sign * obj,
+                bound=obj_sign * obj,
+                gap=0.0,
+                x=_build_x_dict(x_sol, model),
+                wall_time=wall_time,
+                mip_count=0,
+            )
+        return SolveResult(
+            status="infeasible",
+            objective=None,
+            bound=None,
+            gap=None,
+            x={},
+            wall_time=wall_time,
+            mip_count=0,
+        )
+
+    oa_A_rows: list[np.ndarray] = []
+    oa_b_rows: list[float] = []
+    oa_cut_relaxable: list[bool] = []
+    incumbent: Optional[np.ndarray] = None
+    incumbent_obj: Optional[float] = None
+    nlp_subproblem_count = 0
+
+    def accept_incumbent(x: np.ndarray, obj: float) -> None:
+        nonlocal incumbent, incumbent_obj
+        if incumbent_obj is None or obj < incumbent_obj:
+            incumbent = np.asarray(x, dtype=np.float64).copy()
+            incumbent_obj = float(obj)
+
+    def add_oa_cuts_at(x_cut: np.ndarray) -> None:
+        _add_oa_cuts(
+            evaluator,
+            x_cut,
+            n_vars,
+            n_cons,
+            decomp.constraint_senses,
+            oa_A_rows,
+            oa_b_rows,
+            decomp.obj_is_linear,
+            decomp.oa_constraint_mask,
+            decomp.oa_objective_is_convex,
+            equality_relaxation=equality_relaxation,
+            oa_cut_relaxable=oa_cut_relaxable,
+        )
+
+    if init_strategy == "rNLP":
+        x_relax, obj_relax = _solve_nlp_relaxation(
+            evaluator,
+            decomp.lb,
+            decomp.ub,
+            nlp_solver,
+            initial_point=initial_point,
+        )
+        if x_relax is not None:
+            add_oa_cuts_at(x_relax)
+            if _is_integer_feasible(decomp, x_relax) and obj_relax is not None:
+                accept_incumbent(x_relax, obj_relax)
+        else:
+            add_oa_cuts_at(_default_nlp_start(decomp.lb, decomp.ub))
+    elif init_strategy == "fp":
+        fp_iterations = max(1, min(max_iterations if max_iterations > 0 else 1, 10))
+        fp_result = _run_feasibility_pump(
+            model,
+            decomp,
+            nlp_solver=nlp_solver,
+            initial_point=initial_point,
+            time_limit=max(time_limit - (time.perf_counter() - t_start), 0.0),
+            gap_tolerance=gap_tolerance,
+            max_iterations=fp_iterations,
+            feasibility_norm=feasibility_norm,
+            add_no_good_cuts=True,
+            milp_solver=milp_solver,
+        )
+        x_cut = fp_result.best_x if fp_result.best_x is not None else fp_result.best_near_x
+        add_oa_cuts_at(x_cut if x_cut is not None else _default_nlp_start(decomp.lb, decomp.ub))
+        if fp_result.best_x is not None and fp_result.best_obj is not None:
+            accept_incumbent(fp_result.best_x, fp_result.best_obj)
+    else:
+        x_seed = _build_initial_strategy_point(decomp, init_strategy, initial_point)
+        x_init, obj_init = _solve_nlp_subproblem(
+            evaluator,
+            decomp.lb,
+            decomp.ub,
+            decomp.int_indices,
+            x_seed,
+            nlp_solver,
+            initial_point=x_seed,
+        )
+        add_oa_cuts_at(x_init if x_init is not None else x_seed)
+        if x_init is not None and obj_init is not None:
+            accept_incumbent(x_init, obj_init)
+
+    elapsed = time.perf_counter() - t_start
+    remaining = max(float(time_limit) - elapsed, 0.0)
+    master = _build_master_milp_data(
+        decomp.linear_A_rows,
+        decomp.linear_b_rows,
+        decomp.linear_senses,
+        oa_A_rows,
+        oa_b_rows,
+        n_vars,
+        decomp.integrality,
+        decomp.lb,
+        decomp.ub,
+        decomp.obj_coeffs,
+        decomp.obj_is_linear,
+        master_bound_valid,
+        add_slack=add_slack,
+        max_slack=max_slack,
+        oa_penalty_factor=oa_penalty_factor,
+        oa_cut_relaxable=oa_cut_relaxable,
+        use_objective_epigraph=(not decomp.obj_is_linear and decomp.oa_objective_is_convex),
+    )
+
+    def collect_new_lazy_cuts(start: int, master_x: np.ndarray) -> list[tuple[np.ndarray, float]]:
+        rows: list[tuple[np.ndarray, float]] = []
+        for idx in range(start, len(oa_A_rows)):
+            relaxable = bool(oa_cut_relaxable[idx]) if idx < len(oa_cut_relaxable) else True
+            row = _format_lazy_master_cut(
+                oa_A_rows[idx],
+                n_vars=n_vars,
+                master=master,
+                relaxable=relaxable,
+            )
+            rhs = float(oa_b_rows[idx])
+            if float(np.dot(row, master_x)) > rhs + 1e-6:
+                rows.append((row, rhs))
+        return rows
+
+    def lazy_callback(master_x: np.ndarray) -> list[tuple[np.ndarray, float]]:
+        nonlocal nlp_subproblem_count
+        x_master = np.asarray(master_x[:n_vars], dtype=np.float64)
+        start = len(oa_A_rows)
+        nlp_subproblem_count += 1
+        x_nlp, obj_nlp = _solve_nlp_subproblem(
+            evaluator,
+            decomp.lb,
+            decomp.ub,
+            decomp.int_indices,
+            x_master,
+            nlp_solver,
+            initial_point=x_master,
+        )
+        if x_nlp is not None:
+            if obj_nlp is not None:
+                accept_incumbent(x_nlp, obj_nlp)
+            add_oa_cuts_at(x_nlp)
+        else:
+            if feasibility_cuts:
+                x_feas = _solve_feasibility_subproblem(
+                    evaluator,
+                    decomp.lb,
+                    decomp.ub,
+                    decomp.int_indices,
+                    x_master,
+                    nlp_solver,
+                    feasibility_norm,
+                )
+                if x_feas is not None:
+                    _add_feasibility_cuts(
+                        evaluator,
+                        x_feas,
+                        n_vars,
+                        decomp.constraint_senses,
+                        oa_A_rows,
+                        oa_b_rows,
+                        decomp.oa_constraint_mask,
+                        oa_cut_relaxable=oa_cut_relaxable,
+                    )
+            if add_no_good_cuts and not decomp.general_integer_indices:
+                _add_no_good_cut(
+                    x_master,
+                    decomp.int_indices,
+                    oa_A_rows,
+                    oa_b_rows,
+                    n_vars,
+                    oa_cut_relaxable=oa_cut_relaxable,
+                )
+            add_oa_cuts_at(x_master)
+
+        return collect_new_lazy_cuts(start, np.asarray(master_x, dtype=np.float64))
+
+    from discopt.solvers import SolveStatus
+    from discopt.solvers.gurobi import solve_milp_with_lazy_cuts
+
+    master_result = solve_milp_with_lazy_cuts(
+        c=master.c,
+        A_ub=master.A_ub,
+        b_ub=master.b_ub,
+        A_eq=master.A_eq,
+        b_eq=master.b_eq,
+        bounds=master.bounds,
+        integrality=master.integrality,
+        time_limit=remaining,
+        gap_tolerance=gap_tolerance,
+        lazy_callback=lazy_callback,
+    )
+    wall_time = time.perf_counter() - t_start
+
+    bound = None
+    if master_bound_valid and master_result.bound is not None:
+        bound = float(master_result.bound)
+    gap = (
+        _compute_gap(bound, incumbent_obj)
+        if bound is not None and incumbent_obj is not None
+        else None
+    )
+    status = "feasible"
+    if master_result.status == SolveStatus.INFEASIBLE:
+        status = "infeasible"
+    elif master_result.status == SolveStatus.TIME_LIMIT:
+        status = "time_limit" if incumbent is None else "feasible"
+    elif master_result.status == SolveStatus.ITERATION_LIMIT:
+        status = "iteration_limit" if incumbent is None else "feasible"
+    elif master_result.status == SolveStatus.OPTIMAL and incumbent is not None:
+        status = "optimal" if gap is not None and gap <= gap_tolerance else "feasible"
+    elif incumbent is None:
+        status = "no_feasible_point"
+
+    if incumbent is not None and incumbent_obj is not None:
+        return SolveResult(
+            status=status,
+            objective=obj_sign * incumbent_obj,
+            bound=(obj_sign * bound if bound is not None else None),
+            gap=gap,
+            x=_build_x_dict(incumbent, model),
+            wall_time=wall_time,
+            node_count=master_result.node_count,
+            mip_count=1,
+            subnlp_calls=nlp_subproblem_count,
+            gap_certified=master_bound_valid,
+        )
+
+    return SolveResult(
+        status=status,
+        objective=None,
+        bound=(obj_sign * bound if bound is not None else None),
+        gap=None,
+        x={},
+        wall_time=wall_time,
+        node_count=master_result.node_count,
+        mip_count=1,
+        subnlp_calls=nlp_subproblem_count,
+        gap_certified=master_bound_valid,
     )
 
 

--- a/python/discopt/solvers/oa.py
+++ b/python/discopt/solvers/oa.py
@@ -1933,7 +1933,10 @@ def solve_lp_nlp_bb(
     This is a single-tree OA method: the MILP master is solved once, and each
     integer incumbent triggers a fixed-integer NLP solve inside a Gurobi lazy
     constraint callback. Lazy rows are generated through the same OA and
-    feasibility-cut helpers used by the multi-tree OA method.
+    feasibility-cut helpers used by the multi-tree OA method. ``max_iterations``
+    only caps the optional feasibility-pump initializer on this path; the main
+    single-tree search is delegated to Gurobi and is controlled by
+    ``time_limit`` and ``gap_tolerance``.
     """
     if kwargs:
         raise ValueError(
@@ -2193,6 +2196,8 @@ def solve_lp_nlp_bb(
     bound = None
     if master_bound_valid and master_result.bound is not None:
         bound = float(master_result.bound)
+        if decomp.obj_is_linear and decomp.obj_coeffs is not None:
+            bound += float(decomp.obj_coeffs[1])
     gap = (
         _compute_gap(bound, incumbent_obj)
         if bound is not None and incumbent_obj is not None

--- a/python/tests/test_gurobi_backend.py
+++ b/python/tests/test_gurobi_backend.py
@@ -248,6 +248,103 @@ def test_gurobi_milp_optimal_result_reports_zero_gap(monkeypatch):
     assert result.gap == 0.0
 
 
+def test_gurobi_milp_lazy_callback_adds_lazy_cut(monkeypatch):
+    class FakeCallback:
+        MIPSOL = 1
+
+    class FakeGRB:
+        CONTINUOUS = "C"
+        BINARY = "B"
+        INTEGER = "I"
+        MINIMIZE = 1
+        INFINITY = 1e100
+        OPTIMAL = 2
+        INFEASIBLE = 3
+        UNBOUNDED = 5
+        INF_OR_UNBD = 4
+        ITERATION_LIMIT = 7
+        TIME_LIMIT = 9
+        Callback = FakeCallback
+
+    class FakeEnv:
+        def __init__(self, empty=True):
+            self.empty = empty
+
+        def setParam(self, *_args):
+            pass
+
+        def start(self):
+            pass
+
+        def dispose(self):
+            pass
+
+    class FakeMVar:
+        __array_priority__ = 1000
+        X = np.array([0.0])
+
+        def __rmatmul__(self, _other):
+            return 0.0
+
+    class FakeModel:
+        Status = FakeGRB.OPTIMAL
+        NodeCount = 1
+        Runtime = 0.0
+        SolCount = 1
+        ObjVal = 0.0
+        ObjBound = 0.0
+        MIPGap = 0.0
+        last = None
+
+        def __init__(self, *_args, **_kwargs):
+            self.params = {}
+            self.lazy_constraints = []
+            FakeModel.last = self
+
+        def setParam(self, key, value):
+            self.params[key] = value
+
+        def addMVar(self, **_kwargs):
+            return FakeMVar()
+
+        def setObjective(self, *_args):
+            pass
+
+        def cbGetSolution(self, _x):
+            return np.array([0.0])
+
+        def cbLazy(self, expr):
+            self.lazy_constraints.append(expr)
+
+        def optimize(self, callback=None):
+            if callback is not None:
+                callback(self, FakeGRB.Callback.MIPSOL)
+
+        def dispose(self):
+            pass
+
+    fake_gp = types.SimpleNamespace(Env=FakeEnv, Model=FakeModel)
+    monkeypatch.setattr(gurobi_backend, "_load_gurobi", lambda: (fake_gp, FakeGRB))
+
+    callback_candidates = []
+
+    def lazy_callback(candidate):
+        callback_candidates.append(candidate)
+        return [(np.array([1.0]), -0.5)]
+
+    result = gurobi_backend.solve_milp_with_lazy_cuts(
+        c=np.array([1.0]),
+        bounds=[(0.0, 1.0)],
+        integrality=np.array([1], dtype=np.int32),
+        lazy_callback=lazy_callback,
+    )
+
+    assert result.status == SolveStatus.OPTIMAL
+    assert callback_candidates
+    assert FakeModel.last.params["LazyConstraints"] == 1
+    assert len(FakeModel.last.lazy_constraints) == 1
+
+
 def test_amp_bound_tolerance_closes_small_master_bound_inversion():
     from discopt.solvers import amp as amp_module
 

--- a/python/tests/test_mip_nlp.py
+++ b/python/tests/test_mip_nlp.py
@@ -11,6 +11,17 @@ except ImportError:
     HAS_HIGHS = False
 
 
+def _require_gurobi():
+    gp = pytest.importorskip("gurobipy")
+    try:
+        env = gp.Env(empty=True)
+        env.setParam("OutputFlag", 0)
+        env.start()
+        env.dispose()
+    except Exception as exc:
+        pytest.skip(f"Gurobi is installed but no usable license is available: {exc}")
+
+
 def _binary_model(name="mip_nlp_route"):
     m = dm.Model(name)
     x = m.binary("x")
@@ -650,6 +661,99 @@ def test_lp_nlp_bb_lazy_callback_solves_fixed_integer_nlp(monkeypatch):
     assert calls["lazy"] == 1
     assert calls["subproblem"] == 1
     assert calls["oa"] >= 2
+
+
+def test_lp_nlp_bb_linear_objective_constant_offsets_certified_bound(monkeypatch):
+    import discopt.solvers.gurobi as gurobi_module
+    import discopt.solvers.oa as oa_module
+    from discopt.solvers import MILPResult, SolveStatus
+    from discopt.solvers.mip_nlp import solve_mip_nlp
+
+    m = dm.Model("lp_nlp_bb_constant_bound")
+    y = m.binary("y")
+    m.minimize(y + 100.0)
+
+    def fake_relaxation(*_args, **_kwargs):
+        return None, None
+
+    def fake_subproblem(
+        _evaluator,
+        _lb,
+        _ub,
+        _int_indices,
+        x_master,
+        _nlp_solver,
+        initial_point=None,
+        return_attempt=False,
+    ):
+        return np.asarray(x_master, dtype=np.float64), 100.0
+
+    def fake_lazy_milp(**kwargs):
+        candidate = np.zeros_like(kwargs["c"], dtype=np.float64)
+        kwargs["lazy_callback"](candidate)
+        return MILPResult(
+            status=SolveStatus.OPTIMAL,
+            x=candidate,
+            objective=0.0,
+            bound=0.0,
+            gap=0.0,
+            node_count=1,
+        )
+
+    monkeypatch.setattr(oa_module, "_solve_nlp_relaxation", fake_relaxation)
+    monkeypatch.setattr(oa_module, "_solve_nlp_subproblem", fake_subproblem)
+    monkeypatch.setattr(gurobi_module, "solve_milp_with_lazy_cuts", fake_lazy_milp)
+
+    result = solve_mip_nlp(m, method="lp_nlp_bb", milp_solver="gurobi")
+
+    assert result.status == "optimal"
+    assert result.objective == pytest.approx(100.0)
+    assert result.bound == pytest.approx(100.0)
+    assert result.gap == pytest.approx(0.0)
+    assert result.gap_certified is True
+
+
+def test_lp_nlp_bb_gurobi_solves_mindtpy_fixture_if_available():
+    _require_gurobi()
+
+    result = _mindtpy_simple_minlp("lp_nlp_bb_gurobi_mindtpy").solve(
+        solver="mip-nlp",
+        mip_nlp_method="lp_nlp_bb",
+        milp_solver="gurobi",
+        time_limit=30.0,
+        gap_tolerance=1e-5,
+    )
+
+    assert result.status == "optimal"
+    assert result.objective == pytest.approx(3.5, abs=1e-3)
+    assert result.bound == pytest.approx(3.5, abs=1e-3)
+    assert result.gap == pytest.approx(0.0, abs=1e-6)
+    assert result.gap_certified is True
+
+
+def test_lp_nlp_bb_gurobi_reports_constant_offset_bound_if_available():
+    _require_gurobi()
+
+    m = dm.Model("lp_nlp_bb_gurobi_constant_bound")
+    x = m.continuous("x", lb=0.0, ub=2.0)
+    y = m.binary("y")
+    m.subject_to((x - 1.0) ** 2 <= 1.0)
+    m.subject_to(x >= y)
+    m.minimize(2.0 * x + 3.0 * y + 100.0)
+
+    result = m.solve(
+        solver="mip-nlp",
+        mip_nlp_method="lp_nlp_bb",
+        milp_solver="gurobi",
+        time_limit=30.0,
+        gap_tolerance=1e-5,
+    )
+
+    assert result.status == "optimal"
+    assert result.objective == pytest.approx(100.0, abs=1e-6)
+    assert result.bound == pytest.approx(100.0, abs=1e-6)
+    assert result.gap == pytest.approx(0.0, abs=1e-8)
+    assert result.gap_certified is True
 
 
 def test_mip_nlp_method_gloa_is_reserved_for_gdp_axis():

--- a/python/tests/test_mip_nlp.py
+++ b/python/tests/test_mip_nlp.py
@@ -524,8 +524,6 @@ def test_mip_nlp_and_deprecated_oa_alias_reformulate_gdp(monkeypatch):
     ("method", "issue"),
     [
         ("roa", "#116/#117"),
-        ("lp_nlp_bb", "#119"),
-        ("lp/nlp-bb", "#119"),
     ],
 )
 def test_mip_nlp_reserved_methods_raise(method, issue):
@@ -533,6 +531,125 @@ def test_mip_nlp_reserved_methods_raise(method, issue):
 
     with pytest.raises(NotImplementedError, match=issue):
         solve_mip_nlp(_binary_model(f"{method}_reserved"), method=method)
+
+
+def test_mip_nlp_method_lp_nlp_bb_requires_gurobi_backend():
+    from discopt.solvers.mip_nlp import solve_mip_nlp
+
+    with pytest.raises(RuntimeError, match="requires milp_solver='gurobi'"):
+        solve_mip_nlp(_binary_model("lp_nlp_bb_backend"), method="lp_nlp_bb", milp_solver="highs")
+
+
+def test_mip_nlp_method_lp_nlp_bb_alias_routes_to_single_tree_solver(monkeypatch):
+    import discopt.solvers.oa as oa_module
+    from discopt.solvers.mip_nlp import solve_mip_nlp
+
+    calls = {}
+
+    def fake_solve_lp_nlp_bb(model, **kwargs):
+        calls.update(kwargs)
+        return SolveResult(status="optimal", objective=0.0, bound=0.0, gap=0.0)
+
+    monkeypatch.setattr(oa_module, "solve_lp_nlp_bb", fake_solve_lp_nlp_bb)
+
+    result = solve_mip_nlp(
+        _binary_model("lp_nlp_bb_route"),
+        method="lp/nlp-bb",
+        milp_solver="gurobi",
+        init_strategy="initial_binary",
+        feasibility_norm="L1",
+    )
+
+    assert result.status == "optimal"
+    assert calls["milp_solver"] == "gurobi"
+    assert calls["init_strategy"] == "initial_binary"
+    assert calls["feasibility_norm"] == "L1"
+
+
+def test_lp_nlp_bb_lazy_callback_solves_fixed_integer_nlp(monkeypatch):
+    import discopt.solvers.gurobi as gurobi_module
+    import discopt.solvers.oa as oa_module
+    from discopt.solvers import MILPResult, SolveStatus
+    from discopt.solvers.mip_nlp import solve_mip_nlp
+
+    calls = {"lazy": 0, "subproblem": 0, "oa": 0}
+
+    def fake_relaxation(*_args, **_kwargs):
+        return None, None
+
+    def fake_subproblem(
+        _evaluator,
+        _lb,
+        _ub,
+        _int_indices,
+        x_master,
+        _nlp_solver,
+        initial_point=None,
+        return_attempt=False,
+    ):
+        assert initial_point is not None
+        calls["subproblem"] += 1
+        x = np.asarray(x_master, dtype=np.float64).copy()
+        return x, 0.0
+
+    def fake_add_oa_cuts(
+        _evaluator,
+        _x_star,
+        n_vars,
+        _n_cons,
+        _constraint_senses,
+        oa_A_rows,
+        oa_b_rows,
+        _obj_is_linear,
+        constraint_convex_mask,
+        _objective_is_convex,
+        equality_relaxation=False,
+        oa_cut_relaxable=None,
+    ):
+        calls["oa"] += 1
+        assert constraint_convex_mask is None or all(
+            isinstance(v, bool) for v in constraint_convex_mask
+        )
+        row = np.zeros(n_vars, dtype=np.float64)
+        row[0] = 1.0
+        oa_A_rows.append(row)
+        oa_b_rows.append(-1.0)
+        if oa_cut_relaxable is not None:
+            oa_cut_relaxable.append(True)
+
+    def fake_lazy_milp(**kwargs):
+        candidate = np.zeros_like(kwargs["c"], dtype=np.float64)
+        cuts = kwargs["lazy_callback"](candidate)
+        calls["lazy"] += 1
+        assert cuts
+        row, rhs = cuts[0]
+        assert row.shape == candidate.shape
+        assert float(row @ candidate) > rhs
+        return MILPResult(
+            status=SolveStatus.OPTIMAL,
+            x=candidate,
+            objective=0.0,
+            bound=0.0,
+            gap=0.0,
+            node_count=1,
+        )
+
+    monkeypatch.setattr(oa_module, "_solve_nlp_relaxation", fake_relaxation)
+    monkeypatch.setattr(oa_module, "_solve_nlp_subproblem", fake_subproblem)
+    monkeypatch.setattr(oa_module, "_add_oa_cuts", fake_add_oa_cuts)
+    monkeypatch.setattr(gurobi_module, "solve_milp_with_lazy_cuts", fake_lazy_milp)
+
+    result = solve_mip_nlp(
+        _binary_model("lp_nlp_bb_lazy"),
+        method="lp_nlp_bb",
+        milp_solver="gurobi",
+    )
+
+    assert result.status == "optimal"
+    assert result.subnlp_calls == 1
+    assert calls["lazy"] == 1
+    assert calls["subproblem"] == 1
+    assert calls["oa"] >= 2
 
 
 def test_mip_nlp_method_gloa_is_reserved_for_gdp_axis():


### PR DESCRIPTION
## Summary

- Adds `mip_nlp_method="lp_nlp_bb"` / `"lp/nlp-bb"` as a Gurobi-only single-tree MIP-NLP method.
- Adds a Gurobi lazy-constraint MILP helper and reuses OA master construction for callback-generated OA/feasibility cuts.
- Rejects non-Gurobi MILP backends clearly for LP/NLP BB because HiGHS, POUNCE, and simplex do not expose the required persistent lazy-cut callback seam.
- Updates MIP-NLP routing/docs and adds focused tests for routing, unsupported backends, lazy-cut invocation, and fixed-integer NLP solves at integer incumbents.

Closes #119

## Tests

- `env PYTHONPATH=python python -m ruff check python/discopt/solvers/gurobi.py python/discopt/solvers/oa.py python/discopt/solvers/mip_nlp.py python/tests/test_mip_nlp.py python/tests/test_gurobi_backend.py`
- `env PYTHONPATH=python pytest python/tests/test_mip_nlp.py`
- `env PYTHONPATH=python pytest python/tests/test_gurobi_backend.py`

## Branch Hygiene

- Base branch: `bernalde/discopt:feature/mip-nlp-solver`
- Source branch: `bernalde/discopt:fix/issue-119-lp-nlp-bb`
- Source branch point: `74bd7e8` (`feature/mip-nlp-solver` after syncing from fork `main`)
- Base sync performed before this child branch:
  - `1c49451` merged current `upstream/main` into `bernalde:main`
  - `74bd7e8` merged synced fork `main` into `bernalde:feature/mip-nlp-solver`
- Stacked status: not stacked on a previous child PR branch
- Prerequisite PRs: none
