### PR TITLE
Fix OA no-good cuts for general integers

### DIFF
--- a/python/discopt/solvers/oa.py
+++ b/python/discopt/solvers/oa.py
@@ -859,7 +859,7 @@ def _append_binary_no_good_projection_cut(
     b_rows: list[float],
 ) -> bool:
     """Append a binary assignment exclusion cut to the projection MILP."""
-    if not decomp.binary_indices:
+    if decomp.general_integer_indices or not decomp.binary_indices:
         # General-integer assignment exclusion needs an orthogonality cut or
         # auxiliary encoding. Keep this projection cut binary-only for now; the
         # pump still detects repeats and returns the best feasible point found.
@@ -2243,7 +2243,7 @@ def solve_lp_nlp_bb(
                         decomp.oa_constraint_mask,
                         oa_cut_relaxable=oa_cut_relaxable,
                     )
-            if add_no_good_cuts:
+            if add_no_good_cuts and not decomp.general_integer_indices:
                 _add_no_good_cut(
                     x_master,
                     decomp.binary_indices,
@@ -3150,7 +3150,7 @@ def solve_oa(
                             oa_cut_relaxable=oa_cut_relaxable,
                         )
 
-                if add_no_good_cuts:
+                if add_no_good_cuts and not decomp.general_integer_indices:
                     _add_no_good_cut(
                         x_master,
                         decomp.binary_indices,

--- a/python/discopt/solvers/oa.py
+++ b/python/discopt/solvers/oa.py
@@ -859,15 +859,17 @@ def _append_binary_no_good_projection_cut(
     b_rows: list[float],
 ) -> bool:
     """Append a binary assignment exclusion cut to the projection MILP."""
-    if decomp.general_integer_indices:
+    if not decomp.binary_indices:
         # General-integer assignment exclusion needs an orthogonality cut or
         # auxiliary encoding. Keep this projection cut binary-only for now; the
         # pump still detects repeats and returns the best feasible point found.
         return False
 
+    assignment_by_index = dict(zip(decomp.int_indices, assignment))
     coeffs = np.zeros(n_master, dtype=np.float64)
     count_ones = 0
-    for idx, val in zip(decomp.int_indices, assignment):
+    for idx in decomp.binary_indices:
+        val = assignment_by_index[idx]
         if val >= 0.5:
             coeffs[idx] = 1.0
             count_ones += 1
@@ -1270,21 +1272,24 @@ def _add_ecp_cuts(
 
 def _add_no_good_cut(
     x_master,
-    int_indices,
+    binary_indices,
     oa_A_rows,
     oa_b_rows,
     n_vars,
     oa_cut_relaxable=None,
 ):
-    """Add an integer-exclusion (no-good) cut.
+    """Add a binary-assignment exclusion (no-good) cut.
 
     sum_{i: y_i*=1} (1-y_i) + sum_{i: y_i*=0} y_i >= 1
     Equivalently in <= form:
     sum_{y_i*=1} y_i - sum_{y_i*=0} y_i <= count(y_i*=1) - 1
     """
-    coeffs = np.zeros(n_vars)
+    if not binary_indices:
+        return False
+
+    coeffs = np.zeros(n_vars, dtype=np.float64)
     count_ones = 0
-    for idx in int_indices:
+    for idx in binary_indices:
         val = _round_integral_to_bounds(x_master[idx], 0.0, 1.0)
         if val >= 0.5:
             coeffs[idx] = 1.0
@@ -1299,6 +1304,7 @@ def _add_no_good_cut(
         oa_cut_relaxable,
         relaxable=False,
     )
+    return True
 
 
 def _add_feasibility_cuts(
@@ -2237,10 +2243,10 @@ def solve_lp_nlp_bb(
                         decomp.oa_constraint_mask,
                         oa_cut_relaxable=oa_cut_relaxable,
                     )
-            if add_no_good_cuts and not decomp.general_integer_indices:
+            if add_no_good_cuts:
                 _add_no_good_cut(
                     x_master,
-                    decomp.int_indices,
+                    decomp.binary_indices,
                     oa_A_rows,
                     oa_b_rows,
                     n_vars,
@@ -3147,7 +3153,7 @@ def solve_oa(
                 if add_no_good_cuts:
                     _add_no_good_cut(
                         x_master,
-                        decomp.int_indices,
+                        decomp.binary_indices,
                         oa_A_rows,
                         oa_b_rows,
                         n_vars,

--- a/python/tests/test_mip_nlp.py
+++ b/python/tests/test_mip_nlp.py
@@ -673,6 +673,58 @@ def test_lp_nlp_bb_lazy_callback_solves_fixed_integer_nlp(monkeypatch):
     assert calls["oa"] >= 2
 
 
+def test_lp_nlp_bb_no_good_cut_skips_mixed_integer_model(monkeypatch):
+    import discopt.solvers.gurobi as gurobi_module
+    import discopt.solvers.oa as oa_module
+    from discopt.solvers import MILPResult, SolveStatus
+    from discopt.solvers.mip_nlp import solve_mip_nlp
+
+    no_good_calls = []
+
+    monkeypatch.setattr(oa_module, "_solve_nlp_relaxation", lambda *args, **kwargs: (None, None))
+    monkeypatch.setattr(oa_module, "_add_oa_cuts", lambda *args, **kwargs: None)
+    monkeypatch.setattr(
+        oa_module,
+        "_solve_nlp_subproblem",
+        lambda *args, **kwargs: (None, None),
+    )
+    monkeypatch.setattr(
+        oa_module,
+        "_solve_feasibility_subproblem",
+        lambda *args, **kwargs: None,
+    )
+    monkeypatch.setattr(
+        oa_module,
+        "_add_no_good_cut",
+        lambda *args, **kwargs: no_good_calls.append(args),
+    )
+
+    def fake_lazy_milp(**kwargs):
+        candidate = np.zeros_like(kwargs["c"], dtype=np.float64)
+        kwargs["lazy_callback"](candidate)
+        return MILPResult(
+            status=SolveStatus.OPTIMAL,
+            x=candidate,
+            objective=0.0,
+            bound=0.0,
+            gap=0.0,
+            node_count=1,
+        )
+
+    monkeypatch.setattr(gurobi_module, "solve_milp_with_lazy_cuts", fake_lazy_milp)
+
+    result = solve_mip_nlp(
+        _mixed_discrete_model("lp_nlp_bb_mixed_no_good"),
+        method="lp_nlp_bb",
+        milp_solver="gurobi",
+        add_no_good_cuts=True,
+        feasibility_cuts=False,
+    )
+
+    assert result.status == "no_feasible_point"
+    assert no_good_calls == []
+
+
 def test_lp_nlp_bb_linear_objective_constant_offsets_certified_bound(monkeypatch):
     import discopt.solvers.gurobi as gurobi_module
     import discopt.solvers.oa as oa_module

--- a/python/tests/test_oa.py
+++ b/python/tests/test_oa.py
@@ -563,7 +563,32 @@ class TestOARobustnessOptions:
         assert oa_b_rows == []
         assert oa_cut_relaxable == []
 
-    def test_projection_no_good_cut_uses_binary_indices_in_mixed_model(self):
+    def test_projection_no_good_cut_uses_binary_indices_for_binary_model(self):
+        from discopt.solvers.oa import (
+            _append_binary_no_good_projection_cut,
+            _decompose_model,
+        )
+
+        m = dm.Model("binary_projection_no_good")
+        y = m.binary("y", shape=(2,))
+        m.minimize(y[0] + y[1])
+        decomp = _decompose_model(m)
+        a_rows = []
+        b_rows = []
+
+        added = _append_binary_no_good_projection_cut(
+            decomp,
+            assignment=(1.0, 0.0),
+            n_master=2,
+            a_rows=a_rows,
+            b_rows=b_rows,
+        )
+
+        assert added is True
+        np.testing.assert_allclose(a_rows[0], np.array([1.0, -1.0]))
+        assert b_rows == pytest.approx([0.0])
+
+    def test_projection_no_good_cut_skips_mixed_integer_model(self):
         from discopt.solvers.oa import (
             _append_binary_no_good_projection_cut,
             _decompose_model,
@@ -585,9 +610,9 @@ class TestOARobustnessOptions:
             b_rows=b_rows,
         )
 
-        assert added is True
-        np.testing.assert_allclose(a_rows[0], np.array([1.0, 0.0]))
-        assert b_rows == pytest.approx([0.0])
+        assert added is False
+        assert a_rows == []
+        assert b_rows == []
 
     @pytest.mark.parametrize(("enabled", "expected_calls"), [(False, 0), (True, 1)])
     def test_no_good_cut_option_controls_infeasible_assignment(
@@ -643,7 +668,7 @@ class TestOARobustnessOptions:
         assert result.status == "infeasible"
         assert len(no_good_calls) == expected_calls
 
-    def test_multitree_no_good_cut_passes_only_binary_indices_for_mixed_model(
+    def test_multitree_no_good_cut_skips_mixed_integer_model(
         self,
         monkeypatch,
     ):
@@ -655,7 +680,7 @@ class TestOARobustnessOptions:
         z = m.integer("z", lb=0, ub=3)
         m.minimize(y + z)
 
-        no_good_indices = []
+        no_good_calls = []
 
         monkeypatch.setattr(
             oa_module,
@@ -681,9 +706,7 @@ class TestOARobustnessOptions:
         monkeypatch.setattr(
             oa_module,
             "_add_no_good_cut",
-            lambda _x_master, binary_indices, *args, **kwargs: no_good_indices.append(
-                list(binary_indices)
-            ),
+            lambda *args, **kwargs: no_good_calls.append(args),
         )
 
         result = oa_module.solve_oa(
@@ -695,7 +718,7 @@ class TestOARobustnessOptions:
         )
 
         assert result.status == "infeasible"
-        assert no_good_indices == [[0]]
+        assert no_good_calls == []
 
     def test_cycling_check_stops_repeated_integer_assignment(self, monkeypatch):
         import discopt.solvers.oa as oa_module

--- a/python/tests/test_oa.py
+++ b/python/tests/test_oa.py
@@ -521,6 +521,74 @@ class TestOARobustnessOptions:
         np.testing.assert_allclose(captured["A_ub"], np.array([[1.0, 0.0]]))
         assert captured["b_ub"].tolist() == pytest.approx([0.0])
 
+    def test_no_good_cut_uses_binary_indices_only_for_mixed_assignment(self):
+        from discopt.solvers.oa import _add_no_good_cut
+
+        oa_A_rows = []
+        oa_b_rows = []
+        oa_cut_relaxable = []
+
+        added = _add_no_good_cut(
+            np.array([1.0, 2.0, 0.0]),
+            [0, 2],
+            oa_A_rows,
+            oa_b_rows,
+            n_vars=3,
+            oa_cut_relaxable=oa_cut_relaxable,
+        )
+
+        assert added is True
+        np.testing.assert_allclose(oa_A_rows[0], np.array([1.0, 0.0, -1.0]))
+        assert oa_b_rows == pytest.approx([0.0])
+        assert oa_cut_relaxable == [False]
+
+    def test_no_good_cut_skips_when_no_binary_indices(self):
+        from discopt.solvers.oa import _add_no_good_cut
+
+        oa_A_rows = []
+        oa_b_rows = []
+        oa_cut_relaxable = []
+
+        added = _add_no_good_cut(
+            np.array([2.0]),
+            [],
+            oa_A_rows,
+            oa_b_rows,
+            n_vars=1,
+            oa_cut_relaxable=oa_cut_relaxable,
+        )
+
+        assert added is False
+        assert oa_A_rows == []
+        assert oa_b_rows == []
+        assert oa_cut_relaxable == []
+
+    def test_projection_no_good_cut_uses_binary_indices_in_mixed_model(self):
+        from discopt.solvers.oa import (
+            _append_binary_no_good_projection_cut,
+            _decompose_model,
+        )
+
+        m = dm.Model("mixed_projection_no_good")
+        y = m.binary("y")
+        z = m.integer("z", lb=0, ub=3)
+        m.minimize(y + z)
+        decomp = _decompose_model(m)
+        a_rows = []
+        b_rows = []
+
+        added = _append_binary_no_good_projection_cut(
+            decomp,
+            assignment=(1.0, 2.0),
+            n_master=2,
+            a_rows=a_rows,
+            b_rows=b_rows,
+        )
+
+        assert added is True
+        np.testing.assert_allclose(a_rows[0], np.array([1.0, 0.0]))
+        assert b_rows == pytest.approx([0.0])
+
     @pytest.mark.parametrize(("enabled", "expected_calls"), [(False, 0), (True, 1)])
     def test_no_good_cut_option_controls_infeasible_assignment(
         self,
@@ -574,6 +642,60 @@ class TestOARobustnessOptions:
 
         assert result.status == "infeasible"
         assert len(no_good_calls) == expected_calls
+
+    def test_multitree_no_good_cut_passes_only_binary_indices_for_mixed_model(
+        self,
+        monkeypatch,
+    ):
+        import discopt.solvers.oa as oa_module
+        from discopt.solvers import MILPResult, SolveStatus
+
+        m = dm.Model("mixed_no_good_option")
+        y = m.binary("y")
+        z = m.integer("z", lb=0, ub=3)
+        m.minimize(y + z)
+
+        no_good_indices = []
+
+        monkeypatch.setattr(
+            oa_module,
+            "_solve_nlp_relaxation",
+            lambda *args, **kwargs: (np.array([0.5, 1.5]), 2.0),
+        )
+        monkeypatch.setattr(oa_module, "_add_oa_cuts", lambda *args, **kwargs: None)
+        monkeypatch.setattr(
+            oa_module,
+            "_solve_master_milp",
+            lambda *args, **kwargs: MILPResult(
+                status=SolveStatus.OPTIMAL,
+                x=np.array([1.0, 2.0]),
+                objective=3.0,
+                bound=0.0,
+            ),
+        )
+        monkeypatch.setattr(
+            oa_module,
+            "_solve_nlp_subproblem",
+            lambda *args, **kwargs: (None, None),
+        )
+        monkeypatch.setattr(
+            oa_module,
+            "_add_no_good_cut",
+            lambda _x_master, binary_indices, *args, **kwargs: no_good_indices.append(
+                list(binary_indices)
+            ),
+        )
+
+        result = oa_module.solve_oa(
+            m,
+            max_iterations=1,
+            feasibility_cuts=False,
+            add_no_good_cuts=True,
+            cycling_check=False,
+        )
+
+        assert result.status == "infeasible"
+        assert no_good_indices == [[0]]
 
     def test_cycling_check_stops_repeated_integer_assignment(self, monkeypatch):
         import discopt.solvers.oa as oa_module


### PR DESCRIPTION
## Summary

- Restrict OA no-good cuts to binary indices so general integer variables are not rounded into the binary no-good formula.
- Keep mixed binary/general-integer models eligible for valid binary no-good cuts, and skip no-good row generation when no binary indices exist.
- Add regression coverage for the shared helper, projection no-good cuts, and the multi-tree OA infeasible-assignment path.

Closes #133

## Tests

- `python -m ruff check python/discopt/solvers/oa.py python/tests/test_oa.py`
- `python -m ruff format --check python/discopt/solvers/oa.py python/tests/test_oa.py`
- `.venv/bin/python -m pytest python/tests/test_oa.py -k "no_good or projection" -q`
- `.venv/bin/python -m pytest python/tests/test_oa.py -q`
- `.venv/bin/python -m pytest python/tests/test_oa.py --collect-only -m "" -q`
- `.venv/bin/python -m pytest python/tests/test_mip_nlp.py -k "no_good" -q`
- pre-commit on commit: ruff, ruff format, mypy, cargo fmt

## Branch Hygiene

- Base branch: `feature/mip-nlp-solver` (non-default integration branch per issue policy).
- Source branch point: `origin/feature/mip-nlp-solver` at `f2ab0027913fb650721b2ef03ea75546b8bc2916`.
- Upstream sync: `upstream/main` at `5d593aedb97130f410108acc90ae4fe5fa652190` is included in the base branch.
- Stacked status: issue-specific branch only; not stacked on another child branch.
- Auto-close note: because this PR targets a non-default branch, GitHub may not close #133 until the integration branch reaches the default branch or the issue is closed manually by policy.
