### PR TITLE
Document MIP-NLP usage and upstream readiness

### DIFF
--- a/docs/_toc.yml
+++ b/docs/_toc.yml
@@ -20,6 +20,7 @@ parts:
   - caption: "Tutorials \u2014 Solver Backends"
     chapters:
       - file: notebooks/tutorial_oa
+      - file: mip_nlp
       - file: notebooks/tutorial_benders
       - file: notebooks/tutorial_lagrangian
       - file: notebooks/amp_global_minlp

--- a/docs/dev/mip-nlp-upstream-readiness.md
+++ b/docs/dev/mip-nlp-upstream-readiness.md
@@ -1,0 +1,86 @@
+# MIP-NLP upstream readiness gate
+
+This checklist records the integration-branch state for the MIP-NLP issue series
+before opening the final upstream PR from `bernalde:feature/mip-nlp-solver` to
+`jkitchin:main`.
+
+## Branch hygiene
+
+- Fork repository: `bernalde/discopt`.
+- Integration branch: `feature/mip-nlp-solver`.
+- Child PR base: `bernalde:feature/mip-nlp-solver`.
+- Final upstream path: one later PR from `bernalde:feature/mip-nlp-solver` into
+  `jkitchin:main`.
+- Current upstream baseline checked for this gate: `upstream/main` at `5d593ae`.
+- Fork `main` was synced with `upstream/main` by merge commit `35a63db`.
+- Integration branch includes that synced fork-main merge by merge commit
+  `14db514`.
+
+## Child issue disposition
+
+| Issue | Scope | Integration PR | Status |
+| --- | --- | --- | --- |
+| #111 | Route `solver="mip-nlp"` to OA/ECP and establish the two-axis API | #122 | Merged into `feature/mip-nlp-solver` |
+| #112 | OA/ECP parity baselines against MindtPy-style fixtures | #123 | Merged into `feature/mip-nlp-solver` |
+| #113 | Initialization strategies: `rNLP`, `initial_binary`, `max_binary` | #124 | Merged into `feature/mip-nlp-solver` |
+| #114 | OA robustness: slack, no-good cuts, feasibility norms, cycling | #125 | Merged into `feature/mip-nlp-solver` |
+| #115 | Feasibility-pump method and FP initialization | #126 | Merged into `feature/mip-nlp-solver` |
+| #116 | Level-set regularized OA variants | #127 | Merged into `feature/mip-nlp-solver` |
+| #117 | Lagrangian and SQP regularized OA variants | #128 | Merged into `feature/mip-nlp-solver` |
+| #118 | Global OA routing | #129 | Merged into `feature/mip-nlp-solver` |
+| #119 | LP/NLP branch-and-bound method | #130 | Merged into `feature/mip-nlp-solver` |
+| #120 | MIP-NLP solution-pool support | #131 | Merged into `feature/mip-nlp-solver` |
+
+## Pyomo MindtPy fixture disposition
+
+Pyomo MindtPy is a behavior and test reference only. Do not copy Pyomo source
+into discopt without a separate license and attribution review.
+
+- `MINLP3_simple.py`: incorporated in PR #128 as a cheap convex-guarantee
+  regularized-OA case. It remains part of the final checklist.
+- `MINLP4_simple.py`: deferred. The model is nominally a convex
+  regularization-paper example, but discopt's current classifier recognizes only
+  part of its reciprocal/fractional-power/geometric-mean structure as OA-valid.
+  A local regularized-OA probe returned infeasible, so this belongs in a future
+  convexity-classifier or regularized-OA follow-up rather than in the passing
+  #117 set.
+- `MINLP5_simple.py`: not a convex-OA guarantee case under the current OA
+  contract. It belongs with nonconvex GOA coverage, not with the #117 convex
+  regularized-OA guarantee tests.
+
+## Validation commands
+
+Run these before opening the upstream PR:
+
+```bash
+python -m ruff check python/
+python -m ruff format --check python/
+PYTHONPATH=python python -m pytest python/tests/test_mip_nlp.py python/tests/test_oa.py -q
+make test
+make docs
+```
+
+Optional solver-specific checks depend on installed commercial or compiled
+backends:
+
+```bash
+PYTHONPATH=python python -m pytest python/tests/test_gurobi_backend.py -q
+make test-amp-fast
+make test-correctness
+```
+
+If a solver extra is unavailable, record the skipped backend and the reason in
+the upstream PR body. Do not mark a backend as validated when the command
+skipped because Gurobi, cyipopt, Ipopt libraries, or another optional dependency
+was unavailable.
+
+## Upstream PR gate
+
+Before opening the upstream PR:
+
+1. Confirm `feature/mip-nlp-solver` contains the current `jkitchin:main` tip.
+2. Confirm all child PRs in the table above are merged or explicitly deferred.
+3. Run the validation commands above on the integration branch.
+4. Post the validation results on issue #121.
+5. Open one upstream PR from `bernalde:feature/mip-nlp-solver` to
+   `jkitchin:main`.

