### PR TITLE
Add SHOT MIP-NLP profile trace foundation

### DIFF
--- a/docs/dev/shot-port-roadmap.md
+++ b/docs/dev/shot-port-roadmap.md
@@ -1,0 +1,98 @@
+# SHOT Port Roadmap
+
+This roadmap tracks SHOT-parity work for the `feature/mip-nlp-solver` branch.
+The target is behavioral parity in discopt-native architecture, not a direct
+translation of SHOT's C++ modules. Solver-core functionality comes first;
+OSiL, NEOS, CPLEX, and Cbc parity are deferred.
+
+## Current Foundation
+
+- `mip_nlp_profile="shot"` reserves the experimental SHOT-parity surface.
+- SHOT-profile controls are validated instead of silently ignored.
+- `SolveResult.mip_nlp_trace` carries a stable trace envelope for MIP-NLP runs.
+- OA populates iteration-level trace records for master solves, cut counts,
+  fixed-NLP calls, solution-pool candidates, node counts, bounds, and bound
+  validity.
+- Live GitHub issue sequence: [#138](https://github.com/bernalde/discopt/issues/138)
+  through [#153](https://github.com/bernalde/discopt/issues/153).
+
+## Issue Sequence
+
+1. **[#138: SHOT parity audit and benchmark baseline](https://github.com/bernalde/discopt/issues/138)**
+   Build a SHOT-to-discopt feature matrix and run current discopt vs local SHOT
+   on selected convex and nonconvex MINLP fixtures.
+
+2. **[#139: MIP-NLP config and trace foundation](https://github.com/bernalde/discopt/issues/139)**
+   Keep expanding the SHOT profile and trace payload as new algorithmic pieces
+   land. Preserve default behavior for users that do not opt in.
+
+3. **[#140: Unified cut/provenance model](https://github.com/bernalde/discopt/issues/140)**
+   Represent OA, ECP, ESH, objective, and external cuts with source, global
+   validity, local validity, supporting point, violation, row id, and dedup key.
+
+4. **[#141: Reformulation parity audit and controls](https://github.com/bernalde/discopt/issues/141)**
+   Fill gaps around objective epigraph controls, nonlinear and quadratic
+   partitioning, absolute-value auxiliaries, anti-epigraphs, monomial/signomial
+   toggles, integer-bilinear strategy limits, and quadratic extraction/direct
+   solve routing.
+
+5. **[#142: Initial POA and bound-tightening seeding](https://github.com/bernalde/discopt/issues/142)**
+   Add SHOT-style initial polyhedral approximation after bound tightening:
+   solve a relaxed approximation, import hyperplanes/interior points, and
+   update objective cutoffs or bounds.
+
+6. **[#143: Interior-point and rootsearch services](https://github.com/bernalde/discopt/issues/143)**
+   Add reusable interior-point storage, minimax/interior-point search, and
+   rootsearch between interior points and MIP/NLP candidates.
+
+7. **[#144: ESH and objective-rootsearch hyperplanes](https://github.com/bernalde/discopt/issues/144)**
+   Implement supporting-hyperplane separation with ECP fallback, cut selection
+   limits, violation ranking, known-primal safeguards, and objective-rootsearch
+   cuts.
+
+8. **[#145: SHOT-style MultiTree loop](https://github.com/bernalde/discopt/issues/145)**
+   Add relaxation-first phases, adaptive MIP solution limits, MIP starts from
+   incumbents, solution-pool ingestion, and per-iteration cutoff management.
+
+9. **[#146: Fixed-NLP primal candidate manager](https://github.com/bernalde/discopt/issues/146)**
+   Schedule fixed-integer NLP solves from MIP optimum, LP relaxation, solution
+   pool, rootsearch, and external candidates; support original/reformulated
+   NLP source selection, warm starts, dynamic frequency, and infeasibility cuts.
+
+10. **[#147: General integer cuts and solution-pool parity](https://github.com/bernalde/discopt/issues/147)**
+    Extend no-good/integer cuts beyond binary-only cases and expose solution
+    pool capacity/backend parameters consistently.
+
+11. **[#148: Master infeasibility repair and reduction cuts](https://github.com/bernalde/discopt/issues/148)**
+    Add infeasible-master repair, repair-loop detection, objective cutoff reset
+    logic, and nonconvex primal reduction cuts.
+
+12. **[#149: Convex bounding for nonconvex problems](https://github.com/bernalde/discopt/issues/149)**
+    Maintain a secondary master with only globally valid cuts to report valid
+    dual bounds for nonconvex runs.
+
+13. **[#150: SingleTree callback parity](https://github.com/bernalde/discopt/issues/150)**
+    Upgrade the Gurobi lazy-callback path with node-relaxation cuts,
+    rootsearch/fixed-NLP callbacks, integer cuts, trace updates, and callback
+    termination checks.
+
+14. **[#151: Direct NLP, MIQP, and MIQCQP routing](https://github.com/bernalde/discopt/issues/151)**
+    Add SHOT-style strategy selection for continuous NLP, LP/MILP, QP/MIQP, and
+    QCQP/MIQCQP when backend capabilities allow.
+
+15. **[#152: External event hooks](https://github.com/bernalde/discopt/issues/152)**
+    Add optional hooks for external primal candidates, hyperplanes, dual bounds,
+    and user termination.
+
+16. **[#153: Integration docs and release checklist](https://github.com/bernalde/discopt/issues/153)**
+    Keep docs, benchmarks, optional Gurobi checks, and MIP-NLP/GOA/FP regression
+    tests synchronized before merging into mainline discopt.
+
+## Acceptance Defaults
+
+- Default CI remains free of commercial solver requirements.
+- Optional Gurobi tests cover single-tree and solution-pool behavior.
+- SHOT-derived fixtures need clean EPL-2.0 attribution; otherwise recreate
+  equivalent DSL models.
+- Nonconvex results must distinguish heuristic incumbents from globally valid
+  bounds.

--- a/docs/mip_nlp.md
+++ b/docs/mip_nlp.md
@@ -91,6 +91,44 @@ Useful OA options include:
 | `feasibility_norm` | Norm used in feasibility-pump style repairs. |
 | `solution_pool`, `num_solution_iteration` | Iterate through a MILP solution pool; currently requires `milp_solver="gurobi"`. |
 
+## Experimental SHOT profile
+
+`mip_nlp_profile="shot"` enables validated SHOT-parity controls and attaches a
+structured `result.mip_nlp_trace` payload. The profile is experimental: the
+options are accepted and traced so later PRs can add SHOT-style ESH,
+rootsearch, repair, convex-bounding, and adaptive master behavior behind a
+stable interface. Default MIP-NLP behavior is unchanged when the profile is not
+set.
+
+```python
+result = model.solve(
+    solver="mip-nlp",
+    mip_nlp_method="oa",
+    mip_nlp_profile="shot",
+    cut_strategy="esh",
+    tree_strategy="multi_tree",
+    fixed_nlp_strategy="adaptive",
+    master_repair=True,
+)
+```
+
+Accepted SHOT-profile controls are:
+
+| Option | Accepted values |
+| --- | --- |
+| `tree_strategy` | `"auto"`, `"multi_tree"`, `"single_tree"` |
+| `cut_strategy` | `"auto"`, `"oa"`, `"ecp"`, `"esh"` |
+| `rootsearch_strategy` | `"auto"`, `"none"`, `"bisection"`, `"toms748"` |
+| `fixed_nlp_strategy` | `"auto"`, `"none"`, `"always"`, `"adaptive"`, `"iteration"`, `"time"`, `"solution_pool"` |
+| `solution_pool_capacity`, `hyperplane_max_per_iter` | Positive integer or `None` |
+| `hyperplane_selection_factor` | Floating-point factor in `(0, 1]` |
+| `relaxation_phase` | `"auto"`, `"off"`, `"initial"`, `"periodic"` |
+| `mip_solution_limit_strategy` | `"auto"`, `"none"`, `"static"`, `"adaptive"`, `"force_optimal"` |
+| `convex_bounding`, `master_repair`, `reduction_cuts` | Boolean |
+
+Passing one of these controls without `mip_nlp_profile="shot"` raises a
+`ValueError`, which prevents accidental no-op configuration.
+
 Top-level aliases override duplicate entries in `mip_nlp_options`:
 
 ```python

--- a/python/discopt/modeling/core.py
+++ b/python/discopt/modeling/core.py
@@ -1180,6 +1180,10 @@ class SolveResult:
     subnlp_feasible: int = 0
     subnlp_incumbent_updates: int = 0
 
+    # Structured MIP-NLP decomposition trace. Populated by solver="mip-nlp"
+    # paths when iteration/provenance data is available.
+    mip_nlp_trace: Optional[dict[str, object]] = None
+
     # Examiner-style validation report (populated if validate=True).
     validation_report: Optional[object] = None
 
@@ -2847,6 +2851,14 @@ class Model:
             ``solution_pool``, ``num_solution_iteration``, and ``init_strategy``
             take precedence over duplicate keys in ``mip_nlp_options``.
             ``solution_pool`` currently requires ``milp_solver="gurobi"``.
+            Experimental SHOT-parity controls are accepted only with
+            ``mip_nlp_profile="shot"`` and include ``tree_strategy``,
+            ``cut_strategy``, ``rootsearch_strategy``, ``fixed_nlp_strategy``,
+            ``solution_pool_capacity``, ``hyperplane_max_per_iter``,
+            ``hyperplane_selection_factor``, ``relaxation_phase``,
+            ``mip_solution_limit_strategy``, ``convex_bounding``,
+            ``master_repair``, and ``reduction_cuts``. MIP-NLP runs attach a
+            structured ``result.mip_nlp_trace`` payload.
             For ``mip_nlp_method="goa"``,
             convexity-certified MINLPs use OA's valid master bounds and other
             models use AMP/global relaxations. AMP options such as ``rel_gap``,

--- a/python/discopt/result_io.py
+++ b/python/discopt/result_io.py
@@ -65,6 +65,8 @@ def serialize_result(r: SolveResult) -> dict:
         val = _jsonify_arrays(getattr(r, name, None))
         if val is not None:
             out[name] = val
+    if r.mip_nlp_trace is not None:
+        out["mip_nlp_trace"] = r.mip_nlp_trace
     expl = getattr(r, "_explanation", None)
     if expl:
         out["explanation"] = str(expl)
@@ -80,6 +82,8 @@ def deserialize_result(d: dict) -> SolveResult:
     for name in _DICT_ARRAY_FIELDS:
         if d.get(name) is not None:
             kwargs[name] = {k: np.asarray(v) for k, v in d[name].items()}
+    if d.get("mip_nlp_trace") is not None:
+        kwargs["mip_nlp_trace"] = d["mip_nlp_trace"]
     r = SolveResult(**kwargs)
     if d.get("explanation"):
         r._explanation = d["explanation"]

--- a/python/discopt/solver.py
+++ b/python/discopt/solver.py
@@ -2244,6 +2244,14 @@ def solve_model(
         ``mip_nlp_method="lp_nlp_bb"``, ``milp_solver="gurobi"`` is also
         required because the single-tree LP/NLP branch-and-bound variant uses
         lazy master callbacks.
+        Experimental SHOT-parity controls are accepted only with
+        ``mip_nlp_profile="shot"`` and include ``tree_strategy``,
+        ``cut_strategy``, ``rootsearch_strategy``, ``fixed_nlp_strategy``,
+        ``solution_pool_capacity``, ``hyperplane_max_per_iter``,
+        ``hyperplane_selection_factor``, ``relaxation_phase``,
+        ``mip_solution_limit_strategy``, ``convex_bounding``,
+        ``master_repair``, and ``reduction_cuts``. MIP-NLP runs attach a
+        structured ``result.mip_nlp_trace`` payload.
         For ``mip_nlp_method="goa"``, convexity-certified MINLPs use OA's
         valid master bounds and other models use AMP/global relaxations.
         AMP options such as ``rel_gap``, ``abs_tol``, ``max_iter``,
@@ -2422,7 +2430,12 @@ def solve_model(
         import warnings
 
         from discopt.solvers.mip_nlp import solve_mip_nlp
-        from discopt.solvers.mip_nlp_options import FP_OPTION_KEYS, GOA_OPTION_KEYS
+        from discopt.solvers.mip_nlp_options import (
+            FP_OPTION_KEYS,
+            GOA_OPTION_KEYS,
+            MIP_NLP_PROFILE_OPTION_KEYS,
+            SHOT_OPTION_KEYS,
+        )
 
         mip_nlp_method = kwargs.pop("mip_nlp_method", None)
         mip_nlp_options = kwargs.pop("mip_nlp_options", None)
@@ -2446,6 +2459,8 @@ def solve_model(
             "milp_solver",
             "solution_pool",
             "num_solution_iteration",
+            *MIP_NLP_PROFILE_OPTION_KEYS,
+            *SHOT_OPTION_KEYS,
             *FP_OPTION_KEYS,
         ):
             if key in kwargs:
@@ -2770,7 +2785,11 @@ def solve_model(
 
         from discopt._jax.gdp_reformulate import reformulate_gdp
         from discopt.solvers.mip_nlp import solve_mip_nlp
-        from discopt.solvers.mip_nlp_options import FP_OPTION_KEYS
+        from discopt.solvers.mip_nlp_options import (
+            FP_OPTION_KEYS,
+            MIP_NLP_PROFILE_OPTION_KEYS,
+            SHOT_OPTION_KEYS,
+        )
 
         warnings.warn(
             "gdp_method='oa' is deprecated for selecting MINLP OA. Use "
@@ -2801,6 +2820,8 @@ def solve_model(
             "milp_solver",
             "solution_pool",
             "num_solution_iteration",
+            *MIP_NLP_PROFILE_OPTION_KEYS,
+            *SHOT_OPTION_KEYS,
             *FP_OPTION_KEYS,
         ):
             if key in kwargs:

--- a/python/discopt/solvers/mip_nlp.py
+++ b/python/discopt/solvers/mip_nlp.py
@@ -5,7 +5,12 @@ from __future__ import annotations
 from typing import Any, Optional
 
 from discopt.modeling.core import Model, SolveResult
-from discopt.solvers.mip_nlp_options import FP_OPTION_KEYS, GOA_OPTION_KEYS
+from discopt.solvers.mip_nlp_options import (
+    FP_OPTION_KEYS,
+    GOA_OPTION_KEYS,
+    ensure_mip_nlp_trace,
+    split_mip_nlp_profile_options,
+)
 
 _IMPLEMENTED_METHODS = frozenset({"oa", "ecp", "fp", "goa", "lp_nlp_bb"})
 _RESERVED_METHOD_ISSUES = {
@@ -116,6 +121,7 @@ def solve_mip_nlp(
             if canonical not in options:
                 options[canonical] = options[alias]
             del options[alias]
+    profile, shot_config, options = split_mip_nlp_profile_options(options)
 
     if method in _IMPLEMENTED_METHODS:
         if method == "fp":
@@ -146,7 +152,7 @@ def solve_mip_nlp(
                         "an initialization strategy is supplied."
                     )
 
-            return solve_feasibility_pump(
+            result = solve_feasibility_pump(
                 model,
                 time_limit=time_limit,
                 gap_tolerance=gap_tolerance,
@@ -166,11 +172,18 @@ def solve_mip_nlp(
                 fp_norm_constraint=options.get("fp_norm_constraint", False),
                 fp_norm_constraint_coef=options.get("fp_norm_constraint_coef", 1.0),
             )
+            ensure_mip_nlp_trace(
+                result,
+                method=method,
+                profile=profile,
+                shot_config=shot_config,
+            )
+            return result
 
         if method == "goa":
             from discopt.solvers.oa import solve_goa
 
-            return solve_goa(
+            result = solve_goa(
                 model,
                 time_limit=time_limit,
                 gap_tolerance=gap_tolerance,
@@ -180,6 +193,13 @@ def solve_mip_nlp(
                 add_no_good_cuts=bool(options.pop("add_no_good_cuts", True)),
                 **options,
             )
+            ensure_mip_nlp_trace(
+                result,
+                method=method,
+                profile=profile,
+                shot_config=shot_config,
+            )
+            return result
 
         if method == "lp_nlp_bb":
             from discopt.solvers.oa import _normalize_init_strategy, solve_lp_nlp_bb
@@ -187,7 +207,7 @@ def solve_mip_nlp(
             options["init_strategy"] = _normalize_init_strategy(
                 options.get("init_strategy", "rNLP")
             )
-            return solve_lp_nlp_bb(
+            result = solve_lp_nlp_bb(
                 model,
                 time_limit=time_limit,
                 gap_tolerance=gap_tolerance,
@@ -196,6 +216,13 @@ def solve_mip_nlp(
                 initial_point=initial_point,
                 **options,
             )
+            ensure_mip_nlp_trace(
+                result,
+                method=method,
+                profile=profile,
+                shot_config=shot_config,
+            )
+            return result
 
         from discopt.solvers.oa import _normalize_init_strategy, solve_oa
 
@@ -209,15 +236,24 @@ def solve_mip_nlp(
         options["ecp_mode"] = method == "ecp"
         options["init_strategy"] = _normalize_init_strategy(options.get("init_strategy", "rNLP"))
 
-        return solve_oa(
+        result = solve_oa(
             model,
             time_limit=time_limit,
             gap_tolerance=gap_tolerance,
             max_iterations=max_iterations,
             nlp_solver=nlp_solver,
             initial_point=initial_point,
+            mip_nlp_profile=profile,
+            mip_nlp_shot_config=shot_config,
             **options,
         )
+        ensure_mip_nlp_trace(
+            result,
+            method=method,
+            profile=profile,
+            shot_config=shot_config,
+        )
+        return result
 
     raise NotImplementedError(
         f"mip_nlp_method={method!r} is reserved for a future MIP-NLP "

--- a/python/discopt/solvers/mip_nlp_options.py
+++ b/python/discopt/solvers/mip_nlp_options.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from dataclasses import asdict, dataclass
 from typing import Any
 
 FP_OPTION_KEYS = (
@@ -57,3 +58,231 @@ GOA_AMP_ONLY_OPTION_KEYS = tuple(GOA_AMP_OPTION_DEFAULTS)
 GOA_OPTION_KEYS = frozenset(
     ("add_no_good_cuts", *GOA_OA_FORWARD_OPTION_KEYS, *GOA_AMP_ONLY_OPTION_KEYS)
 )
+
+MIP_NLP_PROFILE_OPTION_KEYS = ("mip_nlp_profile",)
+
+SHOT_OPTION_KEYS = (
+    "tree_strategy",
+    "cut_strategy",
+    "rootsearch_strategy",
+    "fixed_nlp_strategy",
+    "solution_pool_capacity",
+    "hyperplane_max_per_iter",
+    "hyperplane_selection_factor",
+    "relaxation_phase",
+    "mip_solution_limit_strategy",
+    "convex_bounding",
+    "master_repair",
+    "reduction_cuts",
+)
+
+_PROFILE_ALIASES = {
+    "": "default",
+    "default": "default",
+    "none": "default",
+    "shot": "shot",
+}
+
+_TREE_STRATEGIES = frozenset({"auto", "multi_tree", "single_tree"})
+_CUT_STRATEGIES = frozenset({"auto", "oa", "ecp", "esh"})
+_ROOTSEARCH_STRATEGIES = frozenset({"auto", "none", "bisection", "toms748"})
+_FIXED_NLP_STRATEGIES = frozenset(
+    {"auto", "none", "always", "adaptive", "iteration", "time", "solution_pool"}
+)
+_RELAXATION_PHASES = frozenset({"auto", "off", "initial", "periodic"})
+_MIP_SOLUTION_LIMIT_STRATEGIES = frozenset({"auto", "none", "static", "adaptive", "force_optimal"})
+
+
+@dataclass(frozen=True)
+class MIPNLPShotConfig:
+    """Validated experimental controls for the SHOT-parity MIP-NLP profile."""
+
+    tree_strategy: str = "multi_tree"
+    cut_strategy: str = "auto"
+    rootsearch_strategy: str = "auto"
+    fixed_nlp_strategy: str = "adaptive"
+    solution_pool_capacity: int | None = None
+    hyperplane_max_per_iter: int | None = None
+    hyperplane_selection_factor: float = 1.0
+    relaxation_phase: str = "auto"
+    mip_solution_limit_strategy: str = "adaptive"
+    convex_bounding: bool = False
+    master_repair: bool = False
+    reduction_cuts: bool = False
+
+    def as_trace_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+def normalize_mip_nlp_profile(value: Any = None) -> str:
+    """Normalize the optional MIP-NLP profile selector."""
+    if value is None:
+        return "default"
+    if not isinstance(value, str):
+        raise ValueError(f"mip_nlp_profile must be a string, got {type(value).__name__}.")
+    key = value.strip().lower().replace("-", "_")
+    if key not in _PROFILE_ALIASES:
+        raise ValueError("Unknown mip_nlp_profile={!r}. Choose 'default' or 'shot'.".format(value))
+    return _PROFILE_ALIASES[key]
+
+
+def _normalize_enum(name: str, value: Any, allowed: frozenset[str]) -> str:
+    if not isinstance(value, str):
+        raise ValueError(f"{name} must be a string, got {type(value).__name__}.")
+    key = value.strip().lower().replace("-", "_")
+    if key not in allowed:
+        raise ValueError(
+            f"Unknown {name}={value!r}. Choose one of: " + ", ".join(sorted(allowed)) + "."
+        )
+    return key
+
+
+def _normalize_optional_positive_int(name: str, value: Any) -> int | None:
+    if value is None:
+        return None
+    out = int(value)
+    if out <= 0:
+        raise ValueError(f"{name} must be a positive integer or None, got {value!r}.")
+    return out
+
+
+def _normalize_unit_factor(name: str, value: Any) -> float:
+    out = float(value)
+    if not 0.0 < out <= 1.0:
+        raise ValueError(f"{name} must be in the interval (0, 1], got {value!r}.")
+    return out
+
+
+def _normalize_bool(name: str, value: Any) -> bool:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        key = value.strip().lower()
+        if key in {"1", "true", "yes", "on"}:
+            return True
+        if key in {"0", "false", "no", "off"}:
+            return False
+    raise ValueError(f"{name} must be a boolean, got {value!r}.")
+
+
+def normalize_shot_config(raw_options: dict[str, Any]) -> MIPNLPShotConfig:
+    """Validate the SHOT-profile option subset and fill stable defaults."""
+    unexpected = sorted(set(raw_options) - set(SHOT_OPTION_KEYS))
+    if unexpected:
+        raise ValueError(
+            "Unsupported SHOT-profile MIP-NLP option(s): "
+            + ", ".join(unexpected)
+            + ". Supported options are: "
+            + ", ".join(SHOT_OPTION_KEYS)
+        )
+
+    return MIPNLPShotConfig(
+        tree_strategy=_normalize_enum(
+            "tree_strategy",
+            raw_options.get("tree_strategy", MIPNLPShotConfig.tree_strategy),
+            _TREE_STRATEGIES,
+        ),
+        cut_strategy=_normalize_enum(
+            "cut_strategy",
+            raw_options.get("cut_strategy", MIPNLPShotConfig.cut_strategy),
+            _CUT_STRATEGIES,
+        ),
+        rootsearch_strategy=_normalize_enum(
+            "rootsearch_strategy",
+            raw_options.get("rootsearch_strategy", MIPNLPShotConfig.rootsearch_strategy),
+            _ROOTSEARCH_STRATEGIES,
+        ),
+        fixed_nlp_strategy=_normalize_enum(
+            "fixed_nlp_strategy",
+            raw_options.get("fixed_nlp_strategy", MIPNLPShotConfig.fixed_nlp_strategy),
+            _FIXED_NLP_STRATEGIES,
+        ),
+        solution_pool_capacity=_normalize_optional_positive_int(
+            "solution_pool_capacity",
+            raw_options.get("solution_pool_capacity", MIPNLPShotConfig.solution_pool_capacity),
+        ),
+        hyperplane_max_per_iter=_normalize_optional_positive_int(
+            "hyperplane_max_per_iter",
+            raw_options.get("hyperplane_max_per_iter", MIPNLPShotConfig.hyperplane_max_per_iter),
+        ),
+        hyperplane_selection_factor=_normalize_unit_factor(
+            "hyperplane_selection_factor",
+            raw_options.get(
+                "hyperplane_selection_factor",
+                MIPNLPShotConfig.hyperplane_selection_factor,
+            ),
+        ),
+        relaxation_phase=_normalize_enum(
+            "relaxation_phase",
+            raw_options.get("relaxation_phase", MIPNLPShotConfig.relaxation_phase),
+            _RELAXATION_PHASES,
+        ),
+        mip_solution_limit_strategy=_normalize_enum(
+            "mip_solution_limit_strategy",
+            raw_options.get(
+                "mip_solution_limit_strategy",
+                MIPNLPShotConfig.mip_solution_limit_strategy,
+            ),
+            _MIP_SOLUTION_LIMIT_STRATEGIES,
+        ),
+        convex_bounding=_normalize_bool(
+            "convex_bounding",
+            raw_options.get("convex_bounding", MIPNLPShotConfig.convex_bounding),
+        ),
+        master_repair=_normalize_bool(
+            "master_repair",
+            raw_options.get("master_repair", MIPNLPShotConfig.master_repair),
+        ),
+        reduction_cuts=_normalize_bool(
+            "reduction_cuts",
+            raw_options.get("reduction_cuts", MIPNLPShotConfig.reduction_cuts),
+        ),
+    )
+
+
+def split_mip_nlp_profile_options(
+    options: dict[str, Any],
+) -> tuple[str, MIPNLPShotConfig | None, dict[str, Any]]:
+    """Separate experimental profile options from method-native options."""
+    remaining = dict(options)
+    profile = normalize_mip_nlp_profile(remaining.pop("mip_nlp_profile", None))
+    shot_raw = {key: remaining.pop(key) for key in SHOT_OPTION_KEYS if key in remaining}
+    if profile != "shot":
+        if shot_raw:
+            raise ValueError(
+                "SHOT-style MIP-NLP option(s) require mip_nlp_profile='shot': "
+                + ", ".join(sorted(shot_raw))
+                + "."
+            )
+        return profile, None, remaining
+    return profile, normalize_shot_config(shot_raw), remaining
+
+
+def ensure_mip_nlp_trace(
+    result: Any,
+    *,
+    method: str,
+    profile: str,
+    shot_config: MIPNLPShotConfig | None,
+) -> None:
+    """Attach a minimal trace envelope when a solver path did not populate one."""
+    if getattr(result, "mip_nlp_trace", None) is not None:
+        return
+    result.mip_nlp_trace = {
+        "schema_version": 1,
+        "solver": "mip-nlp",
+        "method": method,
+        "profile": profile,
+        "shot_options": shot_config.as_trace_dict() if shot_config is not None else {},
+        "iterations": [],
+        "summary": {
+            "mip_count": int(getattr(result, "mip_count", 0) or 0),
+            "nlp_subproblem_count": int(getattr(result, "subnlp_calls", 0) or 0),
+            "cut_count": None,
+            "solution_pool_candidates": 0,
+        },
+        "termination_reason": getattr(result, "status", None),
+        "master_bound_valid": bool(getattr(result, "gap_certified", True)),
+        "gap_certified": bool(getattr(result, "gap_certified", True)),
+        "bound_validity": "global" if bool(getattr(result, "gap_certified", True)) else "heuristic",
+    }

--- a/python/discopt/solvers/oa.py
+++ b/python/discopt/solvers/oa.py
@@ -2953,7 +2953,13 @@ def solve_oa(
         return str(status).lower()
 
     def _build_mip_nlp_trace(final_reason: Optional[str]) -> dict[str, object]:
-        gap_value = _compute_gap(LB, UB)
+        final_lb = _trace_value(LB)
+        final_ub = _trace_value(UB)
+        bound_valid = bool(master_bound_valid and final_lb is not None)
+        final_gap = (
+            _trace_value(_compute_gap(LB, UB)) if bound_valid and final_ub is not None else None
+        )
+        gap_certified = bool(bound_valid and final_gap is not None)
         return {
             "schema_version": 1,
             "solver": "mip-nlp",
@@ -2972,11 +2978,11 @@ def solve_oa(
             },
             "termination_reason": final_reason,
             "master_bound_valid": bool(master_bound_valid),
-            "gap_certified": bool(master_bound_valid),
-            "bound_validity": "global" if master_bound_valid else "heuristic",
-            "final_lb": _trace_value(LB),
-            "final_ub": _trace_value(UB),
-            "final_gap": _trace_value(gap_value),
+            "gap_certified": gap_certified,
+            "bound_validity": "global" if bound_valid else "heuristic",
+            "final_lb": final_lb,
+            "final_ub": final_ub,
+            "final_gap": final_gap,
         }
 
     # If no integer variables, just solve the NLP directly

--- a/python/discopt/solvers/oa.py
+++ b/python/discopt/solvers/oa.py
@@ -34,6 +34,7 @@ from discopt.solvers.mip_nlp_options import (
     FP_OPTION_KEYS,
     GOA_AMP_ONLY_OPTION_KEYS,
     GOA_AMP_OPTION_DEFAULTS,
+    MIPNLPShotConfig,
 )
 
 if TYPE_CHECKING:
@@ -2724,6 +2725,8 @@ def solve_oa(
     milp_solver: str = "auto",
     solution_pool: bool = False,
     num_solution_iteration: int = 5,
+    mip_nlp_profile: str = "default",
+    mip_nlp_shot_config: Optional[MIPNLPShotConfig] = None,
     **kwargs,
 ) -> SolveResult:
     """Solve a MINLP via Outer Approximation.
@@ -2914,34 +2917,6 @@ def solve_oa(
         )
     master_bound_valid = decomp.master_bound_valid and not heuristic_nonconvex
 
-    # If no integer variables, just solve the NLP directly
-    if len(decomp.int_indices) == 0:
-        x_sol, obj = _solve_nlp_relaxation(
-            evaluator,
-            decomp.lb,
-            decomp.ub,
-            nlp_solver,
-            initial_point=initial_point,
-        )
-        wall_time = time.perf_counter() - t_start
-        if x_sol is not None:
-            return SolveResult(
-                status="optimal",
-                objective=_obj_sign * obj,
-                bound=_obj_sign * obj,
-                gap=0.0,
-                x=_build_x_dict(x_sol, model),
-                wall_time=wall_time,
-            )
-        return SolveResult(
-            status="infeasible",
-            objective=None,
-            bound=None,
-            gap=None,
-            x={},
-            wall_time=wall_time,
-        )
-
     # 2. Generate initial linearization cuts.
     oa_A_rows: list[np.ndarray] = []
     oa_b_rows: list[float] = []
@@ -2955,6 +2930,86 @@ def solve_oa(
     incumbent_progress: list[float] = []
     termination_reason = None
     incumbent_derivative_data: Optional[_DerivativeRegularizationData] = None
+
+    method_name = "ecp" if ecp_mode else "oa"
+    trace_iterations: list[dict[str, object]] = []
+    mip_count = 0
+    nlp_subproblem_count = 0
+    feasibility_subproblem_count = 0
+    solution_pool_candidate_count = 0
+
+    def _trace_value(value: Optional[float]) -> Optional[float]:
+        if value is None:
+            return None
+        out = float(value)
+        if not np.isfinite(out) or abs(out) >= 1e19:
+            return None
+        return out
+
+    def _trace_status(status) -> str:
+        name = getattr(status, "name", None)
+        if isinstance(name, str):
+            return name.lower()
+        return str(status).lower()
+
+    def _build_mip_nlp_trace(final_reason: Optional[str]) -> dict[str, object]:
+        gap_value = _compute_gap(LB, UB)
+        return {
+            "schema_version": 1,
+            "solver": "mip-nlp",
+            "method": method_name,
+            "profile": mip_nlp_profile,
+            "shot_options": (
+                mip_nlp_shot_config.as_trace_dict() if mip_nlp_shot_config is not None else {}
+            ),
+            "iterations": trace_iterations,
+            "summary": {
+                "mip_count": int(mip_count),
+                "nlp_subproblem_count": int(nlp_subproblem_count),
+                "feasibility_subproblem_count": int(feasibility_subproblem_count),
+                "cut_count": int(len(oa_A_rows)),
+                "solution_pool_candidates": int(solution_pool_candidate_count),
+            },
+            "termination_reason": final_reason,
+            "master_bound_valid": bool(master_bound_valid),
+            "gap_certified": bool(master_bound_valid),
+            "bound_validity": "global" if master_bound_valid else "heuristic",
+            "final_lb": _trace_value(LB),
+            "final_ub": _trace_value(UB),
+            "final_gap": _trace_value(gap_value),
+        }
+
+    # If no integer variables, just solve the NLP directly
+    if len(decomp.int_indices) == 0:
+        x_sol, obj = _solve_nlp_relaxation(
+            evaluator,
+            decomp.lb,
+            decomp.ub,
+            nlp_solver,
+            initial_point=initial_point,
+        )
+        wall_time = time.perf_counter() - t_start
+        if x_sol is not None:
+            LB = float(obj)
+            UB = float(obj)
+            return SolveResult(
+                status="optimal",
+                objective=_obj_sign * obj,
+                bound=_obj_sign * obj,
+                gap=0.0,
+                x=_build_x_dict(x_sol, model),
+                wall_time=wall_time,
+                mip_nlp_trace=_build_mip_nlp_trace("continuous_nlp_optimal"),
+            )
+        return SolveResult(
+            status="infeasible",
+            objective=None,
+            bound=None,
+            gap=None,
+            x={},
+            wall_time=wall_time,
+            mip_nlp_trace=_build_mip_nlp_trace("continuous_nlp_infeasible"),
+        )
 
     def accept_incumbent(
         x: np.ndarray,
@@ -3097,6 +3152,7 @@ def solve_oa(
         else:
             init_attempt = None
             if derivative_regularization:
+                nlp_subproblem_count += 1
                 init_attempt = _solve_nlp_subproblem(
                     evaluator,
                     decomp.lb,
@@ -3109,6 +3165,7 @@ def solve_oa(
                 )
                 x_init, obj_init = init_attempt.x, init_attempt.objective
             else:
+                nlp_subproblem_count += 1
                 x_init, obj_init = _solve_nlp_subproblem(
                     evaluator,
                     decomp.lb,
@@ -3142,9 +3199,15 @@ def solve_oa(
         elapsed = time.perf_counter() - t_start
         if elapsed >= time_limit:
             logger.info("OA: Time limit reached at iteration %d", iteration)
+            termination_reason = "time_limit"
             break
 
         # a. Solve master MILP
+        cuts_before = len(oa_A_rows)
+        nlp_before = nlp_subproblem_count
+        feasibility_before = feasibility_subproblem_count
+        lb_before = _trace_value(LB)
+        ub_before = _trace_value(UB)
         master_result = _solve_master_milp(
             decomp.linear_A_rows,
             decomp.linear_b_rows,
@@ -3169,16 +3232,60 @@ def solve_oa(
             solution_pool=solution_pool,
             num_solution_iteration=num_solution_iteration,
         )
+        mip_count += 1
 
         from discopt.solvers import SolveStatus
 
         if master_result is None:
             logger.info("OA: Master MILP failed at iteration %d", iteration)
+            termination_reason = "master_error"
+            trace_iterations.append(
+                {
+                    "index": int(iteration),
+                    "master_status": "error",
+                    "lb_before": lb_before,
+                    "ub_before": ub_before,
+                    "lb": _trace_value(LB),
+                    "ub": _trace_value(UB),
+                    "gap": _trace_value(_compute_gap(LB, UB)),
+                    "cuts_added": int(len(oa_A_rows) - cuts_before),
+                    "cuts_total": int(len(oa_A_rows)),
+                    "nlp_subproblem_count": int(nlp_subproblem_count - nlp_before),
+                    "feasibility_subproblem_count": int(
+                        feasibility_subproblem_count - feasibility_before
+                    ),
+                    "solution_pool_candidates": 0,
+                    "node_count": 0,
+                    "repair_actions": [],
+                    "termination_reason": termination_reason,
+                }
+            )
             break
 
         if master_result.status == SolveStatus.INFEASIBLE:
             logger.info("OA: Master MILP infeasible at iteration %d", iteration)
             termination_reason = "master_infeasible"
+            trace_iterations.append(
+                {
+                    "index": int(iteration),
+                    "master_status": _trace_status(master_result.status),
+                    "lb_before": lb_before,
+                    "ub_before": ub_before,
+                    "lb": _trace_value(LB),
+                    "ub": _trace_value(UB),
+                    "gap": _trace_value(_compute_gap(LB, UB)),
+                    "cuts_added": int(len(oa_A_rows) - cuts_before),
+                    "cuts_total": int(len(oa_A_rows)),
+                    "nlp_subproblem_count": int(nlp_subproblem_count - nlp_before),
+                    "feasibility_subproblem_count": int(
+                        feasibility_subproblem_count - feasibility_before
+                    ),
+                    "solution_pool_candidates": 0,
+                    "node_count": int(getattr(master_result, "node_count", 0) or 0),
+                    "repair_actions": [],
+                    "termination_reason": termination_reason,
+                }
+            )
             break
 
         if master_result.status == SolveStatus.UNBOUNDED or master_result.x is None:
@@ -3200,6 +3307,27 @@ def solve_oa(
                 decomp.oa_objective_is_convex,
                 equality_relaxation=equality_relaxation,
                 oa_cut_relaxable=oa_cut_relaxable,
+            )
+            trace_iterations.append(
+                {
+                    "index": int(iteration),
+                    "master_status": _trace_status(master_result.status),
+                    "lb_before": lb_before,
+                    "ub_before": ub_before,
+                    "lb": _trace_value(LB),
+                    "ub": _trace_value(UB),
+                    "gap": _trace_value(_compute_gap(LB, UB)),
+                    "cuts_added": int(len(oa_A_rows) - cuts_before),
+                    "cuts_total": int(len(oa_A_rows)),
+                    "nlp_subproblem_count": int(nlp_subproblem_count - nlp_before),
+                    "feasibility_subproblem_count": int(
+                        feasibility_subproblem_count - feasibility_before
+                    ),
+                    "solution_pool_candidates": 0,
+                    "node_count": int(getattr(master_result, "node_count", 0) or 0),
+                    "repair_actions": [],
+                    "termination_reason": "master_unbounded",
+                }
             )
             continue
 
@@ -3262,6 +3390,16 @@ def solve_oa(
             solution_pool=solution_pool,
             num_solution_iteration=num_solution_iteration,
         )
+        solution_pool_candidate_count += len(master_candidates)
+        iteration_record: dict[str, object] = {
+            "index": int(iteration),
+            "master_status": _trace_status(master_result.status),
+            "lb_before": lb_before,
+            "ub_before": ub_before,
+            "solution_pool_candidates": int(len(master_candidates)),
+            "node_count": int(getattr(master_result, "node_count", 0) or 0),
+            "repair_actions": [],
+        }
         stop_after_master_pool = False
         pool_integer_assignments_seen: set[tuple[float, ...]] = set()
 
@@ -3269,6 +3407,7 @@ def solve_oa(
             elapsed = time.perf_counter() - t_start
             if elapsed >= time_limit:
                 logger.info("OA: Time limit reached during iteration %d", iteration)
+                termination_reason = "time_limit"
                 stop_after_master_pool = True
                 break
 
@@ -3344,6 +3483,7 @@ def solve_oa(
             # c. Fix integers, solve NLP subproblem
             nlp_attempt = None
             if derivative_regularization:
+                nlp_subproblem_count += 1
                 nlp_attempt = _solve_nlp_subproblem(
                     evaluator,
                     decomp.lb,
@@ -3356,6 +3496,7 @@ def solve_oa(
                 )
                 x_nlp, obj_nlp = nlp_attempt.x, nlp_attempt.objective
             else:
+                nlp_subproblem_count += 1
                 x_nlp, obj_nlp = _solve_nlp_subproblem(
                     evaluator,
                     decomp.lb,
@@ -3389,6 +3530,7 @@ def solve_oa(
             else:
                 # NLP infeasible for this integer assignment
                 if feasibility_cuts:
+                    feasibility_subproblem_count += 1
                     x_feas = _solve_feasibility_subproblem(
                         evaluator,
                         decomp.lb,
@@ -3467,6 +3609,22 @@ def solve_oa(
                 break
 
         if stop_after_master_pool:
+            iteration_record["termination_reason"] = termination_reason
+        iteration_record.update(
+            {
+                "lb": _trace_value(LB),
+                "ub": _trace_value(UB),
+                "gap": _trace_value(_compute_gap(LB, UB)),
+                "cuts_added": int(len(oa_A_rows) - cuts_before),
+                "cuts_total": int(len(oa_A_rows)),
+                "nlp_subproblem_count": int(nlp_subproblem_count - nlp_before),
+                "feasibility_subproblem_count": int(
+                    feasibility_subproblem_count - feasibility_before
+                ),
+            }
+        )
+        trace_iterations.append(iteration_record)
+        if stop_after_master_pool:
             break
 
     # 4. Build result
@@ -3475,6 +3633,14 @@ def solve_oa(
     bound_certified = master_bound_valid
     bound = LB if bound_certified and LB > -1e19 else None
     reported_gap = gap if bound is not None and UB < 1e19 else None
+    final_reason = termination_reason
+    if final_reason is None:
+        if wall_time >= time_limit:
+            final_reason = "time_limit"
+        elif incumbent is not None and bound_certified and gap <= gap_tolerance:
+            final_reason = "gap"
+        else:
+            final_reason = "iteration_limit"
 
     if incumbent is not None and incumbent_obj is not None:
         status = "optimal" if bound_certified and gap <= gap_tolerance else "feasible"
@@ -3487,6 +3653,9 @@ def solve_oa(
             gap=reported_gap,
             x=_build_x_dict(incumbent, model),
             wall_time=wall_time,
+            mip_count=mip_count,
+            subnlp_calls=nlp_subproblem_count,
+            mip_nlp_trace=_build_mip_nlp_trace(final_reason),
         )
 
     return SolveResult(
@@ -3496,4 +3665,7 @@ def solve_oa(
         gap=None,
         x={},
         wall_time=wall_time,
+        mip_count=mip_count,
+        subnlp_calls=nlp_subproblem_count,
+        mip_nlp_trace=_build_mip_nlp_trace(final_reason),
     )

--- a/python/tests/test_mip_nlp.py
+++ b/python/tests/test_mip_nlp.py
@@ -445,6 +445,96 @@ def test_mip_nlp_new_oa_options_precedence_and_alias(monkeypatch):
     assert calls["num_solution_iteration"] == 4
 
 
+def test_mip_nlp_shot_profile_options_validate_and_attach_trace(monkeypatch):
+    import discopt.solvers.oa as oa_module
+    from discopt.solvers.mip_nlp import solve_mip_nlp
+
+    calls = {}
+
+    def fake_solve_oa(model, **kwargs):
+        calls.update(kwargs)
+        return SolveResult(status="optimal", objective=0.0, bound=0.0, gap=0.0)
+
+    monkeypatch.setattr(oa_module, "solve_oa", fake_solve_oa)
+
+    result = solve_mip_nlp(
+        _binary_model("shot_profile_options"),
+        method="oa",
+        mip_nlp_options={
+            "mip_nlp_profile": "shot",
+            "tree_strategy": "single-tree",
+            "cut_strategy": "esh",
+            "rootsearch_strategy": "toms748",
+            "fixed_nlp_strategy": "solution-pool",
+            "solution_pool_capacity": 5,
+            "hyperplane_max_per_iter": 8,
+            "hyperplane_selection_factor": 0.75,
+            "relaxation_phase": "initial",
+            "mip_solution_limit_strategy": "force-optimal",
+            "convex_bounding": True,
+            "master_repair": "true",
+            "reduction_cuts": False,
+        },
+    )
+
+    cfg = calls["mip_nlp_shot_config"]
+    assert calls["mip_nlp_profile"] == "shot"
+    assert cfg.tree_strategy == "single_tree"
+    assert cfg.cut_strategy == "esh"
+    assert cfg.rootsearch_strategy == "toms748"
+    assert cfg.fixed_nlp_strategy == "solution_pool"
+    assert cfg.solution_pool_capacity == 5
+    assert cfg.hyperplane_max_per_iter == 8
+    assert cfg.hyperplane_selection_factor == pytest.approx(0.75)
+    assert cfg.relaxation_phase == "initial"
+    assert cfg.mip_solution_limit_strategy == "force_optimal"
+    assert cfg.convex_bounding is True
+    assert cfg.master_repair is True
+    assert cfg.reduction_cuts is False
+
+    assert result.mip_nlp_trace["schema_version"] == 1
+    assert result.mip_nlp_trace["profile"] == "shot"
+    assert result.mip_nlp_trace["shot_options"]["cut_strategy"] == "esh"
+
+
+def test_mip_nlp_shot_options_require_shot_profile():
+    from discopt.solvers.mip_nlp import solve_mip_nlp
+
+    with pytest.raises(ValueError, match="require mip_nlp_profile='shot'"):
+        solve_mip_nlp(
+            _binary_model("shot_option_without_profile"),
+            method="oa",
+            mip_nlp_options={"tree_strategy": "single_tree"},
+        )
+
+
+def test_model_solve_forwards_shot_profile_options(monkeypatch):
+    import discopt.solvers.mip_nlp as mip_nlp_module
+
+    calls = {}
+
+    def fake_solve_mip_nlp(model, **kwargs):
+        calls.update(kwargs)
+        return SolveResult(status="optimal", objective=0.0, bound=0.0, gap=0.0)
+
+    monkeypatch.setattr(mip_nlp_module, "solve_mip_nlp", fake_solve_mip_nlp)
+
+    result = _binary_model("model_solve_shot_profile").solve(
+        solver="mip-nlp",
+        mip_nlp_method="oa",
+        mip_nlp_profile="shot",
+        cut_strategy="esh",
+        solution_pool_capacity=3,
+        master_repair=True,
+    )
+
+    assert result.status == "optimal"
+    assert calls["mip_nlp_profile"] == "shot"
+    assert calls["cut_strategy"] == "esh"
+    assert calls["solution_pool_capacity"] == 3
+    assert calls["master_repair"] is True
+
+
 def test_model_solve_passes_initial_solution_to_mip_nlp(monkeypatch):
     import discopt.solvers.mip_nlp as mip_nlp_module
 
@@ -1180,6 +1270,13 @@ def test_oa_solution_pool_processes_multiple_master_candidates(monkeypatch):
     assert master_calls[0]["num_solution_iteration"] == 2
     assert [point.tolist() for point in nlp_master_points[1:]] == [[0.0], [1.0]]
     assert len(cut_points) == 3
+    assert result.mip_nlp_trace is not None
+    assert result.mip_nlp_trace["profile"] == "default"
+    assert result.mip_nlp_trace["summary"]["mip_count"] == 1
+    assert result.mip_nlp_trace["summary"]["nlp_subproblem_count"] == 3
+    assert result.mip_nlp_trace["summary"]["solution_pool_candidates"] == 2
+    assert result.mip_nlp_trace["iterations"][0]["solution_pool_candidates"] == 2
+    assert result.mip_nlp_trace["iterations"][0]["cuts_added"] == 2
 
 
 def test_oa_initial_binary_seed_rounds_and_clamps_discrete_values():

--- a/python/tests/test_mip_nlp.py
+++ b/python/tests/test_mip_nlp.py
@@ -497,6 +497,22 @@ def test_mip_nlp_shot_profile_options_validate_and_attach_trace(monkeypatch):
     assert result.mip_nlp_trace["shot_options"]["cut_strategy"] == "esh"
 
 
+def test_mip_nlp_trace_gap_certification_requires_finite_bound():
+    result = _binary_model("trace_no_bound_time_limit").solve(
+        solver="mip-nlp",
+        mip_nlp_method="oa",
+        time_limit=0.0,
+    )
+
+    assert result.bound is None
+    assert result.gap_certified is False
+    assert result.mip_nlp_trace is not None
+    assert result.mip_nlp_trace["final_lb"] is None
+    assert result.mip_nlp_trace["final_gap"] is None
+    assert result.mip_nlp_trace["gap_certified"] is False
+    assert result.mip_nlp_trace["bound_validity"] == "heuristic"
+
+
 def test_mip_nlp_shot_options_require_shot_profile():
     from discopt.solvers.mip_nlp import solve_mip_nlp
 

--- a/python/tests/test_result_io.py
+++ b/python/tests/test_result_io.py
@@ -46,6 +46,24 @@ def test_serialize_round_trip_optimal():
     np.testing.assert_allclose(r2.x["y"], [0.0, 2.0])
 
 
+def test_serialize_round_trip_mip_nlp_trace():
+    r = _optimal_result()
+    r.mip_nlp_trace = {
+        "schema_version": 1,
+        "solver": "mip-nlp",
+        "method": "oa",
+        "profile": "shot",
+        "iterations": [{"index": 0, "cuts_added": 2}],
+        "summary": {"mip_count": 1},
+    }
+
+    d = serialize_result(r)
+    assert d["mip_nlp_trace"]["profile"] == "shot"
+
+    r2 = deserialize_result(d)
+    assert r2.mip_nlp_trace == r.mip_nlp_trace
+
+
 def test_serialize_infeasible_and_no_solution():
     r = SolveResult(status="infeasible", objective=None, bound=None, gap=None, x=None)
     d = serialize_result(r)


### PR DESCRIPTION
## Summary
- add experimental `mip_nlp_profile="shot"` controls and validation for the SHOT port series
- add `SolveResult.mip_nlp_trace` plus serialization support and OA iteration trace plumbing
- document the SHOT roadmap and link the live issue sequence #138-#153

Closes #139
Refs #138

## Validation
- `PYTHONPATH=/home/bernalde/repos/discopt/python python -m pytest python/tests/test_mip_nlp.py -q` passed: 107 passed, 2 skipped
- `PYTHONPATH=/home/bernalde/repos/discopt/python python -m pytest python/tests/test_result_io.py -q` passed: 8 passed
- `PYTHONPATH=/home/bernalde/repos/discopt/python python -m ruff check python/discopt/solvers/mip_nlp_options.py python/discopt/solvers/mip_nlp.py python/discopt/solvers/oa.py python/discopt/solver.py python/discopt/modeling/core.py python/discopt/result_io.py python/tests/test_mip_nlp.py python/tests/test_result_io.py` passed

Note: local pytest emitted JAX persistent-cache warnings because `/home/bernalde/.cache/discopt/jax-cache` is read-only in this sandbox.