### PR TITLE
Add feasibility pump option controls

### DIFF
--- a/docs/mip_nlp.md
+++ b/docs/mip_nlp.md
@@ -147,6 +147,26 @@ The standalone FP method is an incumbent heuristic. It is useful for finding an
 integer-feasible point quickly, but it is not a proof of global optimality unless
 a later certifying method closes the gap.
 
+MindtPy-style FP controls supported by discopt are intentionally scoped:
+
+| Option | Semantics |
+| --- | --- |
+| `fp_iteration_limit` | Caps FP rounds independently from the OA iteration limit. OA/GOA FP initialization still defaults to `min(max_nodes, 10)` when this is omitted. |
+| `fp_main_norm` | Norm used by the projection MILP distance objective. If omitted, it follows `feasibility_norm`. |
+| `feasibility_norm` | Norm used to score nonlinear constraint violation in fixed-integer feasibility repair subproblems. |
+| `fp_discrete_only` | Controls whether projection distance is computed only over discrete variables (`True`, the default) or over all variables. |
+| `fp_projcuts` | Controls discopt's projection-MILP path with binary no-good cuts. When `False`, FP falls back to direct integer rounding. It does not transfer projection cuts into OA masters. |
+| `fp_projzerotol` | Treats projection targets near zero as zero when zero is within bounds. |
+| `fp_mipgap` | Gap tolerance for FP projection MILPs; defaults to `gap_tolerance`. |
+
+The MindtPy names `fp_transfercuts=True`, `fp_norm_constraint=True`,
+non-default `fp_norm_constraint_coef`, and nonzero `fp_cutoffdecr` are not
+implemented by discopt's FP path yet. Passing them raises `ValueError` instead
+of silently changing neither the projection loop nor OA/GOA certificate state.
+FP-generated cuts are therefore local to the pump; `init_strategy="fp"` may seed
+OA/GOA incumbents and initial cuts at the pump point, but it does not import
+projection no-good cuts into certified OA bounds.
+
 ## Regularized OA
 
 Regularization is selected as an OA option, not as a separate method selector.