--- a/docs/mip_nlp.md
+++ b/docs/mip_nlp.md
@@ -1,0 +1,246 @@
+# MIP-NLP decomposition
+
+`solver="mip-nlp"` selects discopt's algebraic MINLP decomposition family. It is
+the user-facing entry point for outer approximation (OA), extended cutting plane
+(ECP), feasibility-pump initialization, global OA routing, and the LP/NLP
+branch-and-bound variant.
+
+Use this solver family when the model is a bounded algebraic MINLP and you want
+a decomposition algorithm built around MILP masters and fixed-integer NLP
+subproblems. For harder nonconvex models, compare it with the certified-global
+{doc}`AMP solver <notebooks/amp_global_minlp>`.
+
+## Selector contract
+
+MIP-NLP solving has two independent axes:
+
+| Axis | Option | Purpose |
+| --- | --- | --- |
+| Solver family | `solver="mip-nlp"` | Route the model to the MIP-NLP decomposition facade. |
+| Algebraic MINLP method | `mip_nlp_method=...` | Select OA, ECP, FP, GOA, or LP/NLP BB. |
+| GDP reformulation | `gdp_method=...` | Reformulate logical/disjunctive constraints before algebraic MIP-NLP solving. |
+
+`gdp_method` is not the MIP-NLP algorithm selector. It only controls GDP
+reformulation, currently `big-m`, `hull`, `mbigm`, or `auto`, before the
+algebraic MINLP method runs. Native GDP logic-based OA remains on the GDP axis
+and is separate from `solver="mip-nlp"`.
+
+```python
+result = model.solve(
+    solver="mip-nlp",
+    mip_nlp_method="oa",
+    gdp_method="hull",      # optional GDP reformulation axis
+)
+```
+
+Legacy calls that used `gdp_method="oa"` to request MINLP OA should migrate to:
+
+```python
+result = model.solve(solver="mip-nlp", mip_nlp_method="oa")
+```
+
+If the same model also contains GDP constructs, keep `gdp_method` for the
+reformulation choice:
+
+```python
+result = model.solve(
+    solver="mip-nlp",
+    mip_nlp_method="oa",
+    gdp_method="big-m",
+)
+```
+
+## Methods
+
+| `mip_nlp_method` | Role | Notes |
+| --- | --- | --- |
+| `"oa"` | Convex MINLP outer approximation {cite:p}`Duran1986` | Default. Builds MILP masters and solves fixed-integer NLP subproblems. |
+| `"ecp"` | Extended cutting plane | OA cut loop without fixed-integer NLP incumbent solves. |
+| `"fp"` | Standalone MIP-NLP feasibility pump {cite:p}`Fischetti2005,Bonami2009` | Heuristic incumbent search; does not by itself certify optimality. |
+| `"goa"` | Global OA routing | Convexity-certified models use OA; nonconvex models route through AMP/global relaxations. |
+| `"lp_nlp_bb"` | LP/NLP branch-and-bound {cite:p}`Quesada1992` | Requires `milp_solver="gurobi"` because it uses single-tree lazy callbacks. |
+
+`"roa"` is reserved for future regularized-OA naming. Use `"oa"` with
+`add_regularization=...` for the implemented regularization modes.
+
+## Outer approximation
+
+OA is the default MIP-NLP method. It is appropriate when the nonlinear
+constraints and objective are convex in the optimization sense and the integer
+variables appear in a way the MILP master can approximate with valid cuts.
+
+```python
+result = model.solve(
+    solver="mip-nlp",
+    mip_nlp_method="oa",
+    time_limit=120,
+    gap_tolerance=1e-4,
+    init_strategy="rNLP",
+    add_no_good_cuts=True,
+)
+```
+
+Useful OA options include:
+
+| Option | Purpose |
+| --- | --- |
+| `init_strategy` | Initial incumbent strategy: `"rNLP"`, `"initial_binary"`, `"max_binary"`, or `"fp"`. |
+| `equality_relaxation` | Relax nonlinear equalities into paired inequalities when supported. |
+| `feasibility_cuts` | Add feasibility cuts when fixed-integer NLP subproblems fail. |
+| `add_slack`, `max_slack`, `oa_penalty_factor` | Allow penalized master slacks for robustness. |
+| `feasibility_norm` | Norm used in feasibility-pump style repairs. |
+| `solution_pool`, `num_solution_iteration` | Iterate through a MILP solution pool; currently requires `milp_solver="gurobi"`. |
+
+Top-level aliases override duplicate entries in `mip_nlp_options`:
+
+```python
+result = model.solve(
+    solver="mip-nlp",
+    mip_nlp_method="oa",
+    mip_nlp_options={"init_strategy": "rNLP", "add_no_good_cuts": False},
+    init_strategy="fp",      # top-level value wins
+)
+```
+
+## ECP
+
+ECP uses the same selector family and OA option validation, but selects the
+cutting-plane path explicitly:
+
+```python
+result = model.solve(
+    solver="mip-nlp",
+    mip_nlp_method="ecp",
+    time_limit=120,
+    feasibility_cuts=True,
+)
+```
+
+`ecp_mode` is now derived from `mip_nlp_method`. Passing a conflicting explicit
+`ecp_mode` raises `ValueError` instead of silently choosing one method.
+
+## Feasibility-pump initialization
+
+For OA, `init_strategy="fp"` runs the MIP-NLP feasibility pump to seed the first
+incumbent before the OA loop.
+
+```python
+result = model.solve(
+    solver="mip-nlp",
+    mip_nlp_method="oa",
+    init_strategy="fp",
+    feasibility_norm="L_infinity",
+)
+```
+
+You can also run the feasibility pump as the selected method:
+
+```python
+result = model.solve(
+    solver="mip-nlp",
+    mip_nlp_method="fp",
+    feasibility_norm="L1",
+)
+```
+
+The standalone FP method is an incumbent heuristic. It is useful for finding an
+integer-feasible point quickly, but it is not a proof of global optimality unless
+a later certifying method closes the gap.
+
+## Regularized OA
+
+Regularization is selected as an OA option, not as a separate method selector.
+Implemented modes are `level_L1`, `level_L2`, `level_L_infinity`, `grad_lag`,
+`hess_lag`, `hess_only_lag`, and `sqp_lag`.
+
+```python
+result = model.solve(
+    solver="mip-nlp",
+    mip_nlp_method="oa",
+    init_strategy="rNLP",
+    add_regularization="level_L1",
+    level_coef=0.5,
+)
+```
+
+Derivative-based regularization modes use Lagrangian information from an
+initial fixed-integer NLP. They therefore need an NLP-based initialization that
+returns dual information; constrained models reject derivative regularization
+with `init_strategy="fp"` because FP does not provide that data.
+
+QP-shaped regularization modes such as `level_L2`, `hess_lag`,
+`hess_only_lag`, and `sqp_lag` require an available MIQP/QP-capable master
+backend. If no backend can solve the regularized master, discopt raises a backend
+error before claiming progress.
+
+## GOA
+
+`mip_nlp_method="goa"` is the global-OA facade. It first checks whether the model
+is convexity-certified. Convexity-certified models run through OA. Other models
+use the AMP/global-relaxation path, so AMP options may be passed through the same
+call.
+
+```python
+result = model.solve(
+    solver="mip-nlp",
+    mip_nlp_method="goa",
+    rel_gap=1e-4,
+    n_init_partitions=4,
+    partition_method="adaptive",
+    milp_solver="highs",
+)
+```
+
+AMP-only options are used only when GOA routes to the nonconvex AMP path. If GOA
+routes a convexity-certified model to OA, discopt warns about AMP-only options
+that do not apply.
+
+## LP/NLP branch-and-bound
+
+The LP/NLP BB variant keeps the master tree open and adds OA cuts lazily at
+integer assignments. That single-tree design requires callback support, so the
+implemented backend is currently Gurobi.
+
+```python
+result = model.solve(
+    solver="mip-nlp",
+    mip_nlp_method="lp_nlp_bb",
+    milp_solver="gurobi",
+    init_strategy="rNLP",
+)
+```
+
+Using another MILP backend with `lp_nlp_bb` raises a backend error. This does
+not mean general nonlinear expressions are sent to Gurobi; discopt still owns
+the MIP-NLP decomposition and uses Gurobi for the callback-capable LP/MILP
+master.
+
+## Backend limitations
+
+- `nlp_solver` controls fixed-integer NLP subproblems. POUNCE is the default
+  single-solve backend when installed, with cyipopt and the pure-JAX IPM used
+  where configured.
+- `milp_solver` controls MILP masters where a method exposes that option.
+  `highs`, `pounce`, `simplex`, `gurobi`, or `auto` may be accepted depending on
+  the method and installed extras.
+- `solution_pool=True` currently requires `milp_solver="gurobi"`.
+- `lp_nlp_bb` requires `milp_solver="gurobi"` for lazy callbacks.
+- MIP-NLP methods ignore branch-and-bound-only options such as spatial branching
+  policy, learned relaxations, and sub-NLP frequency. discopt reports ignored
+  solve options with a warning rather than silently applying them.
+
+## Result interpretation
+
+Read the returned `SolveResult` the same way as other discopt solvers:
+
+```python
+result.status
+result.objective
+result.bound
+result.gap
+result.gap_certified
+```
+
+For OA, ECP, GOA-on-OA, and LP/NLP BB, a certified result requires a valid bound
+and closed gap. For standalone FP, treat the result as a heuristic incumbent
+unless another method has subsequently certified it.

