### PR TITLE
Add MIP-NLP solution pool support

### DIFF
--- a/docs/_toc.yml
+++ b/docs/_toc.yml
@@ -58,6 +58,7 @@ parts:
       - file: notebooks/suspect_head_to_head
       - file: notebooks/nlp_bb
       - file: notebooks/export_formats
+      - file: notebooks/model_representations
       - file: notebooks/pyomo_solver
       - file: pyomo_solver
       - file: notebooks/callbacks

--- a/docs/notebooks/model_representations.ipynb
+++ b/docs/notebooks/model_representations.ipynb
@@ -1,0 +1,358 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "2eddaf04",
+   "metadata": {},
+   "source": [
+    "# Rich model representations\n",
+    "\n",
+    "A discopt {py:class}`~discopt.modeling.core.Model` renders itself as a typeset optimization problem in standard form {cite:p}`Williams2013` — `minimize f(x)` / `subject to g(x) ≤ 0` / variable domains. In Jupyter the model displays automatically; you can also export the LaTeX or HTML for papers and docs.\n",
+    "\n",
+    "Let us build a small mixed-integer nonlinear program and just *look* at it."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "466e952b",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-29T01:35:35.608989Z",
+     "iopub.status.busy": "2026-06-29T01:35:35.608792Z",
+     "iopub.status.idle": "2026-06-29T01:35:35.650516Z",
+     "shell.execute_reply": "2026-06-29T01:35:35.650097Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div class=\"discopt-model\"><div style=\"font-weight:600\">Model <code>blend</code> <span style=\"color:#888;font-weight:400\">(2 variables, 2 constraints)</span></div>$$\n",
+       "\\begin{aligned}\n",
+       "& \\text{minimize} \\quad && \\left(x - 3\\right)^{2} + 2 \\cdot y \\\\\n",
+       "& \\text{subject to} \\quad && 4 \\le x + 5 \\cdot y \\\\\n",
+       "&  \\quad && \\exp\\!\\left(x\\right) \\le 100 \\\\\n",
+       "& \\text{with} \\quad && 0 \\le x \\le 10 \\\\\n",
+       "&  \\quad && y \\in \\{0, 1\\} \\\\\n",
+       "\\end{aligned}\n",
+       "$$</div>"
+      ],
+      "text/latex": [
+       "$$\n",
+       "\\begin{aligned}\n",
+       "& \\text{minimize} \\quad && \\left(x - 3\\right)^{2} + 2 \\cdot y \\\\\n",
+       "& \\text{subject to} \\quad && 4 \\le x + 5 \\cdot y \\\\\n",
+       "&  \\quad && \\exp\\!\\left(x\\right) \\le 100 \\\\\n",
+       "& \\text{with} \\quad && 0 \\le x \\le 10 \\\\\n",
+       "&  \\quad && y \\in \\{0, 1\\} \\\\\n",
+       "\\end{aligned}\n",
+       "$$"
+      ],
+      "text/plain": [
+       "Model: blend\n",
+       "  Variables: 2 (1 continuous, 1 integer/binary)\n",
+       "  Constraints: 2\n",
+       "  Objective: minimize (((x - 3) ** 2) + (2 * y))\n",
+       "  Parameters: 0"
+      ]
+     },
+     "execution_count": 1,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "import discopt.modeling as dm\n",
+    "\n",
+    "m = dm.Model(\"blend\")\n",
+    "x = m.continuous(\"x\", lb=0, ub=10)\n",
+    "y = m.binary(\"y\")\n",
+    "m.minimize((x - 3) ** 2 + 2 * y)\n",
+    "m.subject_to(x + 5 * y >= 4)\n",
+    "m.subject_to(dm.exp(x) <= 100)\n",
+    "\n",
+    "m  # renders as a typeset problem (HTML/LaTeX via MathJax)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a2fcfe10",
+   "metadata": {},
+   "source": [
+    "The constraints are shown in their natural form (`x + 5y ≥ 4`), even though they are stored internally in normalised `g(x) ≤ 0` form. To get the markup directly — e.g. to paste into a paper — use `to_latex()`:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "bfeb6e27",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-29T01:35:35.651838Z",
+     "iopub.status.busy": "2026-06-29T01:35:35.651749Z",
+     "iopub.status.idle": "2026-06-29T01:35:35.653577Z",
+     "shell.execute_reply": "2026-06-29T01:35:35.653271Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\\begin{aligned}\n",
+      "& \\text{minimize} \\quad && \\left(x - 3\\right)^{2} + 2 \\cdot y \\\\\n",
+      "& \\text{subject to} \\quad && 4 \\le x + 5 \\cdot y \\\\\n",
+      "&  \\quad && \\exp\\!\\left(x\\right) \\le 100 \\\\\n",
+      "& \\text{with} \\quad && 0 \\le x \\le 10 \\\\\n",
+      "&  \\quad && y \\in \\{0, 1\\} \\\\\n",
+      "\\end{aligned}\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(m.to_latex())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e68f5b8b",
+   "metadata": {},
+   "source": [
+    "## Nonlinear expressions\n",
+    "\n",
+    "The renderer handles powers (superscripts), division (fractions), and the elementary functions (`exp`, `log`, `sqrt`, the trig family, …)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "e60f9d81",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-29T01:35:35.654634Z",
+     "iopub.status.busy": "2026-06-29T01:35:35.654581Z",
+     "iopub.status.idle": "2026-06-29T01:35:35.656713Z",
+     "shell.execute_reply": "2026-06-29T01:35:35.656422Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div class=\"discopt-model\"><div style=\"font-weight:600\">Model <code>nlp</code> <span style=\"color:#888;font-weight:400\">(2 variables, 1 constraint)</span></div>$$\n",
+       "\\begin{aligned}\n",
+       "& \\text{maximize} \\quad && \\frac{\\exp\\!\\left(a\\right)}{b + 1} \\\\\n",
+       "& \\text{subject to} \\quad && \\sqrt{a} + b^{2} \\le 10 \\\\\n",
+       "& \\text{with} \\quad && 1 \\le a \\le 5 \\\\\n",
+       "&  \\quad && 1 \\le b \\le 5 \\\\\n",
+       "\\end{aligned}\n",
+       "$$</div>"
+      ],
+      "text/latex": [
+       "$$\n",
+       "\\begin{aligned}\n",
+       "& \\text{maximize} \\quad && \\frac{\\exp\\!\\left(a\\right)}{b + 1} \\\\\n",
+       "& \\text{subject to} \\quad && \\sqrt{a} + b^{2} \\le 10 \\\\\n",
+       "& \\text{with} \\quad && 1 \\le a \\le 5 \\\\\n",
+       "&  \\quad && 1 \\le b \\le 5 \\\\\n",
+       "\\end{aligned}\n",
+       "$$"
+      ],
+      "text/plain": [
+       "Model: nlp\n",
+       "  Variables: 2 (2 continuous, 0 integer/binary)\n",
+       "  Constraints: 1\n",
+       "  Objective: maximize (exp(a) / (b + 1))\n",
+       "  Parameters: 0"
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "n = dm.Model(\"nlp\")\n",
+    "a = n.continuous(\"a\", lb=1, ub=5)\n",
+    "b = n.continuous(\"b\", lb=1, ub=5)\n",
+    "n.maximize(dm.exp(a) / (b + 1))\n",
+    "n.subject_to(dm.sqrt(a) + b**2 <= 10)\n",
+    "n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "667ba3be",
+   "metadata": {},
+   "source": [
+    "## Large models are summarised\n",
+    "\n",
+    "Auto-display truncates large models so a notebook is never flooded: the first few constraints are shown, then a `⋮` row with the totals, and variables are summarised by type. Pass `max_rows=None` to `to_latex()` / `to_html()` for the complete form."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "62f921ca",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-29T01:35:35.657791Z",
+     "iopub.status.busy": "2026-06-29T01:35:35.657736Z",
+     "iopub.status.idle": "2026-06-29T01:35:35.660149Z",
+     "shell.execute_reply": "2026-06-29T01:35:35.659840Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div class=\"discopt-model\"><div style=\"font-weight:600\">Model <code>assignment</code> <span style=\"color:#888;font-weight:400\">(40 variables, 40 constraints)</span></div>$$\n",
+       "\\begin{aligned}\n",
+       "& \\text{minimize} \\quad && 0 + 1 \\cdot z_{0} + 2 \\cdot z_{1} + 3 \\cdot z_{2} + 4 \\cdot z_{3} + 5 \\cdot z_{4} + 6 \\cdot z_{5} + 7 \\cdot z_{6} + 8 \\cdot z_{7} + 9 \\cdot z_{8} + 10 \\cdot z_{9} + 11 \\cdot z_{10} + 12 \\cdot z_{11} + 13 \\cdot z_{12} + 14 \\cdot z_{13} + 15 \\cdot z_{14} + 16 \\cdot z_{15} + 17 \\cdot z_{16} + 18 \\cdot z_{17} + 19 \\cdot z_{18} + 20 \\cdot z_{19} + 21 \\cdot z_{20} + 22 \\cdot z_{21} + 23 \\cdot z_{22} + 24 \\cdot z_{23} + 25 \\cdot z_{24} + 26 \\cdot z_{25} + 27 \\cdot z_{26} + 28 \\cdot z_{27} + 29 \\cdot z_{28} + 30 \\cdot z_{29} + 31 \\cdot z_{30} + 32 \\cdot z_{31} + 33 \\cdot z_{32} + 34 \\cdot z_{33} + 35 \\cdot z_{34} + 36 \\cdot z_{35} + 37 \\cdot z_{36} + 38 \\cdot z_{37} + 39 \\cdot z_{38} + 40 \\cdot z_{39} \\\\\n",
+       "& \\text{subject to} \\quad && z_{0} + z_{1} \\le 1 \\\\\n",
+       "&  \\quad && z_{1} + z_{2} \\le 1 \\\\\n",
+       "&  \\quad && z_{2} + z_{3} \\le 1 \\\\\n",
+       "&  \\quad && z_{3} + z_{4} \\le 1 \\\\\n",
+       "&  \\quad && z_{4} + z_{5} \\le 1 \\\\\n",
+       "&  \\quad && z_{5} + z_{6} \\le 1 \\\\\n",
+       "&  \\quad && z_{6} + z_{7} \\le 1 \\\\\n",
+       "&  \\quad && z_{7} + z_{8} \\le 1 \\\\\n",
+       "&  \\quad && z_{8} + z_{9} \\le 1 \\\\\n",
+       "&  \\quad && z_{9} + z_{10} \\le 1 \\\\\n",
+       "&  \\quad && z_{10} + z_{11} \\le 1 \\\\\n",
+       "&  \\quad && z_{11} + z_{12} \\le 1 \\\\\n",
+       "&  \\quad && z_{12} + z_{13} \\le 1 \\\\\n",
+       "&  \\quad && z_{13} + z_{14} \\le 1 \\\\\n",
+       "&  \\quad && z_{14} + z_{15} \\le 1 \\\\\n",
+       "&  \\quad && z_{15} + z_{16} \\le 1 \\\\\n",
+       "&  \\quad && z_{16} + z_{17} \\le 1 \\\\\n",
+       "&  \\quad && z_{17} + z_{18} \\le 1 \\\\\n",
+       "&  \\quad && z_{18} + z_{19} \\le 1 \\\\\n",
+       "&  \\quad && z_{19} + z_{20} \\le 1 \\\\\n",
+       "&  \\quad && z_{20} + z_{21} \\le 1 \\\\\n",
+       "&  \\quad && z_{21} + z_{22} \\le 1 \\\\\n",
+       "&  \\quad && z_{22} + z_{23} \\le 1 \\\\\n",
+       "&  \\quad && z_{23} + z_{24} \\le 1 \\\\\n",
+       "&  \\quad && \\vdots \\quad (\\text{40 constraints}) \\\\\n",
+       "& \\text{with} \\quad && 40\\ \\text{binary} \\text{ variables} \\\\\n",
+       "\\end{aligned}\n",
+       "$$</div>"
+      ],
+      "text/latex": [
+       "$$\n",
+       "\\begin{aligned}\n",
+       "& \\text{minimize} \\quad && 0 + 1 \\cdot z_{0} + 2 \\cdot z_{1} + 3 \\cdot z_{2} + 4 \\cdot z_{3} + 5 \\cdot z_{4} + 6 \\cdot z_{5} + 7 \\cdot z_{6} + 8 \\cdot z_{7} + 9 \\cdot z_{8} + 10 \\cdot z_{9} + 11 \\cdot z_{10} + 12 \\cdot z_{11} + 13 \\cdot z_{12} + 14 \\cdot z_{13} + 15 \\cdot z_{14} + 16 \\cdot z_{15} + 17 \\cdot z_{16} + 18 \\cdot z_{17} + 19 \\cdot z_{18} + 20 \\cdot z_{19} + 21 \\cdot z_{20} + 22 \\cdot z_{21} + 23 \\cdot z_{22} + 24 \\cdot z_{23} + 25 \\cdot z_{24} + 26 \\cdot z_{25} + 27 \\cdot z_{26} + 28 \\cdot z_{27} + 29 \\cdot z_{28} + 30 \\cdot z_{29} + 31 \\cdot z_{30} + 32 \\cdot z_{31} + 33 \\cdot z_{32} + 34 \\cdot z_{33} + 35 \\cdot z_{34} + 36 \\cdot z_{35} + 37 \\cdot z_{36} + 38 \\cdot z_{37} + 39 \\cdot z_{38} + 40 \\cdot z_{39} \\\\\n",
+       "& \\text{subject to} \\quad && z_{0} + z_{1} \\le 1 \\\\\n",
+       "&  \\quad && z_{1} + z_{2} \\le 1 \\\\\n",
+       "&  \\quad && z_{2} + z_{3} \\le 1 \\\\\n",
+       "&  \\quad && z_{3} + z_{4} \\le 1 \\\\\n",
+       "&  \\quad && z_{4} + z_{5} \\le 1 \\\\\n",
+       "&  \\quad && z_{5} + z_{6} \\le 1 \\\\\n",
+       "&  \\quad && z_{6} + z_{7} \\le 1 \\\\\n",
+       "&  \\quad && z_{7} + z_{8} \\le 1 \\\\\n",
+       "&  \\quad && z_{8} + z_{9} \\le 1 \\\\\n",
+       "&  \\quad && z_{9} + z_{10} \\le 1 \\\\\n",
+       "&  \\quad && z_{10} + z_{11} \\le 1 \\\\\n",
+       "&  \\quad && z_{11} + z_{12} \\le 1 \\\\\n",
+       "&  \\quad && z_{12} + z_{13} \\le 1 \\\\\n",
+       "&  \\quad && z_{13} + z_{14} \\le 1 \\\\\n",
+       "&  \\quad && z_{14} + z_{15} \\le 1 \\\\\n",
+       "&  \\quad && z_{15} + z_{16} \\le 1 \\\\\n",
+       "&  \\quad && z_{16} + z_{17} \\le 1 \\\\\n",
+       "&  \\quad && z_{17} + z_{18} \\le 1 \\\\\n",
+       "&  \\quad && z_{18} + z_{19} \\le 1 \\\\\n",
+       "&  \\quad && z_{19} + z_{20} \\le 1 \\\\\n",
+       "&  \\quad && z_{20} + z_{21} \\le 1 \\\\\n",
+       "&  \\quad && z_{21} + z_{22} \\le 1 \\\\\n",
+       "&  \\quad && z_{22} + z_{23} \\le 1 \\\\\n",
+       "&  \\quad && z_{23} + z_{24} \\le 1 \\\\\n",
+       "&  \\quad && \\vdots \\quad (\\text{40 constraints}) \\\\\n",
+       "& \\text{with} \\quad && 40\\ \\text{binary} \\text{ variables} \\\\\n",
+       "\\end{aligned}\n",
+       "$$"
+      ],
+      "text/plain": [
+       "Model: assignment\n",
+       "  Variables: 40 (0 continuous, 40 integer/binary)\n",
+       "  Constraints: 40\n",
+       "  Objective: minimize ((((((((((((((((((((((((((((((((((((((((0 + (1 * z0)) + (2 * z1)) + (3 * z2)) + (4 * z3)) + (5 * z4)) + (6 * z5)) + (7 * z6)) + (8 * z7)) + (9 * z8)) + (10 * z9)) + (11 * z10)) + (12 * z11)) + (13 * z12)) + (14 * z13)) + (15 * z14)) + (16 * z15)) + (17 * z16)) + (18 * z17)) + (19 * z18)) + (20 * z19)) + (21 * z20)) + (22 * z21)) + (23 * z22)) + (24 * z23)) + (25 * z24)) + (26 * z25)) + (27 * z26)) + (28 * z27)) + (29 * z28)) + (30 * z29)) + (31 * z30)) + (32 * z31)) + (33 * z32)) + (34 * z33)) + (35 * z34)) + (36 * z35)) + (37 * z36)) + (38 * z37)) + (39 * z38)) + (40 * z39))\n",
+       "  Parameters: 0"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "big = dm.Model(\"assignment\")\n",
+    "z = [big.binary(f\"z{i}\") for i in range(40)]\n",
+    "big.minimize(sum((i + 1) * z[i] for i in range(40)))\n",
+    "for i in range(40):\n",
+    "    big.subject_to(z[i] + z[(i + 1) % 40] <= 1)\n",
+    "big  # truncated summary"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ddd91a4f",
+   "metadata": {},
+   "source": [
+    "## Exporting\n",
+    "\n",
+    "`to_latex()` returns a LaTeX `aligned` block; `to_html()` returns a self-contained HTML fragment (the LaTeX typeset via MathJax) with a header naming the model. Both take `max_rows` to control truncation. The plain-text `repr` / `Model.summary()` remain available for terminals and logging."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "744cec0e",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-29T01:35:35.661201Z",
+     "iopub.status.busy": "2026-06-29T01:35:35.661141Z",
+     "iopub.status.idle": "2026-06-29T01:35:35.662813Z",
+     "shell.execute_reply": "2026-06-29T01:35:35.662504Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "<div class=\"discopt-model\"><div style=\"font-weight:600\">Model <code>blend</code> <span style=\"color:#888;font-weight:400\">(2 variables, 2 constraints)</span></div>$$\n",
+      "\\begin{aligned}\n",
+      "& \\text{minimize} \\quad && \\left(x - 3\\right)^{2} + 2 \\cdot y \\\\\n",
+      "& \\text{subject to} \\quad && 4 \\le x + 5 \\cdot y \\\\\n",
+      "& ...\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(m.to_html()[:300], \"...\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.11"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/notebooks/model_representations.ipynb
+++ b/docs/notebooks/model_representations.ipynb
@@ -18,10 +18,10 @@
    "id": "466e952b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-29T01:35:35.608989Z",
-     "iopub.status.busy": "2026-06-29T01:35:35.608792Z",
-     "iopub.status.idle": "2026-06-29T01:35:35.650516Z",
-     "shell.execute_reply": "2026-06-29T01:35:35.650097Z"
+     "iopub.execute_input": "2026-06-29T10:42:10.488323Z",
+     "iopub.status.busy": "2026-06-29T10:42:10.487947Z",
+     "iopub.status.idle": "2026-06-29T10:42:10.554832Z",
+     "shell.execute_reply": "2026-06-29T10:42:10.554405Z"
     }
    },
    "outputs": [
@@ -39,6 +39,17 @@
        "$$</div>"
       ],
       "text/latex": [
+       "$$\n",
+       "\\begin{aligned}\n",
+       "& \\text{minimize} \\quad && \\left(x - 3\\right)^{2} + 2 \\cdot y \\\\\n",
+       "& \\text{subject to} \\quad && 4 \\le x + 5 \\cdot y \\\\\n",
+       "&  \\quad && \\exp\\!\\left(x\\right) \\le 100 \\\\\n",
+       "& \\text{with} \\quad && 0 \\le x \\le 10 \\\\\n",
+       "&  \\quad && y \\in \\{0, 1\\} \\\\\n",
+       "\\end{aligned}\n",
+       "$$"
+      ],
+      "text/markdown": [
        "$$\n",
        "\\begin{aligned}\n",
        "& \\text{minimize} \\quad && \\left(x - 3\\right)^{2} + 2 \\cdot y \\\\\n",
@@ -89,10 +100,10 @@
    "id": "bfeb6e27",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-29T01:35:35.651838Z",
-     "iopub.status.busy": "2026-06-29T01:35:35.651749Z",
-     "iopub.status.idle": "2026-06-29T01:35:35.653577Z",
-     "shell.execute_reply": "2026-06-29T01:35:35.653271Z"
+     "iopub.execute_input": "2026-06-29T10:42:10.556335Z",
+     "iopub.status.busy": "2026-06-29T10:42:10.556227Z",
+     "iopub.status.idle": "2026-06-29T10:42:10.558071Z",
+     "shell.execute_reply": "2026-06-29T10:42:10.557663Z"
     }
    },
    "outputs": [
@@ -130,10 +141,10 @@
    "id": "e60f9d81",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-29T01:35:35.654634Z",
-     "iopub.status.busy": "2026-06-29T01:35:35.654581Z",
-     "iopub.status.idle": "2026-06-29T01:35:35.656713Z",
-     "shell.execute_reply": "2026-06-29T01:35:35.656422Z"
+     "iopub.execute_input": "2026-06-29T10:42:10.559072Z",
+     "iopub.status.busy": "2026-06-29T10:42:10.558996Z",
+     "iopub.status.idle": "2026-06-29T10:42:10.561261Z",
+     "shell.execute_reply": "2026-06-29T10:42:10.560933Z"
     }
    },
    "outputs": [
@@ -150,6 +161,16 @@
        "$$</div>"
       ],
       "text/latex": [
+       "$$\n",
+       "\\begin{aligned}\n",
+       "& \\text{maximize} \\quad && \\frac{\\exp\\!\\left(a\\right)}{b + 1} \\\\\n",
+       "& \\text{subject to} \\quad && \\sqrt{a} + b^{2} \\le 10 \\\\\n",
+       "& \\text{with} \\quad && 1 \\le a \\le 5 \\\\\n",
+       "&  \\quad && 1 \\le b \\le 5 \\\\\n",
+       "\\end{aligned}\n",
+       "$$"
+      ],
+      "text/markdown": [
        "$$\n",
        "\\begin{aligned}\n",
        "& \\text{maximize} \\quad && \\frac{\\exp\\!\\left(a\\right)}{b + 1} \\\\\n",
@@ -197,10 +218,10 @@
    "id": "62f921ca",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-29T01:35:35.657791Z",
-     "iopub.status.busy": "2026-06-29T01:35:35.657736Z",
-     "iopub.status.idle": "2026-06-29T01:35:35.660149Z",
-     "shell.execute_reply": "2026-06-29T01:35:35.659840Z"
+     "iopub.execute_input": "2026-06-29T10:42:10.562343Z",
+     "iopub.status.busy": "2026-06-29T10:42:10.562279Z",
+     "iopub.status.idle": "2026-06-29T10:42:10.565141Z",
+     "shell.execute_reply": "2026-06-29T10:42:10.564770Z"
     }
    },
    "outputs": [
@@ -272,6 +293,39 @@
        "\\end{aligned}\n",
        "$$"
       ],