--- a/python/discopt/solver.py
+++ b/python/discopt/solver.py
@@ -2422,7 +2422,7 @@ def solve_model(
         import warnings
 
         from discopt.solvers.mip_nlp import solve_mip_nlp
-        from discopt.solvers.mip_nlp_options import GOA_OPTION_KEYS
+        from discopt.solvers.mip_nlp_options import FP_OPTION_KEYS, GOA_OPTION_KEYS
 
         mip_nlp_method = kwargs.pop("mip_nlp_method", None)
         mip_nlp_options = kwargs.pop("mip_nlp_options", None)
@@ -2446,6 +2446,7 @@ def solve_model(
             "milp_solver",
             "solution_pool",
             "num_solution_iteration",
+            *FP_OPTION_KEYS,
         ):
             if key in kwargs:
                 mip_nlp_kwargs[key] = kwargs.pop(key)
@@ -2769,6 +2770,7 @@ def solve_model(
 
         from discopt._jax.gdp_reformulate import reformulate_gdp
         from discopt.solvers.mip_nlp import solve_mip_nlp
+        from discopt.solvers.mip_nlp_options import FP_OPTION_KEYS
 
         warnings.warn(
             "gdp_method='oa' is deprecated for selecting MINLP OA. Use "
@@ -2799,6 +2801,7 @@ def solve_model(
             "milp_solver",
             "solution_pool",
             "num_solution_iteration",
+            *FP_OPTION_KEYS,
         ):
             if key in kwargs:
                 mip_nlp_kwargs[key] = kwargs.pop(key)

--- a/python/discopt/solvers/mip_nlp.py
+++ b/python/discopt/solvers/mip_nlp.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from typing import Any, Optional
 
 from discopt.modeling.core import Model, SolveResult
-from discopt.solvers.mip_nlp_options import GOA_OPTION_KEYS
+from discopt.solvers.mip_nlp_options import FP_OPTION_KEYS, GOA_OPTION_KEYS
 
 _IMPLEMENTED_METHODS = frozenset({"oa", "ecp", "fp", "goa", "lp_nlp_bb"})
 _RESERVED_METHOD_ISSUES = {
@@ -34,6 +34,7 @@ _OA_OPTION_KEYS = frozenset(
         "milp_solver",
         "solution_pool",
         "num_solution_iteration",
+        *FP_OPTION_KEYS,
     }
 )
 _OA_OPTION_ALIASES = {
@@ -44,6 +45,7 @@ _FP_OPTION_KEYS = frozenset(
         "add_no_good_cuts",
         "feasibility_norm",
         "init_strategy",
+        *FP_OPTION_KEYS,
     }
 )
 _LP_NLP_BB_OPTION_KEYS = frozenset(
@@ -153,6 +155,16 @@ def solve_mip_nlp(
                 initial_point=initial_point,
                 add_no_good_cuts=bool(options.get("add_no_good_cuts", True)),
                 feasibility_norm=options.get("feasibility_norm", "L_infinity"),
+                fp_iteration_limit=options.get("fp_iteration_limit"),
+                fp_cutoffdecr=options.get("fp_cutoffdecr", 0.0),
+                fp_projcuts=options.get("fp_projcuts"),
+                fp_transfercuts=options.get("fp_transfercuts", False),
+                fp_projzerotol=options.get("fp_projzerotol", 0.0),
+                fp_mipgap=options.get("fp_mipgap"),
+                fp_discrete_only=options.get("fp_discrete_only", True),
+                fp_main_norm=options.get("fp_main_norm"),
+                fp_norm_constraint=options.get("fp_norm_constraint", False),
+                fp_norm_constraint_coef=options.get("fp_norm_constraint_coef", 1.0),
             )
 
         if method == "goa":

--- a/python/discopt/solvers/mip_nlp_options.py
+++ b/python/discopt/solvers/mip_nlp_options.py
@@ -4,11 +4,25 @@ from __future__ import annotations
 
 from typing import Any
 
+FP_OPTION_KEYS = (
+    "fp_iteration_limit",
+    "fp_cutoffdecr",
+    "fp_projcuts",
+    "fp_transfercuts",
+    "fp_projzerotol",
+    "fp_mipgap",
+    "fp_discrete_only",
+    "fp_main_norm",
+    "fp_norm_constraint",
+    "fp_norm_constraint_coef",
+)
+
 GOA_OA_FORWARD_OPTION_KEYS = (
     "rel_gap",
     "max_iter",
     "init_strategy",
     "feasibility_norm",
+    *FP_OPTION_KEYS,
 )
 
 GOA_AMP_OPTION_DEFAULTS: dict[str, Any] = {

--- a/python/discopt/solvers/oa.py
+++ b/python/discopt/solvers/oa.py
@@ -30,7 +30,11 @@ from typing import TYPE_CHECKING, Optional
 import numpy as np
 
 from discopt.modeling.core import Constraint, Model, ObjectiveSense, SolveResult, VarType
-from discopt.solvers.mip_nlp_options import GOA_AMP_ONLY_OPTION_KEYS, GOA_AMP_OPTION_DEFAULTS
+from discopt.solvers.mip_nlp_options import (
+    FP_OPTION_KEYS,
+    GOA_AMP_ONLY_OPTION_KEYS,
+    GOA_AMP_OPTION_DEFAULTS,
+)
 
 if TYPE_CHECKING:
     from discopt._jax.nlp_evaluator import NLPEvaluator
@@ -133,6 +137,14 @@ def _normalize_open_unit_float(name: str, value: float) -> float:
     return out
 
 
+def _normalize_nonnegative_float(name: str, value: float) -> float:
+    """Validate a finite nonnegative float option."""
+    out = float(value)
+    if not np.isfinite(out) or out < 0:
+        raise ValueError(f"{name} must be a finite nonnegative number, got {value!r}.")
+    return out
+
+
 def _normalize_optional_positive_int(name: str, value: Optional[int]) -> Optional[int]:
     """Validate a positive integer option, allowing None to disable it."""
     if value is None:
@@ -149,6 +161,21 @@ def _normalize_positive_int(name: str, value: int) -> int:
     if out <= 0:
         raise ValueError(f"{name} must be a positive integer, got {value!r}.")
     return out
+
+
+def _fp_iteration_count(
+    max_iterations: int,
+    fp_iteration_limit: Optional[int],
+    *,
+    default_cap: Optional[int] = None,
+) -> int:
+    """Resolve the FP loop count from explicit and legacy iteration controls."""
+    if fp_iteration_limit is not None:
+        return _normalize_positive_int("fp_iteration_limit", fp_iteration_limit)
+    limit = int(max_iterations) if int(max_iterations) > 0 else 1
+    if default_cap is not None:
+        limit = min(limit, int(default_cap))
+    return max(1, limit)
 
 
 def _require_solution_pool_backend(milp_solver: str) -> None:
@@ -293,6 +320,83 @@ class OAConfig:
     stalling_limit: Optional[int] = None
     cycling_check: bool = False
     log_iterations: bool = True
+
+
+@dataclass(frozen=True)
+class _FPConfig:
+    """Normalized feasibility-pump option bundle."""
+
+    feasibility_norm: str
+    main_norm: str
+    add_no_good_cuts: bool
+    iteration_limit: Optional[int]
+    projzerotol: float
+    mipgap: Optional[float]
+    discrete_only: bool
+
+
+def _normalize_fp_config(
+    *,
+    feasibility_norm: str,
+    add_no_good_cuts: bool,
+    fp_iteration_limit: Optional[int] = None,
+    fp_cutoffdecr: float = 0.0,
+    fp_projcuts: Optional[bool] = None,
+    fp_transfercuts: bool = False,
+    fp_projzerotol: float = 0.0,
+    fp_mipgap: Optional[float] = None,
+    fp_discrete_only: bool = True,
+    fp_main_norm: Optional[str] = None,
+    fp_norm_constraint: bool = False,
+    fp_norm_constraint_coef: float = 1.0,
+) -> _FPConfig:
+    """Normalize supported MindtPy-style FP controls and reject unsupported ones."""
+    normalized_feasibility_norm = _normalize_feasibility_norm(feasibility_norm)
+    normalized_main_norm = _normalize_feasibility_norm(
+        normalized_feasibility_norm if fp_main_norm is None else fp_main_norm
+    )
+    iteration_limit = _normalize_optional_positive_int("fp_iteration_limit", fp_iteration_limit)
+    projection_cuts = bool(add_no_good_cuts if fp_projcuts is None else fp_projcuts)
+    projzerotol = _normalize_nonnegative_float("fp_projzerotol", fp_projzerotol)
+    mipgap = None if fp_mipgap is None else _normalize_nonnegative_float("fp_mipgap", fp_mipgap)
+    discrete_only = bool(fp_discrete_only)
+
+    cutoffdecr = _normalize_nonnegative_float("fp_cutoffdecr", fp_cutoffdecr)
+    if cutoffdecr > 0.0:
+        raise ValueError(
+            "Unsupported feasibility-pump option fp_cutoffdecr: discopt does not "
+            "currently add improving-objective cutoff constraints during FP. Use "
+            "fp_cutoffdecr=0.0."
+        )
+    if bool(fp_transfercuts):
+        raise ValueError(
+            "Unsupported feasibility-pump option fp_transfercuts=True: FP projection "
+            "cuts are not transferred into OA/GOA master problems. Use "
+            "fp_transfercuts=False."
+        )
+    if bool(fp_norm_constraint):
+        raise ValueError(
+            "Unsupported feasibility-pump option fp_norm_constraint=True: discopt "
+            "does not currently add monotonic norm constraints to FP-NLP subproblems. "
+            "Use fp_norm_constraint=False."
+        )
+    norm_coef = _normalize_positive_float("fp_norm_constraint_coef", fp_norm_constraint_coef)
+    if norm_coef != 1.0:
+        raise ValueError(
+            "Unsupported feasibility-pump option fp_norm_constraint_coef: this option "
+            "has no effect unless fp_norm_constraint=True, which discopt does not "
+            "currently support. Use fp_norm_constraint_coef=1.0."
+        )
+
+    return _FPConfig(
+        feasibility_norm=normalized_feasibility_norm,
+        main_norm=normalized_main_norm,
+        add_no_good_cuts=projection_cuts,
+        iteration_limit=iteration_limit,
+        projzerotol=projzerotol,
+        mipgap=mipgap,
+        discrete_only=discrete_only,
+    )
 
 
 @dataclass
@@ -884,9 +988,11 @@ def _solve_integer_projection_mip(
     decomp: _DecomposedProblem,
     target: np.ndarray,
     seen_assignments: set[tuple[float, ...]],
-    feasibility_norm: str,
+    projection_norm: str,
     time_limit: float,
     gap_tolerance: float,
+    discrete_only: bool = True,
+    projzerotol: float = 0.0,
     milp_solver: str = "auto",
 ) -> Optional[np.ndarray]:
     """Project the current point to a new integer assignment with a small MILP.
@@ -894,6 +1000,9 @@ def _solve_integer_projection_mip(
     The projection objective is L1 for ``L1`` and as a MILP-compatible surrogate
     for ``L2``. The fixed-integer feasibility NLP still scores candidates with
     the requested L2 merit. ``L_infinity`` uses one shared deviation variable.
+    By default the distance is computed over discrete variables only, matching
+    discopt's original FP semantics; ``discrete_only=False`` also penalizes
+    continuous-variable movement in the projection MILP.
     """
     try:
         from discopt.solvers import SolveStatus
@@ -904,8 +1013,15 @@ def _solve_integer_projection_mip(
         return None
 
     target = np.clip(np.asarray(target, dtype=np.float64), decomp.lb, decomp.ub)
+    if projzerotol > 0.0:
+        zeroable = (np.abs(target) <= projzerotol) & (decomp.lb <= 0.0) & (decomp.ub >= 0.0)
+        target = target.copy()
+        target[zeroable] = 0.0
     n_vars = decomp.n_vars
-    use_linf = feasibility_norm == "L_infinity"
+    distance_indices = list(decomp.int_indices if discrete_only else range(n_vars))
+    if not distance_indices:
+        return _snap_integer_assignment(decomp, target)
+    use_linf = projection_norm == "L_infinity"
 
     a_ub_rows: list[np.ndarray] = []
     b_ub_vals: list[float] = []
@@ -920,7 +1036,7 @@ def _solve_integer_projection_mip(
         bounds = list(zip(decomp.lb.tolist(), decomp.ub.tolist()))
         bounds.append((0.0, 1e20))
 
-        for idx in decomp.int_indices:
+        for idx in distance_indices:
             row = np.zeros(n_master, dtype=np.float64)
             row[idx] = 1.0
             row[deviation_index] = -1.0
@@ -933,11 +1049,11 @@ def _solve_integer_projection_mip(
             a_ub_rows.append(row)
             b_ub_vals.append(float(-target[idx]))
     else:
-        n_dev = len(decomp.int_indices)
+        n_dev = len(distance_indices)
         n_master = n_vars + n_dev
         c = np.zeros(n_master, dtype=np.float64)
         bounds = list(zip(decomp.lb.tolist(), decomp.ub.tolist()))
-        for j, idx in enumerate(decomp.int_indices):
+        for j, idx in enumerate(distance_indices):
             dev_idx = n_vars + j
             c[dev_idx] = 1.0
             width = max(float(decomp.ub[idx] - decomp.lb[idx]), 1.0)
@@ -1006,10 +1122,24 @@ def _run_feasibility_pump(
     max_iterations: int,
     feasibility_norm: str,
     add_no_good_cuts: bool,
+    fp_main_norm: Optional[str] = None,
+    fp_mipgap: Optional[float] = None,
+    fp_discrete_only: bool = True,
+    fp_projzerotol: float = 0.0,
     milp_solver: str = "auto",
 ) -> _FeasibilityPumpResult:
     """Run a bounded MindtPy-style feasibility pump."""
     t_start = time.perf_counter()
+    feasibility_norm = _normalize_feasibility_norm(feasibility_norm)
+    projection_norm = _normalize_feasibility_norm(
+        feasibility_norm if fp_main_norm is None else fp_main_norm
+    )
+    projection_gap = (
+        float(gap_tolerance)
+        if fp_mipgap is None
+        else _normalize_nonnegative_float("fp_mipgap", fp_mipgap)
+    )
+    projzerotol = _normalize_nonnegative_float("fp_projzerotol", fp_projzerotol)
     evaluator = decomp.evaluator
     x_relax, obj_relax = _solve_nlp_relaxation(
         evaluator,
@@ -1068,9 +1198,11 @@ def _run_feasibility_pump(
                 decomp,
                 current,
                 seen_assignments,
-                feasibility_norm,
+                projection_norm,
                 remaining,
-                gap_tolerance,
+                projection_gap,
+                discrete_only=bool(fp_discrete_only),
+                projzerotol=projzerotol,
                 milp_solver=milp_solver,
             )
             mip_count += 1
@@ -1882,11 +2014,43 @@ def solve_feasibility_pump(
     initial_point: Optional[np.ndarray] = None,
     feasibility_norm: str = "L_infinity",
     add_no_good_cuts: bool = True,
+    fp_iteration_limit: Optional[int] = None,
+    fp_cutoffdecr: float = 0.0,
+    fp_projcuts: Optional[bool] = None,
+    fp_transfercuts: bool = False,
+    fp_projzerotol: float = 0.0,
+    fp_mipgap: Optional[float] = None,
+    fp_discrete_only: bool = True,
+    fp_main_norm: Optional[str] = None,
+    fp_norm_constraint: bool = False,
+    fp_norm_constraint_coef: float = 1.0,
     **kwargs,
 ) -> SolveResult:
     """Run the MIP-NLP feasibility pump as a standalone heuristic method."""
+    if kwargs:
+        raise ValueError(
+            "Unsupported feasibility-pump option(s): "
+            + ", ".join(sorted(kwargs))
+            + ". Supported FP options are: "
+            + ", ".join(sorted(FP_OPTION_KEYS))
+            + ", add_no_good_cuts, feasibility_norm."
+        )
     t_start = time.perf_counter()
-    feasibility_norm = _normalize_feasibility_norm(feasibility_norm)
+    fp_config = _normalize_fp_config(
+        feasibility_norm=feasibility_norm,
+        add_no_good_cuts=bool(add_no_good_cuts),
+        fp_iteration_limit=fp_iteration_limit,
+        fp_cutoffdecr=fp_cutoffdecr,
+        fp_projcuts=fp_projcuts,
+        fp_transfercuts=fp_transfercuts,
+        fp_projzerotol=fp_projzerotol,
+        fp_mipgap=fp_mipgap,
+        fp_discrete_only=fp_discrete_only,
+        fp_main_norm=fp_main_norm,
+        fp_norm_constraint=fp_norm_constraint,
+        fp_norm_constraint_coef=fp_norm_constraint_coef,
+    )
+    feasibility_norm = fp_config.feasibility_norm
     decomp = _decompose_model(model)
     evaluator = decomp.evaluator
     obj_sign = (
@@ -1931,9 +2095,13 @@ def solve_feasibility_pump(
         initial_point=initial_point,
         time_limit=time_limit,
         gap_tolerance=gap_tolerance,
-        max_iterations=max_iterations,
+        max_iterations=_fp_iteration_count(max_iterations, fp_config.iteration_limit),
         feasibility_norm=feasibility_norm,
-        add_no_good_cuts=bool(add_no_good_cuts),
+        add_no_good_cuts=fp_config.add_no_good_cuts,
+        fp_main_norm=fp_config.main_norm,
+        fp_mipgap=fp_config.mipgap,
+        fp_discrete_only=fp_config.discrete_only,
+        fp_projzerotol=fp_config.projzerotol,
     )
     wall_time = time.perf_counter() - t_start
     if fp.best_x is not None and fp.best_obj is not None:
@@ -2030,6 +2198,10 @@ def solve_lp_nlp_bb(
     t_start = time.perf_counter()
     init_strategy = _normalize_init_strategy(init_strategy)
     feasibility_norm = _normalize_feasibility_norm(feasibility_norm)
+    fp_config = _normalize_fp_config(
+        feasibility_norm=feasibility_norm,
+        add_no_good_cuts=True,
+    )
     max_slack = _normalize_positive_float("max_slack", max_slack)
     oa_penalty_factor = _normalize_positive_float("oa_penalty_factor", oa_penalty_factor)
     heuristic_nonconvex = bool(heuristic_nonconvex)
@@ -2134,7 +2306,11 @@ def solve_lp_nlp_bb(
         else:
             add_oa_cuts_at(_default_nlp_start(decomp.lb, decomp.ub))
     elif init_strategy == "fp":
-        fp_iterations = max(1, min(max_iterations if max_iterations > 0 else 1, 10))
+        fp_iterations = _fp_iteration_count(
+            max_iterations,
+            fp_config.iteration_limit,
+            default_cap=10,
+        )
         fp_result = _run_feasibility_pump(
             model,
             decomp,
@@ -2143,8 +2319,12 @@ def solve_lp_nlp_bb(
             time_limit=max(time_limit - (time.perf_counter() - t_start), 0.0),
             gap_tolerance=gap_tolerance,
             max_iterations=fp_iterations,
-            feasibility_norm=feasibility_norm,
-            add_no_good_cuts=True,
+            feasibility_norm=fp_config.feasibility_norm,
+            add_no_good_cuts=fp_config.add_no_good_cuts,
+            fp_main_norm=fp_config.main_norm,
+            fp_mipgap=fp_config.mipgap,
+            fp_discrete_only=fp_config.discrete_only,
+            fp_projzerotol=fp_config.projzerotol,
             milp_solver=milp_solver,
         )
         x_cut = fp_result.best_x if fp_result.best_x is not None else fp_result.best_near_x
@@ -2352,6 +2532,21 @@ def solve_goa(
     feasibility_norm = _normalize_feasibility_norm(
         amp_options.pop("feasibility_norm", "L_infinity")
     )
+    fp_kwargs = {key: amp_options.pop(key) for key in FP_OPTION_KEYS if key in amp_options}
+    fp_config = _normalize_fp_config(
+        feasibility_norm=feasibility_norm,
+        add_no_good_cuts=bool(add_no_good_cuts),
+        fp_iteration_limit=fp_kwargs.get("fp_iteration_limit"),
+        fp_cutoffdecr=fp_kwargs.get("fp_cutoffdecr", 0.0),
+        fp_projcuts=fp_kwargs.get("fp_projcuts"),
+        fp_transfercuts=fp_kwargs.get("fp_transfercuts", False),
+        fp_projzerotol=fp_kwargs.get("fp_projzerotol", 0.0),
+        fp_mipgap=fp_kwargs.get("fp_mipgap"),
+        fp_discrete_only=fp_kwargs.get("fp_discrete_only", True),
+        fp_main_norm=fp_kwargs.get("fp_main_norm"),
+        fp_norm_constraint=fp_kwargs.get("fp_norm_constraint", False),
+        fp_norm_constraint_coef=fp_kwargs.get("fp_norm_constraint_coef", 1.0),
+    )
     amp_kwargs = dict(GOA_AMP_OPTION_DEFAULTS)
     for key in GOA_AMP_OPTION_DEFAULTS:
         if key in amp_options:
@@ -2388,6 +2583,7 @@ def solve_goa(
             initial_point=initial_point,
             add_no_good_cuts=bool(add_no_good_cuts),
             feasibility_norm=feasibility_norm,
+            **fp_kwargs,
         )
         result.wall_time += elapsed
         return result
@@ -2406,7 +2602,11 @@ def solve_goa(
             pump_budget = min(remaining, max(0.0, 0.1 * float(time_limit)), 10.0)
         else:
             pump_budget = 10.0
-        fp_iterations = max(1, min(int(max_iterations) if max_iterations > 0 else 1, 10))
+        fp_iterations = _fp_iteration_count(
+            max_iterations,
+            fp_config.iteration_limit,
+            default_cap=10,
+        )
         if pump_budget > 0.0:
             fp_result = _run_feasibility_pump(
                 model,
@@ -2416,8 +2616,12 @@ def solve_goa(
                 time_limit=pump_budget,
                 gap_tolerance=gap_tolerance,
                 max_iterations=fp_iterations,
-                feasibility_norm=feasibility_norm,
-                add_no_good_cuts=bool(add_no_good_cuts),
+                feasibility_norm=fp_config.feasibility_norm,
+                add_no_good_cuts=fp_config.add_no_good_cuts,
+                fp_main_norm=fp_config.main_norm,
+                fp_mipgap=fp_config.mipgap,
+                fp_discrete_only=fp_config.discrete_only,
+                fp_projzerotol=fp_config.projzerotol,
             )
             pre_amp_mip_count += fp_result.mip_count
             if fp_result.best_x is not None:
@@ -2503,6 +2707,16 @@ def solve_oa(
     oa_penalty_factor: float = 1000.0,
     add_no_good_cuts: bool = False,
     feasibility_norm: str = "L_infinity",
+    fp_iteration_limit: Optional[int] = None,
+    fp_cutoffdecr: float = 0.0,
+    fp_projcuts: Optional[bool] = None,
+    fp_transfercuts: bool = False,
+    fp_projzerotol: float = 0.0,
+    fp_mipgap: Optional[float] = None,
+    fp_discrete_only: bool = True,
+    fp_main_norm: Optional[str] = None,
+    fp_norm_constraint: bool = False,
+    fp_norm_constraint_coef: float = 1.0,
     add_regularization: Optional[str] = None,
     level_coef: float = 0.5,
     stalling_limit: Optional[int] = None,
@@ -2573,6 +2787,30 @@ def solve_oa(
         Add integer-exclusion cuts after infeasible fixed-integer NLP solves.
     feasibility_norm : {"L1", "L2", "L_infinity"}
         Violation norm minimized by the feasibility subproblem heuristic.
+    fp_iteration_limit : int, optional
+        Iteration cap for the feasibility-pump initializer. When omitted,
+        ``init_strategy="fp"`` keeps the legacy cap of ``min(max_iterations, 10)``.
+    fp_main_norm : {"L1", "L2", "L_infinity"}, optional
+        Distance norm used by the FP projection MILP. When omitted, this follows
+        ``feasibility_norm``. ``L2`` uses the current MILP-compatible L1
+        projection surrogate while the feasibility subproblem still scores
+        nonlinear violation with squared L2 merit.
+    fp_discrete_only : bool
+        When true, the FP projection distance is computed only on discrete
+        variables. When false, continuous-variable deviations are penalized too.
+    fp_projcuts : bool, optional
+        Explicit control for discopt's FP projection-MILP path with binary
+        no-good cuts. When false, FP falls back to direct integer rounding.
+        When omitted, FP initialization enables this path by default.
+    fp_projzerotol : float
+        Projection target entries with absolute value at or below this tolerance
+        are treated as zero when zero lies within that variable's bounds.
+    fp_mipgap : float, optional
+        Gap tolerance for FP projection MILPs. Defaults to ``gap_tolerance``.
+    fp_cutoffdecr, fp_transfercuts, fp_norm_constraint, fp_norm_constraint_coef
+        MindtPy FP controls that are explicitly unsupported in discopt's current
+        FP implementation unless set to their no-op defaults. Non-default values
+        raise ``ValueError`` rather than being silently ignored.
     add_regularization : {None, "level_L1", "level_L2", "level_L_infinity",
             "grad_lag", "hess_lag", "hess_only_lag", "sqp_lag"}
         Optional level-set regularized OA master before fixed-integer NLP solves.
@@ -2606,6 +2844,20 @@ def solve_oa(
     t_start = time.perf_counter()
     init_strategy = _normalize_init_strategy(init_strategy)
     feasibility_norm = _normalize_feasibility_norm(feasibility_norm)
+    fp_config = _normalize_fp_config(
+        feasibility_norm=feasibility_norm,
+        add_no_good_cuts=True,
+        fp_iteration_limit=fp_iteration_limit,
+        fp_cutoffdecr=fp_cutoffdecr,
+        fp_projcuts=fp_projcuts,
+        fp_transfercuts=fp_transfercuts,
+        fp_projzerotol=fp_projzerotol,
+        fp_mipgap=fp_mipgap,
+        fp_discrete_only=fp_discrete_only,
+        fp_main_norm=fp_main_norm,
+        fp_norm_constraint=fp_norm_constraint,
+        fp_norm_constraint_coef=fp_norm_constraint_coef,
+    )
     add_regularization = _normalize_regularization(add_regularization)
     max_slack = _normalize_positive_float("max_slack", max_slack)
     oa_penalty_factor = _normalize_positive_float("oa_penalty_factor", oa_penalty_factor)
@@ -2783,7 +3035,11 @@ def solve_oa(
                 oa_cut_relaxable=oa_cut_relaxable,
             )
     elif init_strategy == "fp":
-        fp_iterations = max(1, min(max_iterations if max_iterations > 0 else 1, 10))
+        fp_iterations = _fp_iteration_count(
+            max_iterations,
+            fp_config.iteration_limit,
+            default_cap=10,
+        )
         fp_result = _run_feasibility_pump(
             model,
             decomp,
@@ -2792,8 +3048,12 @@ def solve_oa(
             time_limit=max(time_limit - (time.perf_counter() - t_start), 0.0),
             gap_tolerance=gap_tolerance,
             max_iterations=fp_iterations,
-            feasibility_norm=feasibility_norm,
-            add_no_good_cuts=True,
+            feasibility_norm=fp_config.feasibility_norm,
+            add_no_good_cuts=fp_config.add_no_good_cuts,
+            fp_main_norm=fp_config.main_norm,
+            fp_mipgap=fp_config.mipgap,
+            fp_discrete_only=fp_config.discrete_only,
+            fp_projzerotol=fp_config.projzerotol,
             milp_solver=milp_solver,
         )
         x_cut = fp_result.best_x if fp_result.best_x is not None else fp_result.best_near_x

--- a/python/tests/test_mip_nlp.py
+++ b/python/tests/test_mip_nlp.py
@@ -252,6 +252,12 @@ def test_model_solve_routes_mip_nlp_options(monkeypatch):
             milp_solver="gurobi",
             solution_pool=True,
             num_solution_iteration=7,
+            fp_iteration_limit=4,
+            fp_main_norm="L1",
+            fp_projcuts=False,
+            fp_discrete_only=False,
+            fp_projzerotol=1e-7,
+            fp_mipgap=0.05,
             skip_convex_check=True,
         )
 
@@ -270,6 +276,12 @@ def test_model_solve_routes_mip_nlp_options(monkeypatch):
     assert calls["milp_solver"] == "gurobi"
     assert calls["solution_pool"] is True
     assert calls["num_solution_iteration"] == 7
+    assert calls["fp_iteration_limit"] == 4
+    assert calls["fp_main_norm"] == "L1"
+    assert calls["fp_projcuts"] is False
+    assert calls["fp_discrete_only"] is False
+    assert calls["fp_projzerotol"] == pytest.approx(1e-7)
+    assert calls["fp_mipgap"] == pytest.approx(0.05)
 
 
 def test_model_solve_mip_nlp_path_runs_entropy_canonicalization(monkeypatch):
@@ -843,11 +855,43 @@ def test_mip_nlp_method_fp_routes_to_standalone_feasibility_pump(monkeypatch):
         init_strategy="fp",
         feasibility_norm="L1",
         add_no_good_cuts=False,
+        fp_iteration_limit=3,
+        fp_main_norm="L_infinity",
+        fp_projcuts=True,
+        fp_projzerotol=1e-8,
+        fp_mipgap=0.2,
+        fp_discrete_only=False,
     )
 
     assert result.status == "feasible"
     assert calls["feasibility_norm"] == "L1"
     assert calls["add_no_good_cuts"] is False
+    assert calls["fp_iteration_limit"] == 3
+    assert calls["fp_main_norm"] == "L_infinity"
+    assert calls["fp_projcuts"] is True
+    assert calls["fp_projzerotol"] == pytest.approx(1e-8)
+    assert calls["fp_mipgap"] == pytest.approx(0.2)
+    assert calls["fp_discrete_only"] is False
+
+
+@pytest.mark.parametrize(
+    ("option", "value", "match"),
+    [
+        ("fp_transfercuts", True, "fp_transfercuts=True"),
+        ("fp_norm_constraint", True, "fp_norm_constraint=True"),
+        ("fp_norm_constraint_coef", 0.5, "fp_norm_constraint_coef"),
+        ("fp_cutoffdecr", 0.1, "fp_cutoffdecr"),
+    ],
+)
+def test_mip_nlp_method_fp_rejects_unsupported_mindtpy_options(option, value, match):
+    from discopt.solvers.mip_nlp import solve_mip_nlp
+
+    with pytest.raises(ValueError, match=match):
+        solve_mip_nlp(
+            _binary_model(f"fp_unsupported_{option}"),
+            method="fp",
+            **{option: value},
+        )
 
 
 def test_mip_nlp_method_goa_routes_to_global_relaxation(monkeypatch):
@@ -1790,8 +1834,10 @@ def test_oa_fp_initialization_adds_cuts_at_best_pump_point(monkeypatch):
     model = _mixed_discrete_model("fp_init_point")
     pump_point = np.array([0.5, 1.0, 0.0, 2.0], dtype=float)
     cut_points = []
+    fp_kwargs = {}
 
     def fake_run_fp(*args, **kwargs):
+        fp_kwargs.update(kwargs)
         return oa_module._FeasibilityPumpResult(
             best_x=pump_point,
             best_obj=3.5,
@@ -1811,11 +1857,23 @@ def test_oa_fp_initialization_adds_cuts_at_best_pump_point(monkeypatch):
         model,
         init_strategy="fp",
         max_iterations=0,
+        fp_iteration_limit=3,
+        fp_main_norm="L1",
+        fp_projcuts=False,
+        fp_discrete_only=False,
+        fp_projzerotol=1e-8,
+        fp_mipgap=0.2,
     )
 
     assert result.status == "feasible"
     assert result.objective == pytest.approx(3.5)
     assert cut_points[0].tolist() == pytest.approx(pump_point.tolist())
+    assert fp_kwargs["max_iterations"] == 3
+    assert fp_kwargs["fp_main_norm"] == "L1"
+    assert fp_kwargs["add_no_good_cuts"] is False
+    assert fp_kwargs["fp_discrete_only"] is False
+    assert fp_kwargs["fp_projzerotol"] == pytest.approx(1e-8)
+    assert fp_kwargs["fp_mipgap"] == pytest.approx(0.2)
 
 
 def test_oa_no_discrete_relaxation_uses_initial_point(monkeypatch):
@@ -1949,7 +2007,7 @@ def test_mip_nlp_goa_certifies_mindtpy_minlp5_convex_fixture():
 
 
 @pytest.mark.skipif(not HAS_HIGHS, reason="highspy not installed")
-@pytest.mark.parametrize("feasibility_norm", ["L_infinity", "L1"])
+@pytest.mark.parametrize("feasibility_norm", ["L_infinity", "L1", "L2"])
 def test_mip_nlp_feasibility_pump_solves_mindtpy_baseline(feasibility_norm):
     result = _mindtpy_simple_minlp(f"mindtpy_fp_{feasibility_norm}").solve(
         solver="mip-nlp",

--- a/python/tests/test_oa.py
+++ b/python/tests/test_oa.py
@@ -614,6 +614,48 @@ class TestOARobustnessOptions:
         assert a_rows == []
         assert b_rows == []
 
+    def test_fp_projection_distance_can_include_continuous_variables(self, monkeypatch):
+        import discopt.solvers.lp_backend as lp_backend
+        from discopt.solvers import MILPResult, SolveStatus
+        from discopt.solvers.oa import _decompose_model, _solve_integer_projection_mip
+
+        m = dm.Model("fp_projection_all_vars")
+        x = m.continuous("x", lb=-1.0, ub=2.0)
+        y = m.binary("y")
+        z = m.integer("z", lb=-2, ub=3)
+        m.minimize(x + y + z)
+        decomp = _decompose_model(m)
+        captured = {}
+
+        def fake_solve_milp(**kwargs):
+            captured.update(kwargs)
+            return MILPResult(
+                status=SolveStatus.OPTIMAL,
+                x=np.zeros_like(kwargs["c"]),
+                objective=0.0,
+                bound=0.0,
+            )
+
+        monkeypatch.setattr(lp_backend, "get_milp_solver", lambda backend="auto": fake_solve_milp)
+
+        result = _solve_integer_projection_mip(
+            decomp,
+            target=np.array([5e-9, 0.3, 1.7], dtype=float),
+            seen_assignments=set(),
+            projection_norm="L1",
+            time_limit=10.0,
+            gap_tolerance=0.25,
+            discrete_only=False,
+            projzerotol=1e-8,
+        )
+
+        assert result is not None
+        assert len(captured["c"]) == 6
+        assert captured["c"][:3].tolist() == pytest.approx([0.0, 0.0, 0.0])
+        assert captured["c"][3:].tolist() == pytest.approx([1.0, 1.0, 1.0])
+        assert captured["integrality"][:3].tolist() == decomp.integrality.tolist()
+        assert captured["b_ub"][:2].tolist() == pytest.approx([0.0, 0.0])
+
     @pytest.mark.parametrize(("enabled", "expected_calls"), [(False, 0), (True, 1)])
     def test_no_good_cut_option_controls_infeasible_assignment(
         self,


### PR DESCRIPTION
## Summary

- Add MindtPy-named feasibility-pump option routing for standalone FP, OA FP initialization, and GOA FP seeding.
- Separate FP projection distance semantics (`fp_main_norm`, `fp_discrete_only`, `fp_projzerotol`, `fp_mipgap`, `fp_iteration_limit`) from feasibility-repair violation scoring (`feasibility_norm`).
- Reject unsupported MindtPy FP controls (`fp_transfercuts=True`, `fp_norm_constraint=True`, non-default `fp_norm_constraint_coef`, nonzero `fp_cutoffdecr`) with explicit `ValueError`s instead of silently ignoring them.
- Document that FP-generated projection cuts remain local to the pump and do not transfer into OA/GOA master certificates.

Closes #134

## Tests

- `python -m py_compile python/discopt/solvers/oa.py python/discopt/solvers/mip_nlp.py python/discopt/solver.py python/discopt/solvers/mip_nlp_options.py python/tests/test_mip_nlp.py python/tests/test_oa.py`
- `PYTHONPATH=python python -m pytest python/tests/test_mip_nlp.py::test_model_solve_routes_mip_nlp_options python/tests/test_mip_nlp.py::test_mip_nlp_method_fp_routes_to_standalone_feasibility_pump python/tests/test_mip_nlp.py::test_mip_nlp_method_fp_rejects_unsupported_mindtpy_options python/tests/test_mip_nlp.py::test_oa_fp_initialization_adds_cuts_at_best_pump_point python/tests/test_oa.py::TestOARobustnessOptions::test_fp_projection_distance_can_include_continuous_variables -q`
- `PYTHONPATH=python python -m pytest python/tests/test_mip_nlp.py::test_mip_nlp_feasibility_pump_solves_mindtpy_baseline python/tests/test_mip_nlp.py::test_mip_nlp_oa_fp_init_strategy_solves_mindtpy_baseline_to_optimum python/tests/test_mip_nlp.py::test_goa_fp_seed_uses_no_good_cuts_without_certifying_seed_bound python/tests/test_mip_nlp.py::test_mip_nlp_feasibility_pump_continuous_only_is_uncertified -q`
- `PYTHONPATH=python python -m pytest python/tests/test_mip_nlp.py python/tests/test_oa.py -q` (`132 passed, 2 skipped, 17 deselected`; JAX emitted sandbox-only warnings because `/home/bernalde/.cache/discopt/jax-cache` is read-only)
- `python -m ruff check python/discopt/solvers/oa.py python/discopt/solvers/mip_nlp.py python/discopt/solver.py python/tests/test_mip_nlp.py python/tests/test_oa.py`
- Commit hooks: `ruff`, `ruff format`, `mypy`

## Branch Hygiene

- Base branch: `feature/mip-nlp-solver`
- Head branch: `fix/issue-134-feasibility-pump-parity`
- Source branch point: `origin/feature/mip-nlp-solver` at `ee465d8103ac990267279eae76bb8cab940dcbc6`
- Stacked status: issue-specific branch created directly from `origin/feature/mip-nlp-solver`; not stacked on another child branch.
- Upstream status: `upstream/main` was fetched at `3ef59c508c37d090c0870d1538641bd39a94b62d`; the integration branch intentionally did not include that latest upstream tip at branch creation because issue #134 requires targeting `feature/mip-nlp-solver`.

Because this PR targets a non-default base branch, GitHub may not auto-close #134 until `feature/mip-nlp-solver` is later merged into the default branch.