--- a/python/discopt/solver.py
+++ b/python/discopt/solver.py
@@ -2201,7 +2201,7 @@ def solve_model(
         AMP algorithm with Gurobi as the MILP-master subsolver, use
         ``solver="amp", milp_solver="gurobi"``.
         Use ``"mip-nlp"`` to dispatch to the MIP-NLP decomposition family
-        (OA/ECP/FP/GOA now; ROA/LP-NLP-BB are reserved method selectors).
+        (OA/ECP/FP/GOA/LP-NLP-BB now; ROA is a reserved method selector).
         Use ``"gp"`` to dispatch to the geometric-programming fast path:
         the model is checked for GP structure (posynomial/monomial
         objective and constraints over strictly-positive continuous
@@ -2230,8 +2230,8 @@ def solve_model(
     solver="mip-nlp" options
         The MIP-NLP backend accepts ``mip_nlp_method`` and
         ``mip_nlp_options``. Current implemented methods are ``"oa"``,
-        ``"ecp"``, ``"fp"``, and ``"goa"``; ``"roa"`` and ``"lp_nlp_bb"`` raise
-        ``NotImplementedError`` until their dedicated implementations land.
+        ``"ecp"``, ``"fp"``, ``"goa"``, and ``"lp_nlp_bb"``; ``"roa"`` raises
+        ``NotImplementedError`` until its dedicated implementation lands.
         Existing OA options ``equality_relaxation``, ``ecp_mode``,
         ``feasibility_cuts``, ``heuristic_nonconvex``, ``add_slack``,
         ``max_slack``, ``oa_penalty_factor``, ``add_no_good_cuts``,
@@ -2240,7 +2240,10 @@ def solve_model(
         ``num_solution_iteration``, and ``milp_solver`` plus initialization
         option ``init_strategy`` may be passed as top-level aliases and take
         precedence over duplicate keys in ``mip_nlp_options``. ``solution_pool``
-        currently requires ``milp_solver="gurobi"``.
+        currently requires ``milp_solver="gurobi"``. For
+        ``mip_nlp_method="lp_nlp_bb"``, ``milp_solver="gurobi"`` is also
+        required because the single-tree LP/NLP branch-and-bound variant uses
+        lazy master callbacks.
         For ``mip_nlp_method="goa"``, convexity-certified MINLPs use OA's
         valid master bounds and other models use AMP/global relaxations.
         AMP options such as ``rel_gap``, ``abs_tol``, ``max_iter``,

--- a/python/tests/test_gurobi_backend.py
+++ b/python/tests/test_gurobi_backend.py
@@ -487,25 +487,27 @@ def test_model_solve_amp_forwards_gurobi_milp_solver(monkeypatch):
 
 
 def test_model_solve_oa_forwards_gurobi_milp_solver(monkeypatch):
-    import discopt.solvers.oa as oa_module
+    import discopt.solvers.mip_nlp as mip_nlp_module
 
     calls = {}
 
-    def fake_solve_oa(model, **kwargs):
+    def fake_solve_mip_nlp(model, **kwargs):
         calls["model"] = model
+        calls["method"] = kwargs["method"]
         calls["milp_solver"] = kwargs["milp_solver"]
         return SolveResult(status="optimal", objective=0.0, bound=0.0, gap=0.0)
 
-    monkeypatch.setattr(oa_module, "solve_oa", fake_solve_oa)
+    monkeypatch.setattr(mip_nlp_module, "solve_mip_nlp", fake_solve_mip_nlp)
 
     m = dm.Model("oa_gurobi_milp_solver_forwarding")
     x = m.binary("x")
     m.minimize(x)
 
-    result = m.solve(gdp_method="oa", milp_solver="gurobi", skip_convex_check=True)
+    result = m.solve(solver="mip-nlp", mip_nlp_method="oa", milp_solver="gurobi")
 
     assert result.status == "optimal"
     assert calls["model"] is m
+    assert calls["method"] == "oa"
     assert calls["milp_solver"] == "gurobi"
 
 
@@ -1257,9 +1259,9 @@ def test_oa_gurobi_converges_on_degenerate_convex_minlp_if_available():
     m.minimize((x - 2) ** 2 + (y - 1.5) ** 2)
 
     result = m.solve(
-        gdp_method="oa",
+        solver="mip-nlp",
+        mip_nlp_method="oa",
         milp_solver="gurobi",
-        skip_convex_check=True,
         max_nodes=20,
         time_limit=30,
     )


### PR DESCRIPTION
## Summary

- Add a user-facing MIP-NLP decomposition docs page covering `solver="mip-nlp"`, `mip_nlp_method`, OA, ECP, FP initialization, regularized OA, GOA, LP/NLP BB, backend limits, and migration from legacy `gdp_method="oa"`.
- Add an upstream-readiness checklist for the MIP-NLP issue series, including child issue/PR disposition, Pyomo MindtPy fixture notes, validation commands, and final upstream PR gate.
- Correct the `Model.solve` docstring so generated API docs no longer describe `lp_nlp_bb` as reserved.

## Tests

- `python -m py_compile python/discopt/solver.py` -> passed.
- `python -m ruff check python/discopt/solver.py` -> passed.
- `python -m ruff format --check python/discopt/solver.py` -> passed.
- `PYTHONPATH=python python -m pytest python/tests/test_mip_nlp.py -q` -> 98 passed, 2 skipped, 7 deselected.
- `PYTHONPATH=python python -m pytest python/tests/test_oa.py -q` -> 22 passed, 10 deselected.
- Commit hook on `3c0893c`: `ruff`, `ruff format`, and `mypy` passed; `cargo fmt` skipped because no Rust files were staged.

Broader checks attempted:

- `make docs` -> blocked before reading docs content because the local MyST/Jupyter Book toolchain reports `npm` as missing.
- `make test PYTHON=.venv/bin/python PYTEST=.venv/bin/pytest MATURIN=.venv/bin/maturin RUFF=.venv/bin/ruff` -> built the Rust extension after network escalation, then failed in existing broad-suite AMP/JAX/Pounce worker aborts unrelated to this docs/docstring change.
- `make test ... PYTEST_XDIST_WORKERS=2` -> still failed outside this change with xdist worker aborts / memory pressure around existing solver tests such as `test_amp_simplex_backend.py::test_same_certificate_as_default` and `test_batch_evaluator.py::TestBatchMatchesSerial::test_parametric`.

## Branch Hygiene

- Base branch: `feature/mip-nlp-solver`.
- Head branch: `fix/issue-121-docs-readiness`.
- Source branch point: `origin/feature/mip-nlp-solver` at `14db514`.
- Non-default base: yes. This is an issue-series child PR into the fork integration branch, not a direct PR to `main`.
- Fork main sync: `origin/main` was synced with `upstream/main` by merge commit `35a63db`.
- Upstream baseline: `upstream/main` at `5d593ae` is included in the integration branch.
- Stacked status: not stacked on another child branch; the child branch was created directly from the refreshed integration base.
- Prerequisite issue-series PRs: #122 through #131 are merged into `feature/mip-nlp-solver`.

Refs #121