+      "text/markdown": [
+       "$$\n",
+       "\\begin{aligned}\n",
+       "& \\text{minimize} \\quad && 0 + 1 \\cdot z_{0} + 2 \\cdot z_{1} + 3 \\cdot z_{2} + 4 \\cdot z_{3} + 5 \\cdot z_{4} + 6 \\cdot z_{5} + 7 \\cdot z_{6} + 8 \\cdot z_{7} + 9 \\cdot z_{8} + 10 \\cdot z_{9} + 11 \\cdot z_{10} + 12 \\cdot z_{11} + 13 \\cdot z_{12} + 14 \\cdot z_{13} + 15 \\cdot z_{14} + 16 \\cdot z_{15} + 17 \\cdot z_{16} + 18 \\cdot z_{17} + 19 \\cdot z_{18} + 20 \\cdot z_{19} + 21 \\cdot z_{20} + 22 \\cdot z_{21} + 23 \\cdot z_{22} + 24 \\cdot z_{23} + 25 \\cdot z_{24} + 26 \\cdot z_{25} + 27 \\cdot z_{26} + 28 \\cdot z_{27} + 29 \\cdot z_{28} + 30 \\cdot z_{29} + 31 \\cdot z_{30} + 32 \\cdot z_{31} + 33 \\cdot z_{32} + 34 \\cdot z_{33} + 35 \\cdot z_{34} + 36 \\cdot z_{35} + 37 \\cdot z_{36} + 38 \\cdot z_{37} + 39 \\cdot z_{38} + 40 \\cdot z_{39} \\\\\n",
+       "& \\text{subject to} \\quad && z_{0} + z_{1} \\le 1 \\\\\n",
+       "&  \\quad && z_{1} + z_{2} \\le 1 \\\\\n",
+       "&  \\quad && z_{2} + z_{3} \\le 1 \\\\\n",
+       "&  \\quad && z_{3} + z_{4} \\le 1 \\\\\n",
+       "&  \\quad && z_{4} + z_{5} \\le 1 \\\\\n",
+       "&  \\quad && z_{5} + z_{6} \\le 1 \\\\\n",
+       "&  \\quad && z_{6} + z_{7} \\le 1 \\\\\n",
+       "&  \\quad && z_{7} + z_{8} \\le 1 \\\\\n",
+       "&  \\quad && z_{8} + z_{9} \\le 1 \\\\\n",
+       "&  \\quad && z_{9} + z_{10} \\le 1 \\\\\n",
+       "&  \\quad && z_{10} + z_{11} \\le 1 \\\\\n",
+       "&  \\quad && z_{11} + z_{12} \\le 1 \\\\\n",
+       "&  \\quad && z_{12} + z_{13} \\le 1 \\\\\n",
+       "&  \\quad && z_{13} + z_{14} \\le 1 \\\\\n",
+       "&  \\quad && z_{14} + z_{15} \\le 1 \\\\\n",
+       "&  \\quad && z_{15} + z_{16} \\le 1 \\\\\n",
+       "&  \\quad && z_{16} + z_{17} \\le 1 \\\\\n",
+       "&  \\quad && z_{17} + z_{18} \\le 1 \\\\\n",
+       "&  \\quad && z_{18} + z_{19} \\le 1 \\\\\n",
+       "&  \\quad && z_{19} + z_{20} \\le 1 \\\\\n",
+       "&  \\quad && z_{20} + z_{21} \\le 1 \\\\\n",
+       "&  \\quad && z_{21} + z_{22} \\le 1 \\\\\n",
+       "&  \\quad && z_{22} + z_{23} \\le 1 \\\\\n",
+       "&  \\quad && z_{23} + z_{24} \\le 1 \\\\\n",
+       "&  \\quad && \\vdots \\quad (\\text{40 constraints}) \\\\\n",
+       "& \\text{with} \\quad && 40\\ \\text{binary} \\text{ variables} \\\\\n",
+       "\\end{aligned}\n",
+       "$$"
+      ],
       "text/plain": [
        "Model: assignment\n",
        "  Variables: 40 (0 continuous, 40 integer/binary)\n",
@@ -310,10 +364,10 @@
    "id": "744cec0e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-29T01:35:35.661201Z",
-     "iopub.status.busy": "2026-06-29T01:35:35.661141Z",
-     "iopub.status.idle": "2026-06-29T01:35:35.662813Z",
-     "shell.execute_reply": "2026-06-29T01:35:35.662504Z"
+     "iopub.execute_input": "2026-06-29T10:42:10.566163Z",
+     "iopub.status.busy": "2026-06-29T10:42:10.566101Z",
+     "iopub.status.idle": "2026-06-29T10:42:10.567650Z",
+     "shell.execute_reply": "2026-06-29T10:42:10.567316Z"
     }
    },
    "outputs": [

--- a/python/discopt/_jax/envelopes.py
+++ b/python/discopt/_jax/envelopes.py
@@ -11,12 +11,16 @@ and are compatible with jax.jit, jax.grad, and jax.vmap.
 
 from __future__ import annotations
 
+from itertools import combinations
+
 import jax.numpy as jnp
 
 from discopt._jax.mccormick import (
     _secant,
     relax_bilinear,
 )
+
+_TRILINEAR_FACET_CANDIDATES = jnp.array(tuple(combinations(range(8), 4)), dtype=jnp.int32)
 
 
 def relax_trilinear(x, y, z, x_lb, x_ub, y_lb, y_ub, z_lb, z_ub):
@@ -116,6 +120,55 @@ def relax_trilinear_exact(x, y, z, x_lb, x_ub, y_lb, y_ub, z_lb, z_ub):
     cv = jnp.maximum(jnp.maximum(cv1, cv2), cv3)
     cc = jnp.minimum(jnp.minimum(cc1, cc2), cc3)
     return cv, cc
+
+
+def relax_trilinear_meyer_floudas(x, y, z, x_lb, x_ub, y_lb, y_ub, z_lb, z_ub):
+    """Meyer-Floudas/Rikun convex-hull relaxation for ``x * y * z``.
+
+    The hull of the trilinear graph over a box is represented by affine
+    facets through subsets of the eight box vertices. This implementation
+    enumerates the candidate four-vertex facets in pure JAX, keeps the global
+    lower and upper supporting planes, and evaluates the tightest bounds at
+    ``(x, y, z)``. The result is merged with the best-of-three nested
+    McCormick envelope, preserving the historical pointwise tightening used by
+    this module while adding the missing hull facets.
+    """
+    verts = jnp.stack(
+        [
+            jnp.stack([x_lb, y_lb, z_lb]),
+            jnp.stack([x_lb, y_lb, z_ub]),
+            jnp.stack([x_lb, y_ub, z_lb]),
+            jnp.stack([x_lb, y_ub, z_ub]),
+            jnp.stack([x_ub, y_lb, z_lb]),
+            jnp.stack([x_ub, y_lb, z_ub]),
+            jnp.stack([x_ub, y_ub, z_lb]),
+            jnp.stack([x_ub, y_ub, z_ub]),
+        ]
+    )
+    values = verts[:, 0] * verts[:, 1] * verts[:, 2]
+    ones = jnp.ones((verts.shape[0], 1), dtype=verts.dtype)
+    aug_verts = jnp.concatenate([verts, ones], axis=1)
+
+    a = aug_verts[_TRILINEAR_FACET_CANDIDATES]
+    b = values[_TRILINEAR_FACET_CANDIDATES]
+    det = jnp.linalg.det(a)
+    nonsingular = jnp.abs(det) > 1e-12
+    safe_a = jnp.where(nonsingular[:, None, None], a, jnp.eye(4, dtype=verts.dtype))
+    safe_b = jnp.where(nonsingular[:, None], b, jnp.zeros_like(b))
+    coeffs = jnp.linalg.solve(safe_a, safe_b[..., None]).squeeze(-1)
+
+    residual = aug_verts @ coeffs.T - values[:, None]
+    tol = 1e-9 * (1.0 + jnp.max(jnp.abs(values)))
+    lower_facet = nonsingular & jnp.all(residual <= tol, axis=0)
+    upper_facet = nonsingular & jnp.all(residual >= -tol, axis=0)
+
+    point = jnp.stack([x, y, z, jnp.array(1.0, dtype=verts.dtype)])
+    plane_values = coeffs @ point
+    hull_cv = jnp.max(jnp.where(lower_facet, plane_values, -jnp.inf))
+    hull_cc = jnp.min(jnp.where(upper_facet, plane_values, jnp.inf))
+
+    nested_cv, nested_cc = relax_trilinear_exact(x, y, z, x_lb, x_ub, y_lb, y_ub, z_lb, z_ub)
+    return jnp.maximum(hull_cv, nested_cv), jnp.minimum(hull_cc, nested_cc)
 
 
 def relax_fractional(x, y, x_lb, x_ub, y_lb, y_ub):

--- a/python/discopt/_jax/relaxation_compiler.py
+++ b/python/discopt/_jax/relaxation_compiler.py
@@ -565,20 +565,25 @@ def _compile_relax_node(
                     return fn
 
             # Trilinear pattern detection: x*y*z over 3 distinct scalar
-            # Variables. Routes to permutation-symmetric nested McCormick
-            # (relax_trilinear_exact) which is strictly tighter than the
-            # default single-ordering bilinear chain. Validity requires
-            # finite box bounds at runtime; otherwise the dispatch falls
-            # through to the bilinear path via `jnp.where`.
+            # Variables. Routes to the Meyer-Floudas/Rikun convex-hull
+            # envelope by default, with debug selectors for the older
+            # best-of-three and nested-bilinear paths.
             #
             # Opt-out: setting DISCOPT_TRILINEAR=nested in the environment
             # skips this dispatch and uses the original nested-bilinear
-            # path. This is for debug / parity testing only and is not a
-            # public API.
-            _trilinear_disabled = _tuning().trilinear_nested
-            tri_offsets = None if _trilinear_disabled else _try_extract_trilinear_chain(expr, model)
+            # path. Setting DISCOPT_TRILINEAR=exact selects the historical
+            # permutation-symmetric nested McCormick path.
+            tuning = _tuning()
+            tri_offsets = (
+                None if tuning.trilinear_nested else _try_extract_trilinear_chain(expr, model)
+            )
             if tri_offsets is not None:
-                from discopt._jax.envelopes import relax_trilinear_exact
+                if tuning.trilinear_exact:
+                    from discopt._jax.envelopes import relax_trilinear_exact as _relax_trilinear
+                else:
+                    from discopt._jax.envelopes import (
+                        relax_trilinear_meyer_floudas as _relax_trilinear,
+                    )
 
                 _ti, _tj, _tk = tri_offsets
 
@@ -594,7 +599,7 @@ def _compile_relax_node(
                     xv = 0.5 * (x_lb_ + x_ub_)
                     yv = 0.5 * (y_lb_ + y_ub_)
                     zv = 0.5 * (z_lb_ + z_ub_)
-                    return relax_trilinear_exact(
+                    return _relax_trilinear(
                         xv,
                         yv,
                         zv,

--- a/python/discopt/modeling/core.py
+++ b/python/discopt/modeling/core.py
@@ -2801,9 +2801,11 @@ class Model:
             ``ecp_mode``, ``feasibility_cuts``, ``heuristic_nonconvex``,
             ``add_slack``, ``max_slack``, ``oa_penalty_factor``,
             ``add_no_good_cuts``, ``feasibility_norm``, ``add_regularization``,
-            ``level_coef``, ``stalling_limit``, ``cycling_check``, and
-            ``init_strategy`` take precedence over duplicate keys in
-            ``mip_nlp_options``. For ``mip_nlp_method="goa"``,
+            ``level_coef``, ``stalling_limit``, ``cycling_check``,
+            ``solution_pool``, ``num_solution_iteration``, and ``init_strategy``
+            take precedence over duplicate keys in ``mip_nlp_options``.
+            ``solution_pool`` currently requires ``milp_solver="gurobi"``.
+            For ``mip_nlp_method="goa"``,
             convexity-certified MINLPs use OA's valid master bounds and other
             models use AMP/global relaxations. AMP options such as ``rel_gap``,
             ``abs_tol``, ``max_iter``, ``n_init_partitions``,

--- a/python/discopt/modeling/core.py
+++ b/python/discopt/modeling/core.py
@@ -1447,6 +1447,15 @@ class Model:
 
         return f"$$\n{latex.model_to_latex(self, max_rows=latex._DEFAULT_MAX_ROWS)}\n$$"
 
+    def _repr_markdown_(self) -> str:
+        # VS Code's notebook renderer typesets ``text/markdown`` outputs with
+        # KaTeX but does not reliably render ``text/latex`` outputs; emit the
+        # same PSE block as fenced display math so it renders there too.
+        # Jupyter/MathJax frontends prefer ``_repr_latex_``/``_repr_html_``.
+        from discopt.modeling import latex
+
+        return f"$$\n{latex.model_to_latex(self, max_rows=latex._DEFAULT_MAX_ROWS)}\n$$"
+
     def _repr_html_(self) -> str:
         from discopt.modeling import latex
 

--- a/python/discopt/modeling/core.py
+++ b/python/discopt/modeling/core.py
@@ -1419,6 +1419,39 @@ class Model:
         self._builder_linear_objective: Optional[tuple] = None
         self._builder_quadratic_objective: Optional[tuple] = None
 
+    # ── Rich representation (LaTeX / HTML in standard PSE form) ──
+
+    def to_latex(self, max_rows: Optional[int] = None) -> str:
+        """Render the model as a LaTeX ``aligned`` block in standard problem form
+        (``minimize f(x)`` / ``subject to g(x) <= 0`` / variable domains).
+
+        Parameters
+        ----------
+        max_rows : int, optional
+            Cap on the number of constraint/variable rows shown; excess is
+            summarised with a ``\\vdots`` row. ``None`` (default) renders everything.
+        """
+        from discopt.modeling import latex
+
+        return latex.model_to_latex(self, max_rows=max_rows)
+
+    def to_html(self, max_rows: Optional[int] = None) -> str:
+        """Render the model as standalone HTML (the PSE LaTeX typeset via MathJax,
+        with a header naming the model and its size). See :meth:`to_latex`."""
+        from discopt.modeling import latex
+
+        return latex.model_to_html(self, max_rows=max_rows)
+
+    def _repr_latex_(self) -> str:
+        from discopt.modeling import latex
+
+        return f"$$\n{latex.model_to_latex(self, max_rows=latex._DEFAULT_MAX_ROWS)}\n$$"
+
+    def _repr_html_(self) -> str:
+        from discopt.modeling import latex
+
+        return latex.model_to_html(self, max_rows=latex._DEFAULT_MAX_ROWS)
+
     # ── Index sets ──
 
     def set(self, name: str, members, dimen: Optional[int] = None):

--- a/python/discopt/modeling/latex.py
+++ b/python/discopt/modeling/latex.py
@@ -1,0 +1,260 @@
+"""Rich rendering of :class:`~discopt.modeling.core.Model` objects.
+
+Produces LaTeX (and MathJax-backed HTML) in **standard PSE problem form**::
+
+    minimize/maximize   f(x)
+    subject to          g_i(x)  <=/>=/=  c_i
+                        bounds and integrality on the variables
+
+A small recursive visitor maps the expression DAG to LaTeX with minimal
+parenthesisation (operator precedence), proper superscripts/fractions/function
+names, and variable subscripts. Large models are summarised so an auto-rendered
+``_repr_`` cannot flood a notebook; the public ``model_to_latex`` / ``model_to_html``
+take ``max_rows=None`` for the full, untruncated form.
+
+Imported lazily by ``core.Model`` (the ``to_latex``/``_repr_latex_`` methods) to
+avoid a circular import.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+import numpy as np
+
+from discopt.modeling.core import (
+    BinaryOp,
+    Constant,
+    CustomCall,
+    Expression,
+    FunctionCall,
+    IndexExpression,
+    MatMulExpression,
+    SumExpression,
+    UnaryOp,
+    Variable,
+)
+
+# Default number of constraint / variable rows shown in an auto ``_repr_``.
+_DEFAULT_MAX_ROWS = 24
+
+# LaTeX renderings for known unary/elementary functions; ``None`` => special-cased.
+_FUNC_LATEX = {
+    "exp": r"\exp",
+    "log": r"\ln",
+    "log10": r"\log_{10}",
+    "sqrt": None,  # \sqrt{...}
+    "sin": r"\sin",
+    "cos": r"\cos",
+    "tan": r"\tan",
+    "sinh": r"\sinh",
+    "cosh": r"\cosh",
+    "tanh": r"\tanh",
+    "abs": None,  # \left|...\right|
+}
+
+# Binary-operator precedence (higher binds tighter) for minimal parenthesisation.
+_PREC = {"+": 1, "-": 1, "*": 2, "/": 2, "@": 2, "**": 4}
+
+
+def _fmt_num(v: float) -> str:
+    f = float(v)
+    if f == int(f) and abs(f) < 1e15:
+        return str(int(f))
+    return f"{f:.6g}"
+
+
+def _const_to_latex(value: Any) -> str:
+    """Render a constant: scalars as numbers, small vectors/matrices inline, and
+    larger arrays as a shape-annotated bold placeholder (the model does not name
+    numpy coefficients, so a shaped placeholder is the most honest compact form)."""
+    arr = np.asarray(value)
+    if arr.ndim == 0:
+        return _fmt_num(float(arr))
+    if arr.size <= 6 and arr.ndim == 1:
+        return r"\begin{bmatrix}" + r" \\ ".join(_fmt_num(x) for x in arr) + r"\end{bmatrix}"
+    if arr.size <= 6 and arr.ndim == 2:
+        return (
+            r"\begin{bmatrix}"
+            + r" \\ ".join(" & ".join(_fmt_num(x) for x in row) for row in arr)
+            + r"\end{bmatrix}"
+        )
+    shape = r"{\times}".join(str(d) for d in arr.shape)
+    return rf"\mathbf{{C}}_{{[{shape}]}}"
+
+
+def _sym(name: str) -> str:
+    """Render a variable name: ``x3`` -> ``x_{3}``; escape underscores otherwise."""
+    m = re.fullmatch(r"([A-Za-z]+)(\d+)", name)
+    if m:
+        return f"{m.group(1)}_{{{m.group(2)}}}"
+    return name.replace("_", r"\_")
+
+
+def expr_to_latex(e: Any, parent_prec: int = 0) -> str:
+    """Render an expression DAG node to LaTeX. Never raises — unknown nodes fall
+    back to an escaped string form so a display can't crash a model build."""
+    try:
+        if isinstance(e, Constant):
+            return _const_to_latex(e.value)
+        if isinstance(e, Variable):
+            return _sym(e.name)
+        if isinstance(e, IndexExpression):
+            idx = e.index
+            idx_s = ",".join(str(i) for i in idx) if isinstance(idx, tuple) else str(idx)
+            return f"{expr_to_latex(e.base, 5)}_{{{idx_s}}}"
+        if isinstance(e, BinaryOp):
+            return _binop_to_latex(e, parent_prec)
+        if isinstance(e, UnaryOp):
+            if e.op == "neg":
+                return f"-{expr_to_latex(e.operand, 3)}"
+            if e.op == "abs":
+                return rf"\left|{expr_to_latex(e.operand)}\right|"
+            return rf"\mathrm{{{e.op}}}\!\left({expr_to_latex(e.operand)}\right)"
+        if isinstance(e, FunctionCall):
+            args = ", ".join(expr_to_latex(a) for a in e.args)
+            if e.func_name == "sqrt":
+                return rf"\sqrt{{{args}}}"
+            name = _FUNC_LATEX.get(e.func_name) or rf"\mathrm{{{_sym(str(e.func_name))}}}"
+            return rf"{name}\!\left({args}\right)"
+        if isinstance(e, CustomCall):
+            args = ", ".join(expr_to_latex(a) for a in e.args)
+            return rf"\mathrm{{{_sym(str(e.name))}}}\!\left({args}\right)"
+        if isinstance(e, MatMulExpression):
+            return f"{expr_to_latex(e.left, 2)}\\,{expr_to_latex(e.right, 2)}"
+        if isinstance(e, SumExpression):
+            return rf"\textstyle\sum {expr_to_latex(e.operand, 3)}"
+        if isinstance(e, Expression):
+            return _escape_text(repr(e))
+        return _fmt_num(e) if _is_number(e) else _escape_text(str(e))
+    except Exception:
+        return _escape_text(repr(e))
+
+
+def _binop_to_latex(e: Any, parent_prec: int) -> str:
+    op = e.op
+    if op == "/":
+        return rf"\frac{{{expr_to_latex(e.left)}}}{{{expr_to_latex(e.right)}}}"
+    if op == "**":
+        return f"{expr_to_latex(e.left, 5)}^{{{expr_to_latex(e.right)}}}"
+    prec = _PREC.get(op, 1)
+    left = expr_to_latex(e.left, prec)
+    # right operand of a non-associative op needs one extra precedence level
+    right = expr_to_latex(e.right, prec + (1 if op in ("-", "/") else 0))
+    sym = {"+": "+", "-": "-", "*": r"\cdot", "@": r"\,"}[op]
+    s = f"{left} {sym} {right}"
+    if prec < parent_prec:
+        return rf"\left({s}\right)"
+    return s
+
+
+def _constraint_to_latex(c: Any) -> str:
+    """Render a constraint. Constraints are normalised to ``body sense 0``; when the
+    body is a top-level subtraction ``L - R`` we un-normalise to ``L sense R`` for a
+    natural reading (e.g. ``x + 5y >= 4`` instead of ``4 - (x + 5y) <= 0``)."""
+    sense = {"<=": r"\le", ">=": r"\ge", "==": "="}.get(c.sense, c.sense)
+    body = c.body
+    if isinstance(body, BinaryOp) and body.op == "-":
+        return f"{expr_to_latex(body.left)} {sense} {expr_to_latex(body.right)}"
+    rhs = _fmt_num(c.rhs) if getattr(c, "rhs", 0.0) else "0"
+    return f"{expr_to_latex(body)} {sense} {rhs}"
+
+
+def _var_domain_to_latex(v: Any) -> str:
+    vtype = v.var_type.value if hasattr(v.var_type, "value") else str(v.var_type)
+    lb = float(np.min(v.lb))
+    ub = float(np.max(v.ub))
+    big = 1e15
+    name = _sym(v.name) + (r"_{i}" if getattr(v, "size", 1) > 1 else "")
+    if vtype == "binary":
+        return rf"{name} \in \{{0, 1\}}"
+    if lb > -big and ub < big:
+        rng = rf"{_fmt_num(lb)} \le {name} \le {_fmt_num(ub)}"
+    elif lb > -big:
+        rng = rf"{name} \ge {_fmt_num(lb)}"
+    elif ub < big:
+        rng = rf"{name} \le {_fmt_num(ub)}"
+    else:
+        rng = ""
+    domain = {"integer": r"\mathbb{Z}", "continuous": r"\mathbb{R}"}.get(vtype, "")
+    if vtype == "integer":
+        return rf"{rng},\ {name} \in \mathbb{{Z}}" if rng else rf"{name} \in \mathbb{{Z}}"
+    return rng or rf"{name} \in {domain}"
+
+
+def model_to_latex(model: Any, max_rows: int | None = None, env: str = "aligned") -> str:
+    """Render *model* to a LaTeX ``aligned`` block in standard PSE form.
+
+    ``max_rows`` caps the number of constraint and variable rows shown (``None`` =
+    no limit); excess is replaced with a ``\\vdots`` summary row.
+    """
+    rows: list[str] = []
+    obj = getattr(model, "_objective", None)
+    if obj is not None:
+        sense = "minimize" if obj.sense.value == "minimize" else "maximize"
+        rows.append(rf"& \text{{{sense}}} \quad && {expr_to_latex(obj.expression)} \\")
+    else:
+        rows.append(r"& \text{find} \quad && x \\")
+
+    cons = list(getattr(model, "_constraints", []) or [])
+    shown = cons if max_rows is None else cons[:max_rows]
+    for i, c in enumerate(shown):
+        lead = r"\text{subject to}" if i == 0 else ""
+        rows.append(rf"& {lead} \quad && {_constraint_to_latex(c)} \\")
+    if max_rows is not None and len(cons) > max_rows:
+        lead = r"\text{subject to}" if not shown else ""
+        rows.append(rf"& {lead} \quad && \vdots \quad (\text{{{len(cons)} constraints}}) \\")
+
+    variables = list(getattr(model, "_variables", []) or [])
+    rows.extend(_variable_rows(variables, max_rows))
+    body = "\n".join(rows)
+    return f"\\begin{{{env}}}\n{body}\n\\end{{{env}}}"
+
+
+def _variable_rows(variables: list, max_rows: int | None) -> list[str]:
+    if not variables:
+        return []
+    if max_rows is not None and len(variables) > max_rows:
+        # Summarise by type rather than listing hundreds of declarations.
+        counts: dict[str, int] = {}
+        for v in variables:
+            t = v.var_type.value if hasattr(v.var_type, "value") else str(v.var_type)
+            counts[t] = counts.get(t, 0) + 1
+        parts = ", ".join(f"{n}\\ \\text{{{t}}}" for t, n in counts.items())
+        return [rf"& \text{{with}} \quad && {parts} \text{{ variables}} \\"]
+    out = []
+    for j, v in enumerate(variables):
+        lead = r"\text{with}" if j == 0 else ""
+        out.append(rf"& {lead} \quad && {_var_domain_to_latex(v)} \\")
+    return out
+
+
+def model_to_html(model: Any, max_rows: int | None = None) -> str:
+    """Standalone HTML rendering: a titled block with the PSE LaTeX rendered via the
+    notebook's MathJax. Falls back gracefully to showing the LaTeX source."""
+    name = getattr(model, "name", "model")
+    n_v = len(getattr(model, "_variables", []) or [])
+    n_c = len(getattr(model, "_constraints", []) or [])
+    latex = model_to_latex(model, max_rows=max_rows)
+    return (
+        f'<div class="discopt-model">'
+        f'<div style="font-weight:600">Model <code>{_escape_text(str(name))}</code>'
+        f' <span style="color:#888;font-weight:400">'
+        f"({n_v} variable{'s' if n_v != 1 else ''}, "
+        f"{n_c} constraint{'s' if n_c != 1 else ''})</span></div>"
+        f"$$\n{latex}\n$$"
+        f"</div>"
+    )
+
+
+def _escape_text(s: str) -> str:
+    return (
+        s.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;")
+        if "<" in s or ">" in s or "&" in s
+        else s
+    )
+
+
+def _is_number(x: Any) -> bool:
+    return isinstance(x, (int, float, np.integer, np.floating))

--- a/python/discopt/solver.py
+++ b/python/discopt/solver.py
@@ -2236,9 +2236,11 @@ def solve_model(
         ``feasibility_cuts``, ``heuristic_nonconvex``, ``add_slack``,
         ``max_slack``, ``oa_penalty_factor``, ``add_no_good_cuts``,
         ``feasibility_norm``, ``add_regularization``, ``level_coef``,
-        ``stalling_limit``, ``cycling_check``, and ``milp_solver`` plus
-        initialization option ``init_strategy`` may be passed as top-level
-        aliases and take precedence over duplicate keys in ``mip_nlp_options``.
+        ``stalling_limit``, ``cycling_check``, ``solution_pool``,
+        ``num_solution_iteration``, and ``milp_solver`` plus initialization
+        option ``init_strategy`` may be passed as top-level aliases and take
+        precedence over duplicate keys in ``mip_nlp_options``. ``solution_pool``
+        currently requires ``milp_solver="gurobi"``.
         For ``mip_nlp_method="goa"``, convexity-certified MINLPs use OA's
         valid master bounds and other models use AMP/global relaxations.
         AMP options such as ``rel_gap``, ``abs_tol``, ``max_iter``,
@@ -2439,6 +2441,8 @@ def solve_model(
             "stalling_limit",
             "cycling_check",
             "milp_solver",
+            "solution_pool",
+            "num_solution_iteration",
         ):
             if key in kwargs:
                 mip_nlp_kwargs[key] = kwargs.pop(key)
@@ -2790,6 +2794,8 @@ def solve_model(
             "stalling_limit",
             "cycling_check",
             "milp_solver",
+            "solution_pool",
+            "num_solution_iteration",
         ):
             if key in kwargs:
                 mip_nlp_kwargs[key] = kwargs.pop(key)

--- a/python/discopt/solver_tuning.py
+++ b/python/discopt/solver_tuning.py
@@ -79,6 +79,12 @@ class SolverTuning:
     """Use nested bilinear instead of the tight trilinear envelope
     (``DISCOPT_TRILINEAR=nested``, default off)."""
 
+    trilinear_exact: bool = field(
+        default_factory=lambda: os.environ.get("DISCOPT_TRILINEAR") == "exact"
+    )
+    """Use the best-of-three nested trilinear envelope instead of Meyer-Floudas
+    (``DISCOPT_TRILINEAR=exact``, default off)."""
+
     trilinear_rlt: bool = field(
         default_factory=lambda: _env_flag("DISCOPT_TRILINEAR_RLT", default=True)
     )

--- a/python/discopt/solvers/__init__.py
+++ b/python/discopt/solvers/__init__.py
@@ -72,6 +72,8 @@ class MILPResult:
     MUST read ``bound``, never ``objective`` — using the incumbent as a lower
     bound can inflate the global LB past the true optimum and falsely certify
     optimality. ``bound`` is ``None`` when no valid dual bound is available.
+    ``solution_pool`` and ``solution_pool_objectives`` are populated only by
+    backends that explicitly expose multiple incumbent solutions.
     """
 
     status: SolveStatus
@@ -82,6 +84,8 @@ class MILPResult:
     node_count: int = 0
     iterations: int = 0
     wall_time: float = 0.0
+    solution_pool: Optional[list[np.ndarray]] = None
+    solution_pool_objectives: Optional[list[float]] = None
 
 
 @dataclass

--- a/python/discopt/solvers/gurobi.py
+++ b/python/discopt/solvers/gurobi.py
@@ -245,6 +245,42 @@ def _safe_attr(obj, name: str):
         return None
 
 
+def _safe_solver_attr(obj, name: str):
+    value = _safe_attr(obj, name)
+    if value is not None:
+        return value
+    get_attr = _safe_attr(obj, "getAttr")
+    if get_attr is None:
+        return None
+    try:
+        return get_attr(name)
+    except Exception:
+        return None
+
+
+def _collect_solution_pool(model, x, limit: int) -> tuple[list[np.ndarray], list[float]]:
+    """Return up to ``limit`` Gurobi pool solutions sorted by objective."""
+    sol_count = int(_safe_attr(model, "SolCount") or 0)
+    if sol_count <= 0:
+        return [], []
+
+    candidates: list[tuple[float, np.ndarray]] = []
+    for solution_number in range(min(sol_count, int(limit))):
+        model.setParam("SolutionNumber", solution_number)
+        x_pool = _safe_solver_attr(x, "Xn")
+        if x_pool is None and solution_number == 0:
+            x_pool = _safe_solver_attr(x, "X")
+        obj_pool = _safe_attr(model, "PoolObjVal")
+        if obj_pool is None and solution_number == 0:
+            obj_pool = _safe_attr(model, "ObjVal")
+        if x_pool is None or obj_pool is None:
+            continue
+        candidates.append((float(obj_pool), np.asarray(x_pool, dtype=np.float64).ravel()))
+
+    candidates.sort(key=lambda item: item[0])
+    return [candidate for _obj, candidate in candidates], [obj for obj, _candidate in candidates]
+
+
 def _build_model(
     gp,
     GRB,
@@ -393,10 +429,16 @@ def solve_milp(
     gap_tolerance: float = 1e-4,
     threads: Optional[int] = None,
     options: Optional[dict] = None,
+    solution_pool: bool = False,
+    num_solution_iteration: int = 5,
 ) -> MILPResult:
     """Solve a mixed-integer linear program using Gurobi."""
     c_arr, _n = _validate_linear_data(c, A_ub, b_ub, A_eq, b_eq, bounds)
     gp, GRB = _load_gurobi()
+    merged_options = dict(options or {})
+    if solution_pool:
+        merged_options.setdefault("PoolSearchMode", 2)
+        merged_options.setdefault("PoolSolutions", max(1, int(num_solution_iteration)))
 
     env, model, x, _ub_con, _eq_con = _build_model(
         gp,
@@ -412,7 +454,7 @@ def solve_milp(
         time_limit=time_limit,
         gap_tolerance=gap_tolerance,
         threads=threads,
-        options=options,
+        options=merged_options,
     )
     try:
         status_code = _optimize(model, GRB)
@@ -425,6 +467,15 @@ def solve_milp(
         if int(_safe_attr(model, "SolCount") or 0) > 0:
             objective = float(model.ObjVal)
             x_val = np.asarray(x.X, dtype=np.float64).ravel()
+
+        pool_x = None
+        pool_obj = None
+        if solution_pool:
+            pool_x, pool_obj = _collect_solution_pool(
+                model,
+                x,
+                max(1, int(num_solution_iteration)),
+            )
 
         bound = _safe_attr(model, "ObjBound")
         bound = float(bound) if bound is not None and np.isfinite(bound) else None
@@ -441,6 +492,8 @@ def solve_milp(
                 gap=0.0,
                 node_count=node_count,
                 wall_time=wall_time,
+                solution_pool=pool_x,
+                solution_pool_objectives=pool_obj,
             )
 
         return MILPResult(
@@ -451,6 +504,8 @@ def solve_milp(
             gap=gap,
             node_count=node_count,
             wall_time=wall_time,
+            solution_pool=pool_x,
+            solution_pool_objectives=pool_obj,
         )
     finally:
         model.dispose()

--- a/python/discopt/solvers/mip_nlp.py
+++ b/python/discopt/solvers/mip_nlp.py
@@ -32,6 +32,8 @@ _OA_OPTION_KEYS = frozenset(
         "stalling_limit",
         "cycling_check",
         "milp_solver",
+        "solution_pool",
+        "num_solution_iteration",
     }
 )
 _OA_OPTION_ALIASES = {

--- a/python/discopt/solvers/oa.py
+++ b/python/discopt/solvers/oa.py
@@ -143,6 +143,22 @@ def _normalize_optional_positive_int(name: str, value: Optional[int]) -> Optiona
     return out
 
 
+def _normalize_positive_int(name: str, value: int) -> int:
+    """Validate a positive integer option."""
+    out = int(value)
+    if out <= 0:
+        raise ValueError(f"{name} must be a positive integer, got {value!r}.")
+    return out
+
+
+def _require_solution_pool_backend(milp_solver: str) -> None:
+    if not isinstance(milp_solver, str) or milp_solver.strip().lower() != "gurobi":
+        raise RuntimeError(
+            "OA solution_pool=True requires milp_solver='gurobi' because only "
+            "the Gurobi backend currently exposes a MIP solution pool."
+        )
+
+
 def _qp_regularization_backend_error(add_regularization: str) -> RuntimeError:
     return RuntimeError(
         f"OA {add_regularization} regularization requires a QP/MIQP-capable backend "
@@ -1453,6 +1469,46 @@ def _build_master_milp_data(
     )
 
 
+def _master_solution_candidates(
+    master_result,
+    n_vars: int,
+    *,
+    solution_pool: bool,
+    num_solution_iteration: int,
+) -> list[np.ndarray]:
+    """Return original-variable master candidates for one OA iteration."""
+    if master_result.x is None:
+        return []
+
+    incumbent = np.asarray(master_result.x, dtype=np.float64).ravel()
+    if not solution_pool:
+        return [incumbent[:n_vars].copy()]
+
+    raw_pool = list(master_result.solution_pool or [])
+    if not raw_pool:
+        raw_pool = [incumbent]
+    elif not any(
+        np.allclose(np.asarray(candidate, dtype=np.float64).ravel()[:n_vars], incumbent[:n_vars])
+        for candidate in raw_pool
+        if np.asarray(candidate, dtype=np.float64).ravel().size >= n_vars
+    ):
+        raw_pool.insert(0, incumbent)
+
+    candidates: list[np.ndarray] = []
+    for raw_candidate in raw_pool:
+        arr = np.asarray(raw_candidate, dtype=np.float64).ravel()
+        if arr.size < n_vars:
+            continue
+        x_candidate = arr[:n_vars].copy()
+        if any(np.allclose(x_candidate, existing) for existing in candidates):
+            continue
+        candidates.append(x_candidate)
+        if len(candidates) >= num_solution_iteration:
+            break
+
+    return candidates or [incumbent[:n_vars].copy()]
+
+
 def _solve_master_milp(
     linear_A_rows,
     linear_b_rows,
@@ -1474,12 +1530,18 @@ def _solve_master_milp(
     oa_cut_relaxable=None,
     use_objective_epigraph=None,
     milp_solver="auto",
+    solution_pool=False,
+    num_solution_iteration=5,
 ):
     """Build and solve the master MILP."""
     try:
-        from discopt.solvers.lp_backend import get_milp_solver
+        if solution_pool:
+            _require_solution_pool_backend(milp_solver)
+            from discopt.solvers.gurobi import solve_milp
+        else:
+            from discopt.solvers.lp_backend import get_milp_solver
 
-        solve_milp = get_milp_solver(backend=milp_solver)
+            solve_milp = get_milp_solver(backend=milp_solver)
     except ImportError as e:
         raise ImportError(
             "OA solver requires a MILP backend for the master. Install one of: "
@@ -1516,6 +1578,18 @@ def _solve_master_milp(
         integrality=master.integrality,
         time_limit=time_limit,
         gap_tolerance=gap_tolerance,
+        **(
+            {
+                "options": {
+                    "PoolSearchMode": 2,
+                    "PoolSolutions": max(1, int(num_solution_iteration)),
+                },
+                "solution_pool": True,
+                "num_solution_iteration": max(1, int(num_solution_iteration)),
+            }
+            if solution_pool
+            else {}
+        ),
     )
 
 
@@ -2428,6 +2502,8 @@ def solve_oa(
     stalling_limit: Optional[int] = None,
     cycling_check: bool = False,
     milp_solver: str = "auto",
+    solution_pool: bool = False,
+    num_solution_iteration: int = 5,
     **kwargs,
 ) -> SolveResult:
     """Solve a MINLP via Outer Approximation.
@@ -2509,6 +2585,13 @@ def solve_oa(
     milp_solver : str
         MILP backend for OA master problems: ``"auto"``, ``"highs"``,
         ``"pounce"``, ``"simplex"``, or ``"gurobi"``.
+    solution_pool : bool
+        When true, request multiple Gurobi master MILP solutions per OA
+        iteration and solve fixed-NLP subproblems for each selected integer
+        assignment. Currently requires ``milp_solver="gurobi"``.
+    num_solution_iteration : int
+        Maximum number of master solution-pool candidates to process per OA
+        iteration when ``solution_pool=True``.
 
     Returns
     -------
@@ -2522,7 +2605,14 @@ def solve_oa(
     oa_penalty_factor = _normalize_positive_float("oa_penalty_factor", oa_penalty_factor)
     level_coef = _normalize_open_unit_float("level_coef", level_coef)
     stalling_limit = _normalize_optional_positive_int("stalling_limit", stalling_limit)
+    num_solution_iteration = _normalize_positive_int(
+        "num_solution_iteration",
+        num_solution_iteration,
+    )
     heuristic_nonconvex = bool(heuristic_nonconvex)
+    solution_pool = bool(solution_pool)
+    if solution_pool:
+        _require_solution_pool_backend(milp_solver)
     if add_regularization is not None and ecp_mode:
         raise ValueError("add_regularization is only supported for OA, not ECP mode.")
     if heuristic_nonconvex:
@@ -2810,6 +2900,8 @@ def solve_oa(
             oa_cut_relaxable=oa_cut_relaxable,
             use_objective_epigraph=(not decomp.obj_is_linear and decomp.oa_objective_is_convex),
             milp_solver=milp_solver,
+            solution_pool=solution_pool,
+            num_solution_iteration=num_solution_iteration,
         )
 
         from discopt.solvers import SolveStatus
@@ -2844,22 +2936,6 @@ def solve_oa(
                 oa_cut_relaxable=oa_cut_relaxable,
             )
             continue
-
-        x_master = master_result.x[:n_vars]
-        if cycling_check:
-            int_assignment = tuple(
-                _round_integral_to_bounds(x_master[idx], decomp.lb[idx], decomp.ub[idx])
-                for idx in decomp.int_indices
-            )
-            if int_assignment in integer_assignments_seen:
-                logger.info(
-                    "OA: cycling detected at iteration %d for integer assignment %s",
-                    iteration,
-                    int_assignment,
-                )
-                termination_reason = "cycling"
-                break
-            integer_assignments_seen.add(int_assignment)
 
         # The master gives a valid LB only via its dual ``bound`` (never the
         # incumbent ``objective``, which is an upper bound on a limited solve).
@@ -2914,170 +2990,217 @@ def solve_oa(
                     add_regularization,
                 )
 
-        # b. ECP mode: add cuts at master point, skip NLP
-        if ecp_mode:
-            n_violated = _add_ecp_cuts(
-                evaluator,
-                x_master,
-                n_vars,
-                decomp.constraint_senses,
-                oa_A_rows,
-                oa_b_rows,
-                decomp.obj_is_linear,
-                decomp.oa_constraint_mask,
-                decomp.oa_objective_is_convex,
-                equality_relaxation=equality_relaxation,
-                oa_cut_relaxable=oa_cut_relaxable,
-            )
-            # In ECP, use master objective as heuristic UB
-            master_obj = float(evaluator.evaluate_objective(x_master))
-            cons_vals = evaluator.evaluate_constraints(x_master)
-            is_feasible = all(cons_vals[k] <= 1e-6 for k in range(n_cons))
-            if is_feasible and master_obj < UB:
-                UB = master_obj
-                incumbent = x_master.copy()
-                incumbent_obj = master_obj
+        master_candidates = _master_solution_candidates(
+            master_result,
+            n_vars,
+            solution_pool=solution_pool,
+            num_solution_iteration=num_solution_iteration,
+        )
+        stop_after_master_pool = False
+        pool_integer_assignments_seen: set[tuple[float, ...]] = set()
 
-            gap = _compute_gap(LB, UB)
-            logger.info(
-                "OA-ECP iter %d: LB=%.6f UB=%.6f gap=%.4f%% cuts=%d violated=%d",
-                iteration,
-                LB,
-                UB,
-                gap * 100,
-                len(oa_A_rows),
-                n_violated,
-            )
-
-            if n_violated == 0:
-                termination_reason = "ecp_feasible"
+        for candidate_index, x_master in enumerate(master_candidates):
+            elapsed = time.perf_counter() - t_start
+            if elapsed >= time_limit:
+                logger.info("OA: Time limit reached during iteration %d", iteration)
+                stop_after_master_pool = True
                 break
-            if master_bound_valid and gap <= gap_tolerance:
-                termination_reason = "gap"
-                break
-            continue
 
-        # c. Fix integers, solve NLP subproblem
-        nlp_attempt = None
-        if derivative_regularization:
-            nlp_attempt = _solve_nlp_subproblem(
-                evaluator,
-                decomp.lb,
-                decomp.ub,
-                decomp.int_indices,
-                x_master,
-                nlp_solver,
-                initial_point=nlp_initial_point,
-                return_attempt=True,
+            int_assignment = tuple(
+                _round_integral_to_bounds(x_master[idx], decomp.lb[idx], decomp.ub[idx])
+                for idx in decomp.int_indices
             )
-            x_nlp, obj_nlp = nlp_attempt.x, nlp_attempt.objective
-        else:
-            x_nlp, obj_nlp = _solve_nlp_subproblem(
-                evaluator,
-                decomp.lb,
-                decomp.ub,
-                decomp.int_indices,
-                x_master,
-                nlp_solver,
-                initial_point=nlp_initial_point,
-            )
+            if solution_pool:
+                if int_assignment in pool_integer_assignments_seen:
+                    logger.info(
+                        "OA: skipping duplicate pooled integer assignment %s",
+                        int_assignment,
+                    )
+                    continue
+                pool_integer_assignments_seen.add(int_assignment)
+            if cycling_check:
+                if int_assignment in integer_assignments_seen:
+                    logger.info(
+                        "OA: cycling detected at iteration %d for integer assignment %s",
+                        iteration,
+                        int_assignment,
+                    )
+                    termination_reason = "cycling"
+                    stop_after_master_pool = True
+                    break
+                integer_assignments_seen.add(int_assignment)
 
-        if x_nlp is not None:
-            if obj_nlp < UB:
-                multipliers = nlp_attempt.multipliers if nlp_attempt is not None else None
-                accept_incumbent(x_nlp, obj_nlp, multipliers)
+            # b. ECP mode: add cuts at master point, skip NLP
+            if ecp_mode:
+                n_violated = _add_ecp_cuts(
+                    evaluator,
+                    x_master,
+                    n_vars,
+                    decomp.constraint_senses,
+                    oa_A_rows,
+                    oa_b_rows,
+                    decomp.obj_is_linear,
+                    decomp.oa_constraint_mask,
+                    decomp.oa_objective_is_convex,
+                    equality_relaxation=equality_relaxation,
+                    oa_cut_relaxable=oa_cut_relaxable,
+                )
+                # In ECP, use master objective as heuristic UB
+                master_obj = float(evaluator.evaluate_objective(x_master))
+                cons_vals = evaluator.evaluate_constraints(x_master)
+                is_feasible = all(cons_vals[k] <= 1e-6 for k in range(n_cons))
+                if is_feasible and master_obj < UB:
+                    UB = master_obj
+                    incumbent = x_master.copy()
+                    incumbent_obj = master_obj
 
-            # Generate OA cuts at NLP solution
-            _add_oa_cuts(
-                evaluator,
-                x_nlp,
-                n_vars,
-                n_cons,
-                decomp.constraint_senses,
-                oa_A_rows,
-                oa_b_rows,
-                decomp.obj_is_linear,
-                decomp.oa_constraint_mask,
-                decomp.oa_objective_is_convex,
-                equality_relaxation=equality_relaxation,
-                oa_cut_relaxable=oa_cut_relaxable,
-            )
-        else:
-            # NLP infeasible for this integer assignment
-            if feasibility_cuts:
-                x_feas = _solve_feasibility_subproblem(
+                gap = _compute_gap(LB, UB)
+                logger.info(
+                    "OA-ECP iter %d: LB=%.6f UB=%.6f gap=%.4f%% cuts=%d violated=%d",
+                    iteration,
+                    LB,
+                    UB,
+                    gap * 100,
+                    len(oa_A_rows),
+                    n_violated,
+                )
+
+                if n_violated == 0:
+                    termination_reason = "ecp_feasible"
+                    stop_after_master_pool = True
+                    break
+                if master_bound_valid and gap <= gap_tolerance:
+                    termination_reason = "gap"
+                    stop_after_master_pool = True
+                    break
+                continue
+
+            # c. Fix integers, solve NLP subproblem
+            nlp_attempt = None
+            if derivative_regularization:
+                nlp_attempt = _solve_nlp_subproblem(
                     evaluator,
                     decomp.lb,
                     decomp.ub,
                     decomp.int_indices,
                     x_master,
                     nlp_solver,
-                    feasibility_norm,
+                    initial_point=nlp_initial_point,
+                    return_attempt=True,
                 )
-                if x_feas is not None:
-                    _add_feasibility_cuts(
+                x_nlp, obj_nlp = nlp_attempt.x, nlp_attempt.objective
+            else:
+                x_nlp, obj_nlp = _solve_nlp_subproblem(
+                    evaluator,
+                    decomp.lb,
+                    decomp.ub,
+                    decomp.int_indices,
+                    x_master,
+                    nlp_solver,
+                    initial_point=nlp_initial_point,
+                )
+
+            if x_nlp is not None:
+                if obj_nlp < UB:
+                    multipliers = nlp_attempt.multipliers if nlp_attempt is not None else None
+                    accept_incumbent(x_nlp, obj_nlp, multipliers)
+
+                # Generate OA cuts at NLP solution
+                _add_oa_cuts(
+                    evaluator,
+                    x_nlp,
+                    n_vars,
+                    n_cons,
+                    decomp.constraint_senses,
+                    oa_A_rows,
+                    oa_b_rows,
+                    decomp.obj_is_linear,
+                    decomp.oa_constraint_mask,
+                    decomp.oa_objective_is_convex,
+                    equality_relaxation=equality_relaxation,
+                    oa_cut_relaxable=oa_cut_relaxable,
+                )
+            else:
+                # NLP infeasible for this integer assignment
+                if feasibility_cuts:
+                    x_feas = _solve_feasibility_subproblem(
                         evaluator,
-                        x_feas,
-                        n_vars,
-                        decomp.constraint_senses,
+                        decomp.lb,
+                        decomp.ub,
+                        decomp.int_indices,
+                        x_master,
+                        nlp_solver,
+                        feasibility_norm,
+                    )
+                    if x_feas is not None:
+                        _add_feasibility_cuts(
+                            evaluator,
+                            x_feas,
+                            n_vars,
+                            decomp.constraint_senses,
+                            oa_A_rows,
+                            oa_b_rows,
+                            decomp.oa_constraint_mask,
+                            oa_cut_relaxable=oa_cut_relaxable,
+                        )
+
+                if add_no_good_cuts:
+                    _add_no_good_cut(
+                        x_master,
+                        decomp.int_indices,
                         oa_A_rows,
                         oa_b_rows,
-                        decomp.oa_constraint_mask,
+                        n_vars,
                         oa_cut_relaxable=oa_cut_relaxable,
                     )
 
-            if add_no_good_cuts:
-                _add_no_good_cut(
+                # Also add OA cuts at master point
+                _add_oa_cuts(
+                    evaluator,
                     x_master,
-                    decomp.int_indices,
+                    n_vars,
+                    n_cons,
+                    decomp.constraint_senses,
                     oa_A_rows,
                     oa_b_rows,
-                    n_vars,
+                    decomp.obj_is_linear,
+                    decomp.oa_constraint_mask,
+                    decomp.oa_objective_is_convex,
+                    equality_relaxation=equality_relaxation,
                     oa_cut_relaxable=oa_cut_relaxable,
                 )
 
-            # Also add OA cuts at master point
-            _add_oa_cuts(
-                evaluator,
-                x_master,
-                n_vars,
-                n_cons,
-                decomp.constraint_senses,
-                oa_A_rows,
-                oa_b_rows,
-                decomp.obj_is_linear,
-                decomp.oa_constraint_mask,
-                decomp.oa_objective_is_convex,
-                equality_relaxation=equality_relaxation,
-                oa_cut_relaxable=oa_cut_relaxable,
+            # d. Check convergence
+            gap = _compute_gap(LB, UB)
+            logger.info(
+                "OA iter %d: LB=%.6f UB=%.6f gap=%.4f%% cuts=%d",
+                iteration,
+                LB,
+                UB,
+                gap * 100,
+                len(oa_A_rows),
             )
 
-        # d. Check convergence
-        gap = _compute_gap(LB, UB)
-        logger.info(
-            "OA iter %d: LB=%.6f UB=%.6f gap=%.4f%% cuts=%d",
-            iteration,
-            LB,
-            UB,
-            gap * 100,
-            len(oa_A_rows),
-        )
+            if incumbent_obj is not None:
+                incumbent_progress.append(float(UB))
+                if stalling_limit is not None and len(incumbent_progress) >= stalling_limit:
+                    prev = incumbent_progress[-stalling_limit]
+                    if abs(incumbent_progress[-1] - prev) <= 1e-12:
+                        logger.info(
+                            "OA: stalling detected after %d incumbent records; best objective %.6f",
+                            stalling_limit,
+                            UB,
+                        )
+                        termination_reason = "stalling"
+                        stop_after_master_pool = True
+                        break
 
-        if incumbent_obj is not None:
-            incumbent_progress.append(float(UB))
-            if stalling_limit is not None and len(incumbent_progress) >= stalling_limit:
-                prev = incumbent_progress[-stalling_limit]
-                if abs(incumbent_progress[-1] - prev) <= 1e-12:
-                    logger.info(
-                        "OA: stalling detected after %d incumbent records; best objective %.6f",
-                        stalling_limit,
-                        UB,
-                    )
-                    termination_reason = "stalling"
-                    break
+            if master_bound_valid and gap <= gap_tolerance:
+                termination_reason = "gap"
+                stop_after_master_pool = True
+                break
 
-        if master_bound_valid and gap <= gap_tolerance:
-            termination_reason = "gap"
+        if stop_after_master_pool:
             break
 
     # 4. Build result

--- a/python/tests/test_amp_integration.py
+++ b/python/tests/test_amp_integration.py
@@ -26,7 +26,6 @@ Sections:
 
 from __future__ import annotations
 
-import itertools
 import logging
 import os
 import warnings

--- a/python/tests/test_amp_integration.py
+++ b/python/tests/test_amp_integration.py
@@ -3474,6 +3474,14 @@ class TestCurrentCodeWeaknesses:
         # making the AMP loop strictly worse while staying robust to solver noise.
         assert len(iters_with) <= len(iters_without)
 
+    @pytest.mark.xfail(
+        strict=False,
+        reason=(
+            "Diagnostic weakness probe: status/gap depends on NLP backend "
+            "(cyipopt vs JAX IPM) and BLAS. Stable on macOS+py3.13, "
+            "intermittent on Linux+py3.12 CI."
+        ),
+    )
     def test_amp_max_iter_without_gap_certificate_returns_feasible(self):
         """An incumbent without a certified gap should not be labeled optimal."""
         m = _make_nlp1()
@@ -3501,6 +3509,8 @@ class TestCurrentCodeWeaknesses:
 
     def test_amp_time_limit_with_incumbent_returns_feasible(self, monkeypatch):
         """Timing out after finding an incumbent should not hide the feasible point."""
+        import itertools
+
         from discopt._jax.milp_relaxation import MilpRelaxationResult
         from discopt.solvers import amp as amp_mod
 
@@ -3542,6 +3552,14 @@ class TestCurrentCodeWeaknesses:
         assert result.objective is not None
         assert result.gap_certified is False
 
+    @pytest.mark.xfail(
+        strict=False,
+        reason=(
+            "Diagnostic weakness probe: convergence path through "
+            "pick_partition_vars depends on NLP backend and MILP tolerances. "
+            "Stable on macOS+py3.13, intermittent on Linux+py3.12 CI."
+        ),
+    )
     def test_adaptive_partition_selection_path_runs_inside_amp(self, monkeypatch):
         """AMP should re-pick partition variables when adaptive selection is enabled."""
         import discopt._jax.discretization as disc_mod

--- a/python/tests/test_gurobi_backend.py
+++ b/python/tests/test_gurobi_backend.py
@@ -248,6 +248,109 @@ def test_gurobi_milp_optimal_result_reports_zero_gap(monkeypatch):
     assert result.gap == 0.0
 
 
+def test_gurobi_milp_solution_pool_sets_params_and_returns_candidates(monkeypatch):
+    class FakeGRB:
+        CONTINUOUS = "C"
+        BINARY = "B"
+        INTEGER = "I"
+        MINIMIZE = 1
+        INFINITY = 1e100
+        OPTIMAL = 2
+        INFEASIBLE = 3
+        UNBOUNDED = 5
+        INF_OR_UNBD = 4
+        ITERATION_LIMIT = 7
+        TIME_LIMIT = 9
+
+    class FakeEnv:
+        def __init__(self, empty=True):
+            self.empty = empty
+
+        def setParam(self, *_args):
+            pass
+
+        def start(self):
+            pass
+
+        def dispose(self):
+            pass
+
+    class FakeMVar:
+        __array_priority__ = 1000
+
+        def __init__(self, model):
+            self.model = model
+
+        @property
+        def X(self):
+            return self.model.solutions[0]
+
+        @property
+        def Xn(self):
+            return self.model.solutions[self.model.solution_number]
+
+        def __rmatmul__(self, _other):
+            return 0.0
+
+    class FakeModel:
+        Status = FakeGRB.OPTIMAL
+        NodeCount = 0
+        Runtime = 0.0
+        SolCount = 3
+        ObjVal = 1.0
+        ObjBound = 1.0
+        MIPGap = 0.0
+        last = None
+
+        def __init__(self, *_args, **_kwargs):
+            self.params = {}
+            self.solution_number = 0
+            self.solutions = [
+                np.array([0.0]),
+                np.array([1.0]),
+                np.array([0.5]),
+            ]
+            self.pool_objectives = [1.0, 3.0, 2.0]
+            FakeModel.last = self
+
+        @property
+        def PoolObjVal(self):
+            return self.pool_objectives[self.solution_number]
+
+        def setParam(self, key, value):
+            self.params[key] = value
+            if key == "SolutionNumber":
+                self.solution_number = int(value)
+
+        def addMVar(self, **_kwargs):
+            return FakeMVar(self)
+
+        def setObjective(self, *_args):
+            pass
+
+        def optimize(self):
+            pass
+
+        def dispose(self):
+            pass
+
+    fake_gp = types.SimpleNamespace(Env=FakeEnv, Model=FakeModel)
+    monkeypatch.setattr(gurobi_backend, "_load_gurobi", lambda: (fake_gp, FakeGRB))
+
+    result = gurobi_backend.solve_milp(
+        c=np.array([1.0]),
+        bounds=[(0.0, 1.0)],
+        integrality=np.array([1], dtype=np.int32),
+        solution_pool=True,
+        num_solution_iteration=3,
+    )
+
+    assert FakeModel.last.params["PoolSearchMode"] == 2
+    assert FakeModel.last.params["PoolSolutions"] == 3
+    assert result.solution_pool_objectives == pytest.approx([1.0, 2.0, 3.0])
+    assert [candidate.tolist() for candidate in result.solution_pool] == [[0.0], [0.5], [1.0]]
+
+
 def test_gurobi_milp_lazy_callback_adds_lazy_cut(monkeypatch):
     class FakeCallback:
         MIPSOL = 1

--- a/python/tests/test_mip_nlp.py
+++ b/python/tests/test_mip_nlp.py
@@ -250,6 +250,8 @@ def test_model_solve_routes_mip_nlp_options(monkeypatch):
             stalling_limit=3,
             cycling_check=False,
             milp_solver="gurobi",
+            solution_pool=True,
+            num_solution_iteration=7,
             skip_convex_check=True,
         )
 
@@ -266,6 +268,8 @@ def test_model_solve_routes_mip_nlp_options(monkeypatch):
     assert calls["stalling_limit"] == 3
     assert calls["cycling_check"] is False
     assert calls["milp_solver"] == "gurobi"
+    assert calls["solution_pool"] is True
+    assert calls["num_solution_iteration"] == 7
 
 
 def test_model_solve_mip_nlp_path_runs_entropy_canonicalization(monkeypatch):
@@ -399,6 +403,8 @@ def test_mip_nlp_new_oa_options_precedence_and_alias(monkeypatch):
             "add_regularization": "level_L1",
             "level_coef": 0.4,
             "cycling_check": True,
+            "solution_pool": False,
+            "num_solution_iteration": 2,
         },
         add_slack=True,
         oa_penalty_factor=17.0,
@@ -409,6 +415,8 @@ def test_mip_nlp_new_oa_options_precedence_and_alias(monkeypatch):
         stalling_limit=4,
         heuristic_nonconvex=True,
         cycling_check=False,
+        solution_pool=True,
+        num_solution_iteration=4,
     )
 
     assert result.status == "optimal"
@@ -421,6 +429,8 @@ def test_mip_nlp_new_oa_options_precedence_and_alias(monkeypatch):
     assert calls["stalling_limit"] == 4
     assert calls["heuristic_nonconvex"] is True
     assert calls["cycling_check"] is False
+    assert calls["solution_pool"] is True
+    assert calls["num_solution_iteration"] == 4
 
 
 def test_model_solve_passes_initial_solution_to_mip_nlp(monkeypatch):
@@ -983,6 +993,18 @@ def test_mip_nlp_rejects_unsupported_oa_options():
         )
 
 
+def test_oa_solution_pool_requires_gurobi_backend():
+    from discopt.solvers.mip_nlp import solve_mip_nlp
+
+    with pytest.raises(RuntimeError, match="solution_pool=True requires milp_solver='gurobi'"):
+        solve_mip_nlp(
+            _binary_model("solution_pool_non_gurobi"),
+            method="oa",
+            solution_pool=True,
+            milp_solver="highs",
+        )
+
+
 def test_mip_nlp_options_must_be_dict():
     from discopt.solvers.mip_nlp import solve_mip_nlp
 
@@ -992,6 +1014,76 @@ def test_mip_nlp_options_must_be_dict():
             method="oa",
             mip_nlp_options=[("ecp_mode", True)],
         )
+
+
+def test_oa_solution_pool_processes_multiple_master_candidates(monkeypatch):
+    import discopt.solvers.oa as oa_module
+    from discopt.solvers import MILPResult, SolveStatus
+
+    nlp_master_points = []
+    cut_points = []
+    master_calls = []
+
+    def fake_add_oa_cuts(*args, **kwargs):
+        x_star = np.asarray(args[1], dtype=float).copy()
+        n_vars = int(args[2])
+        oa_A_rows = args[5]
+        oa_b_rows = args[6]
+        cut_points.append(x_star)
+        oa_A_rows.append(np.zeros(n_vars, dtype=float))
+        oa_b_rows.append(0.0)
+        if kwargs.get("oa_cut_relaxable") is not None:
+            kwargs["oa_cut_relaxable"].append(True)
+
+    def fake_solve_nlp_subproblem(
+        _evaluator,
+        _lb,
+        _ub,
+        _int_indices,
+        x_master,
+        _nlp_solver,
+        initial_point=None,
+        return_attempt=False,
+    ):
+        del initial_point
+        x = np.asarray(x_master, dtype=float).copy()
+        nlp_master_points.append(x)
+        obj = 10.0 - float(x[0])
+        if return_attempt:
+            return oa_module._NLPAttempt(x=x, objective=obj, multipliers=None)
+        return x, obj
+
+    def fake_solve_master_milp(*args, **kwargs):
+        master_calls.append(kwargs)
+        return MILPResult(
+            status=SolveStatus.OPTIMAL,
+            x=np.array([0.0]),
+            objective=0.0,
+            bound=-100.0,
+            solution_pool=[np.array([0.0]), np.array([1.0])],
+            solution_pool_objectives=[0.0, 1.0],
+        )
+
+    monkeypatch.setattr(oa_module, "_add_oa_cuts", fake_add_oa_cuts)
+    monkeypatch.setattr(oa_module, "_solve_nlp_subproblem", fake_solve_nlp_subproblem)
+    monkeypatch.setattr(oa_module, "_solve_master_milp", fake_solve_master_milp)
+
+    result = oa_module.solve_oa(
+        _binary_model("solution_pool_rounds"),
+        init_strategy="initial_binary",
+        max_iterations=1,
+        gap_tolerance=0.0,
+        solution_pool=True,
+        num_solution_iteration=2,
+        milp_solver="gurobi",
+    )
+
+    assert result.status == "feasible"
+    assert len(master_calls) == 1
+    assert master_calls[0]["solution_pool"] is True
+    assert master_calls[0]["num_solution_iteration"] == 2
+    assert [point.tolist() for point in nlp_master_points[1:]] == [[0.0], [1.0]]
+    assert len(cut_points) == 3
 
 
 def test_oa_initial_binary_seed_rounds_and_clamps_discrete_values():

--- a/python/tests/test_model_latex.py
+++ b/python/tests/test_model_latex.py
@@ -1,0 +1,122 @@
+"""Rich LaTeX / HTML representation of Model objects (standard PSE problem form)."""
+
+from __future__ import annotations
+
+import os
+
+os.environ.setdefault("JAX_PLATFORMS", "cpu")
+os.environ.setdefault("JAX_ENABLE_X64", "1")
+
+import discopt.modeling as dm  # noqa: E402
+import numpy as np  # noqa: E402
+import pytest  # noqa: E402
+from discopt.modeling import latex  # noqa: E402
+
+
+def _minlp():
+    m = dm.Model("demo")
+    x = m.continuous("x", lb=0, ub=10)
+    y = m.binary("y")
+    m.minimize((x - 3) ** 2 + 2 * y)
+    m.subject_to(x + 5 * y >= 4)
+    return m
+
+
+def test_to_latex_structure():
+    s = _minlp().to_latex()
+    assert s.startswith("\\begin{aligned}") and s.endswith("\\end{aligned}")
+    assert r"\text{minimize}" in s
+    assert r"\text{subject to}" in s
+    # power -> superscript, product -> \cdot
+    assert "^{2}" in s
+    assert r"\cdot" in s
+    # un-normalised natural constraint form (not "4 - (...) <= 0")
+    assert r"4 \le x + 5 \cdot y" in s
+    # variable domains
+    assert r"0 \le x \le 10" in s
+    assert r"y \in \{0, 1\}" in s
+
+
+def test_operator_rendering():
+    m = dm.Model("ops")
+    a = m.continuous("a", lb=1, ub=5)
+    b = m.continuous("b", lb=1, ub=5)
+    m.maximize(dm.exp(a) / (b + 1))
+    m.subject_to(a * b <= 6)
+    s = m.to_latex()
+    assert r"\text{maximize}" in s
+    assert r"\frac{" in s  # division
+    assert r"\exp" in s  # function name
+
+
+def test_integer_and_continuous_domains():
+    m = dm.Model("d")
+    k = m.integer("k", lb=0, ub=7)
+    z = m.continuous("z", lb=-1, ub=1)
+    m.minimize(k + z)
+    s = m.to_latex()
+    assert r"\mathbb{Z}" in s
+    assert r"-1 \le z \le 1" in s
+
+
+def test_maximize_sense():
+    m = dm.Model("mx")
+    x = m.continuous("x", lb=0, ub=10)
+    m.maximize(-((x - 3) ** 2))
+    assert r"\text{maximize}" in m.to_latex()
+
+
+def test_constant_vector_rendering():
+    m = dm.Model("vec")
+    v = m.continuous("v", shape=(3,), lb=0, ub=5)
+    m.minimize(np.array([1.0, 2.0, 3.0]) @ v)
+    s = m.to_latex()
+    assert "bmatrix" in s  # small constant vector rendered inline
+
+
+def test_truncation_and_full():
+    m = dm.Model("big")
+    xs = [m.continuous(f"x{i}", lb=0, ub=1) for i in range(60)]
+    m.minimize(sum(xs))
+    for i in range(60):
+        m.subject_to(xs[i] >= 0.0)
+    truncated = m.to_latex(max_rows=5)
+    assert r"\vdots" in truncated
+    assert "60 constraints" in truncated
+    # variable summary instead of 60 rows
+    assert r"\text{continuous}" in truncated
+    full = m.to_latex(max_rows=None)
+    assert r"\vdots" not in full
+    assert full.count(r"\\") > 60  # all constraints + vars rendered
+
+
+def test_repr_latex_and_html():
+    m = _minlp()
+    lx = m._repr_latex_()
+    assert lx.startswith("$$") and lx.endswith("$$")
+    html = m._repr_html_()
+    assert "discopt-model" in html
+    assert "demo" in html  # model name in header
+    assert "2 variables" in html and "1 constraint" in html
+
+
+def test_never_crashes_on_empty_model():
+    m = dm.Model("empty")
+    # no objective, no constraints, no vars
+    assert isinstance(m.to_latex(), str)
+    assert isinstance(m.to_html(), str)
+    assert r"\text{find}" in m.to_latex()
+
+
+def test_expr_to_latex_is_total():
+    """The visitor must return a string for every node type, never raising."""
+    m = dm.Model("nodes")
+    x = m.continuous("x", shape=(2,), lb=0, ub=5)
+    exprs = [x[0] ** 2, abs(x[0]), -x[1], dm.sqrt(x[0]), dm.log(x[1] + 1), x[0] * x[1]]
+    for e in exprs:
+        out = latex.expr_to_latex(e)
+        assert isinstance(out, str) and out
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-v"]))

--- a/python/tests/test_trilinear_meyer_floudas.py
+++ b/python/tests/test_trilinear_meyer_floudas.py
@@ -1,0 +1,388 @@
+"""Tests for relax_trilinear_meyer_floudas (Meyer-Floudas 2004 convex hull).
+
+Validates that ``relax_trilinear_meyer_floudas`` returns the convex / concave
+envelopes of ``x*y*z`` on an axis-aligned box, computed via the convex hull
+of the eight vertex values (Rikun 1997 / Meyer-Floudas 2004).
+
+The implementation is verified against:
+  - corner exactness (cv = cc = x*y*z at all 8 corners);
+  - pointwise soundness (cv <= x*y*z <= cc) on random box points;
+  - pointwise dominance over single-ordering nested McCormick
+    (``relax_trilinear``) and the best-of-three nested McCormick
+    (``relax_trilinear_exact``);
+  - agreement with an external LP solver (scipy.optimize.linprog) on the
+    convex-hull LP (up to numerical tolerance);
+  - JAX compatibility (``jit``, ``vmap``, ``grad``);
+  - compiler dispatch behaviour for x*y*z expressions and the
+    ``DISCOPT_TRILINEAR`` env-var selector.
+"""
+
+from __future__ import annotations
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+import pytest
+from discopt._jax.envelopes import (
+    relax_trilinear,
+    relax_trilinear_exact,
+    relax_trilinear_meyer_floudas,
+)
+
+# ─────────────────────────────────────────────────────────────────────
+# Sign-pattern coverage
+# ─────────────────────────────────────────────────────────────────────
+
+
+_SIGN_PATTERN_BOXES: list[tuple[float, float, float, float, float, float]] = [
+    # All positive
+    (0.5, 2.0, 1.0, 3.0, 0.2, 1.5),
+    # All negative
+    (-2.0, -0.5, -3.0, -1.0, -1.5, -0.2),
+    # x mixed, y/z positive
+    (-1.0, 2.0, 0.5, 2.5, 1.0, 3.0),
+    # y mixed
+    (1.0, 3.0, -1.5, 1.5, 0.5, 2.0),
+    # z mixed
+    (0.5, 2.0, 1.0, 2.5, -2.0, 1.0),
+    # All mixed sign
+    (-1.5, 2.0, -2.0, 1.0, -1.0, 1.5),
+    # Tight around zero
+    (-0.1, 0.1, -0.1, 0.1, -0.1, 0.1),
+    # Asymmetric mixed
+    (-3.0, 0.5, 0.2, 1.0, -0.5, 2.0),
+]
+
+
+# ─────────────────────────────────────────────────────────────────────
+# Corner exactness
+# ─────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize("box", _SIGN_PATTERN_BOXES)
+def test_corner_tightness(box):
+    """At every box corner, cv = cc = corner_value."""
+    x_lb, x_ub, y_lb, y_ub, z_lb, z_ub = box
+    for xc in (x_lb, x_ub):
+        for yc in (y_lb, y_ub):
+            for zc in (z_lb, z_ub):
+                cv, cc = relax_trilinear_meyer_floudas(
+                    xc, yc, zc, x_lb, x_ub, y_lb, y_ub, z_lb, z_ub
+                )
+                truth = xc * yc * zc
+                np.testing.assert_allclose(float(cv), truth, atol=1e-9)
+                np.testing.assert_allclose(float(cc), truth, atol=1e-9)
+
+
+# ─────────────────────────────────────────────────────────────────────
+# Soundness on random points
+# ─────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize("box", _SIGN_PATTERN_BOXES)
+def test_soundness_random_points(box):
+    """For random points in the box, cv <= x*y*z <= cc."""
+    x_lb, x_ub, y_lb, y_ub, z_lb, z_ub = box
+    key = jax.random.PRNGKey(7)
+    n = 512
+    kx, ky, kz = jax.random.split(key, 3)
+    xs = jax.random.uniform(kx, (n,), minval=x_lb, maxval=x_ub)
+    ys = jax.random.uniform(ky, (n,), minval=y_lb, maxval=y_ub)
+    zs = jax.random.uniform(kz, (n,), minval=z_lb, maxval=z_ub)
+
+    fn = jax.vmap(
+        lambda xv, yv, zv: relax_trilinear_meyer_floudas(
+            xv, yv, zv, x_lb, x_ub, y_lb, y_ub, z_lb, z_ub
+        )
+    )
+    cvs, ccs = fn(xs, ys, zs)
+    truths = xs * ys * zs
+
+    eps = 1e-8
+    assert jnp.all(cvs <= truths + eps), (
+        f"cv violated on box {box}: max gap = {float(jnp.max(cvs - truths))}"
+    )
+    assert jnp.all(ccs >= truths - eps), (
+        f"cc violated on box {box}: max gap = {float(jnp.max(truths - ccs))}"
+    )
+
+
+# ─────────────────────────────────────────────────────────────────────
+# Pointwise dominance over weaker relaxations
+# ─────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize("box", _SIGN_PATTERN_BOXES)
+def test_dominates_nested_pointwise(box):
+    """MF cv >= nested cv and MF cc <= nested cc at every sampled point."""
+    x_lb, x_ub, y_lb, y_ub, z_lb, z_ub = box
+    key = jax.random.PRNGKey(13)
+    n = 256
+    kx, ky, kz = jax.random.split(key, 3)
+    xs = jax.random.uniform(kx, (n,), minval=x_lb, maxval=x_ub)
+    ys = jax.random.uniform(ky, (n,), minval=y_lb, maxval=y_ub)
+    zs = jax.random.uniform(kz, (n,), minval=z_lb, maxval=z_ub)
+
+    nested_fn = jax.vmap(
+        lambda xv, yv, zv: relax_trilinear(xv, yv, zv, x_lb, x_ub, y_lb, y_ub, z_lb, z_ub)
+    )
+    mf_fn = jax.vmap(
+        lambda xv, yv, zv: relax_trilinear_meyer_floudas(
+            xv, yv, zv, x_lb, x_ub, y_lb, y_ub, z_lb, z_ub
+        )
+    )
+    cv_n, cc_n = nested_fn(xs, ys, zs)
+    cv_m, cc_m = mf_fn(xs, ys, zs)
+
+    eps = 1e-8
+    assert jnp.all(cv_m >= cv_n - eps), "MF cv looser than nested at some point"
+    assert jnp.all(cc_m <= cc_n + eps), "MF cc looser than nested at some point"
+
+
+@pytest.mark.parametrize("box", _SIGN_PATTERN_BOXES)
+def test_dominates_best_of_three_pointwise(box):
+    """MF cv >= best-of-three cv and MF cc <= best-of-three cc at every point.
+
+    The Meyer-Floudas envelope merges the convex-hull LP value with the
+    best-of-three nested McCormick (which is sound pointwise but not
+    convex). Taking the elementwise max-of-cvs / min-of-ccs guarantees MF
+    is at least as tight as the best-of-three relaxation everywhere.
+    """
+    x_lb, x_ub, y_lb, y_ub, z_lb, z_ub = box
+    key = jax.random.PRNGKey(29)
+    n = 256
+    kx, ky, kz = jax.random.split(key, 3)
+    xs = jax.random.uniform(kx, (n,), minval=x_lb, maxval=x_ub)
+    ys = jax.random.uniform(ky, (n,), minval=y_lb, maxval=y_ub)
+    zs = jax.random.uniform(kz, (n,), minval=z_lb, maxval=z_ub)
+
+    exact_fn = jax.vmap(
+        lambda xv, yv, zv: relax_trilinear_exact(xv, yv, zv, x_lb, x_ub, y_lb, y_ub, z_lb, z_ub)
+    )
+    mf_fn = jax.vmap(
+        lambda xv, yv, zv: relax_trilinear_meyer_floudas(
+            xv, yv, zv, x_lb, x_ub, y_lb, y_ub, z_lb, z_ub
+        )
+    )
+    cv_e, cc_e = exact_fn(xs, ys, zs)
+    cv_m, cc_m = mf_fn(xs, ys, zs)
+
+    eps = 1e-8
+    assert jnp.all(cv_m >= cv_e - eps), (
+        f"MF cv looser than best-of-three: max gap = {float(jnp.max(cv_e - cv_m))}"
+    )
+    assert jnp.all(cc_m <= cc_e + eps), (
+        f"MF cc looser than best-of-three: max gap = {float(jnp.max(cc_m - cc_e))}"
+    )
+
+
+def test_strictly_tighter_on_mixed_sign_box():
+    """On a mixed-sign box, MF is strictly tighter than best-of-three somewhere."""
+    box = (-1.5, 2.0, -2.0, 1.0, -1.0, 1.5)
+    x_lb, x_ub, y_lb, y_ub, z_lb, z_ub = box
+
+    key = jax.random.PRNGKey(99)
+    n = 1024
+    kx, ky, kz = jax.random.split(key, 3)
+    xs = jax.random.uniform(kx, (n,), minval=x_lb, maxval=x_ub)
+    ys = jax.random.uniform(ky, (n,), minval=y_lb, maxval=y_ub)
+    zs = jax.random.uniform(kz, (n,), minval=z_lb, maxval=z_ub)
+
+    exact_fn = jax.vmap(
+        lambda xv, yv, zv: relax_trilinear_exact(xv, yv, zv, x_lb, x_ub, y_lb, y_ub, z_lb, z_ub)
+    )
+    mf_fn = jax.vmap(
+        lambda xv, yv, zv: relax_trilinear_meyer_floudas(
+            xv, yv, zv, x_lb, x_ub, y_lb, y_ub, z_lb, z_ub
+        )
+    )
+    cv_e, cc_e = exact_fn(xs, ys, zs)
+    cv_m, cc_m = mf_fn(xs, ys, zs)
+
+    cv_gap = float(jnp.max(cv_m - cv_e))
+    cc_gap = float(jnp.max(cc_e - cc_m))
+    assert max(cv_gap, cc_gap) > 1e-3, (
+        "MF gives no strict improvement over best-of-three on this box "
+        f"(cv_gap={cv_gap}, cc_gap={cc_gap})"
+    )
+
+
+# ─────────────────────────────────────────────────────────────────────
+# Agreement with external LP solver (scipy.optimize.linprog)
+# ─────────────────────────────────────────────────────────────────────
+
+
+def test_matches_scipy_lp_hull():
+    """MF envelope should match the explicit convex-hull LP from scipy.linprog.
+
+    Solves the LP   min/max sum_i lambda_i * f_i
+       s.t.  sum_i lambda_i * v_i = p,  sum_i lambda_i = 1,  lambda_i >= 0
+    at random box points and confirms MF reproduces the LP value (within
+    numerical tolerance). MF's merge with best-of-three may sometimes be
+    *tighter* than the convex hull (because best-of-three is non-convex),
+    so we check cv_mf >= cv_lp and cc_mf <= cc_lp.
+    """
+    from scipy.optimize import linprog
+
+    box = (-1.5, 2.0, -2.0, 1.0, -1.0, 1.5)
+    x_lb, x_ub, y_lb, y_ub, z_lb, z_ub = box
+    verts = np.array([[a, b, c] for a in (x_lb, x_ub) for b in (y_lb, y_ub) for c in (z_lb, z_ub)])
+    fc = verts[:, 0] * verts[:, 1] * verts[:, 2]
+
+    rng = np.random.default_rng(42)
+    n = 100
+    xs = rng.uniform(x_lb, x_ub, n)
+    ys = rng.uniform(y_lb, y_ub, n)
+    zs = rng.uniform(z_lb, z_ub, n)
+
+    for i in range(n):
+        p = np.array([xs[i], ys[i], zs[i]])
+        A_eq = np.vstack([verts.T, np.ones((1, 8))])
+        b_eq = np.concatenate([p, [1.0]])
+        res_cv = linprog(fc, A_eq=A_eq, b_eq=b_eq, bounds=[(0, None)] * 8, method="highs")
+        res_cc = linprog(-fc, A_eq=A_eq, b_eq=b_eq, bounds=[(0, None)] * 8, method="highs")
+        cv_lp = float(res_cv.fun)
+        cc_lp = float(-res_cc.fun)
+
+        cv_mf, cc_mf = relax_trilinear_meyer_floudas(
+            float(xs[i]), float(ys[i]), float(zs[i]), x_lb, x_ub, y_lb, y_ub, z_lb, z_ub
+        )
+
+        eps = 1e-6
+        # MF tightens at least as much as the convex-hull LP
+        assert float(cv_mf) >= cv_lp - eps, f"MF cv looser than LP hull at {p}"
+        assert float(cc_mf) <= cc_lp + eps, f"MF cc looser than LP hull at {p}"
+
+
+# ─────────────────────────────────────────────────────────────────────
+# JAX compatibility — jit, vmap, grad
+# ─────────────────────────────────────────────────────────────────────
+
+
+def test_jit_compiles_and_runs():
+    f = jax.jit(relax_trilinear_meyer_floudas)
+    cv, cc = f(0.5, 1.0, 1.5, 0.0, 1.0, 0.0, 2.0, 0.0, 3.0)
+    truth = 0.5 * 1.0 * 1.5
+    assert float(cv) <= truth + 1e-8
+    assert float(cc) >= truth - 1e-8
+
+
+def test_vmap_over_points():
+    n = 32
+    key = jax.random.PRNGKey(0)
+    xs = jax.random.uniform(key, (n,), minval=-1.0, maxval=1.0)
+    ys = jax.random.uniform(key, (n,), minval=-1.0, maxval=1.0)
+    zs = jax.random.uniform(key, (n,), minval=-1.0, maxval=1.0)
+    f = jax.vmap(
+        lambda xv, yv, zv: relax_trilinear_meyer_floudas(
+            xv, yv, zv, -1.0, 1.0, -1.0, 1.0, -1.0, 1.0
+        )
+    )
+    cvs, ccs = f(xs, ys, zs)
+    assert cvs.shape == (n,)
+    assert ccs.shape == (n,)
+
+
+def test_grad_through_cv_is_finite():
+    def loss(xv):
+        cv, _ = relax_trilinear_meyer_floudas(xv, 1.0, 1.5, -1.0, 2.0, 0.0, 2.0, 0.0, 3.0)
+        return cv
+
+    g = jax.grad(loss)(0.5)
+    assert jnp.isfinite(g)
+
+
+# ─────────────────────────────────────────────────────────────────────
+# Compiler dispatch — default selects MF, env var routes to alternatives
+# ─────────────────────────────────────────────────────────────────────
+
+
+def _build_xyz_relaxation(x_lb, x_ub, y_lb, y_ub, z_lb, z_ub):
+    """Build a relaxation callable for f = x*y*z over the given box."""
+    from discopt._jax.relaxation_compiler import _compile_relax_node
+    from discopt.modeling.core import Model
+
+    m = Model("trilinear_mf_test")
+    x = m.continuous("x", lb=x_lb, ub=x_ub)
+    y = m.continuous("y", lb=y_lb, ub=y_ub)
+    z = m.continuous("z", lb=z_lb, ub=z_ub)
+    expr = x * y * z
+
+    fn = _compile_relax_node(expr, m)
+    return fn
+
+
+def test_compiler_default_uses_meyer_floudas(monkeypatch):
+    """Without DISCOPT_TRILINEAR set, the compiler picks Meyer-Floudas.
+
+    On an all-positive asymmetric box, MF should produce strictly tighter
+    LP bounds at the midpoint than the best-of-three permutation-symmetric
+    nested path (DISCOPT_TRILINEAR=exact). Validates that the env-var
+    selector engages distinct dispatches. (The midpoint of some boxes
+    lands on a region where both relaxations coincide; the all-positive
+    box below is one where they differ.)
+    """
+    box = (0.5, 2.0, 1.0, 3.0, 0.2, 1.5)
+
+    monkeypatch.delenv("DISCOPT_TRILINEAR", raising=False)
+    fn_mf = _build_xyz_relaxation(*box)
+
+    monkeypatch.setenv("DISCOPT_TRILINEAR", "exact")
+    fn_exact = _build_xyz_relaxation(*box)
+
+    monkeypatch.delenv("DISCOPT_TRILINEAR", raising=False)
+
+    lb_arr = jnp.array([box[0], box[2], box[4]])
+    ub_arr = jnp.array([box[1], box[3], box[5]])
+
+    cv_mf_v, cc_mf_v = fn_mf(lb_arr, ub_arr, lb_arr, ub_arr)
+    cv_ex_v, cc_ex_v = fn_exact(lb_arr, ub_arr, lb_arr, ub_arr)
+
+    mid = (lb_arr + ub_arr) * 0.5
+    f_mid = float(mid[0] * mid[1] * mid[2])
+    eps = 1e-7
+
+    # Both are sound at the midpoint.
+    assert float(cv_mf_v) <= f_mid + eps
+    assert float(cc_mf_v) >= f_mid - eps
+    assert float(cv_ex_v) <= f_mid + eps
+    assert float(cc_ex_v) >= f_mid - eps
+
+    # MF dominates best-of-three.
+    assert float(cv_mf_v) >= float(cv_ex_v) - eps
+    assert float(cc_mf_v) <= float(cc_ex_v) + eps
+
+    # MF must be strictly tighter than best-of-three on this box.
+    cv_tighten = float(cv_mf_v) - float(cv_ex_v)
+    cc_tighten = float(cc_ex_v) - float(cc_mf_v)
+    assert max(cv_tighten, cc_tighten) > 1e-6, (
+        "MF and best-of-three returned identical LP bounds — "
+        "dispatch is not selecting Meyer-Floudas."
+    )
+
+
+def test_compiler_env_var_nested_falls_through(monkeypatch):
+    """DISCOPT_TRILINEAR=nested disables the trilinear dispatch and routes the
+    expression through the generic compositional bilinear path. This is a
+    legacy/debug path -- the test only verifies the dispatch toggles distinct
+    behavior (different return values), not strict tightness orderings.
+    """
+    box = (0.5, 2.0, 1.0, 3.0, 0.2, 1.5)
+
+    monkeypatch.delenv("DISCOPT_TRILINEAR", raising=False)
+    fn_mf = _build_xyz_relaxation(*box)
+
+    monkeypatch.setenv("DISCOPT_TRILINEAR", "nested")
+    fn_nested = _build_xyz_relaxation(*box)
+    monkeypatch.delenv("DISCOPT_TRILINEAR", raising=False)
+
+    lb_arr = jnp.array([box[0], box[2], box[4]])
+    ub_arr = jnp.array([box[1], box[3], box[5]])
+
+    cv_mf_v, cc_mf_v = fn_mf(lb_arr, ub_arr, lb_arr, ub_arr)
+    cv_ne_v, cc_ne_v = fn_nested(lb_arr, ub_arr, lb_arr, ub_arr)
+
+    # The two dispatches must produce distinguishable bounds.
+    assert (abs(float(cv_mf_v) - float(cv_ne_v)) > 1e-6) or (
+        abs(float(cc_mf_v) - float(cc_ne_v)) > 1e-6
+    ), "Trilinear dispatch is not toggling with DISCOPT_TRILINEAR=nested."


### PR DESCRIPTION
## Summary

- Adds `solution_pool` and `num_solution_iteration` MIP-NLP OA options.
- Exposes Gurobi MILP solution-pool candidates through `MILPResult`.
- Processes selected pooled master candidates as independent fixed-NLP/cut rounds within one OA master iteration.
- Raises a clear unsupported-capability error for non-Gurobi pool requests.

## Tests

- `env PYTHONPATH=python python -m ruff check python/discopt/solvers/__init__.py python/discopt/solvers/gurobi.py python/discopt/solvers/oa.py python/discopt/solvers/mip_nlp.py python/discopt/solver.py python/discopt/modeling/core.py python/tests/test_gurobi_backend.py python/tests/test_mip_nlp.py`
- `env PYTHONPATH=python python -m ruff format --check python/discopt/solvers/__init__.py python/discopt/solvers/gurobi.py python/discopt/solvers/oa.py python/discopt/solvers/mip_nlp.py python/discopt/solver.py python/discopt/modeling/core.py python/tests/test_gurobi_backend.py python/tests/test_mip_nlp.py`
- `env PYTHONPATH=python python -m pytest python/tests/test_gurobi_backend.py python/tests/test_mip_nlp.py`

## Branch Hygiene

- Base branch: `bernalde:feature/mip-nlp-solver`
- Source branch point: `origin/feature/mip-nlp-solver` at `4ae41c8` after merge-only sync from current `upstream/main`.
- Stacked status: child PR in the fork integration series; not stacked on a previous child issue branch.
- Prerequisites: integration branch already contains issues `#111` through `#119` plus branch-hygiene sync commits `bccac83` and `4ae41c8`.

This PR targets the non-default `feature/mip-nlp-solver` branch, so GitHub may not auto-close the issue until that integration branch reaches the default branch.

Closes #120
