### PR TITLE
Establish SHOT parity audit and benchmark baseline

### DIFF
--- a/docs/dev/data/shot-parity-baseline.json
+++ b/docs/dev/data/shot-parity-baseline.json
@@ -1,0 +1,221 @@
+{
+  "command": "scripts/shot_parity_baseline.py --output docs/dev/data/shot-parity-baseline.json",
+  "fixtures": [
+    {
+      "convexity": "convex",
+      "expected_certification": "global",
+      "intent": "continuous convex NLP routing and KKT-certified objective",
+      "key": "convex_nlp",
+      "problem_class": "NLP",
+      "results": [
+        {
+          "available": true,
+          "backend": "discopt",
+          "bound": 0.0,
+          "bound_validity": "global",
+          "certification_caveat": "none",
+          "convex_fast_path": true,
+          "elapsed_seconds": 0.445793,
+          "gap": null,
+          "gap_certified": true,
+          "mip_count": 0,
+          "nlp_bb": false,
+          "node_count": 0,
+          "objective": 0.0,
+          "solution": {
+            "x": 1.5000000013376102
+          },
+          "solve_options": {
+            "time_limit": 30
+          },
+          "status": "optimal",
+          "trace_summary": null,
+          "wall_time_seconds": 0.185242
+        },
+        {
+          "available": false,
+          "backend": "SHOT",
+          "bound": null,
+          "bound_validity": "not_run",
+          "certification_caveat": "No built SHOT executable found. Set SHOT_EXECUTABLE or build the local checkout.",
+          "gap": null,
+          "gap_certified": false,
+          "objective": null,
+          "shot_root": "/home/bernalde/repos/SHOT",
+          "status": "unavailable",
+          "wall_time_seconds": 0.0
+        }
+      ],
+      "title": "Convex continuous NLP"
+    },
+    {
+      "convexity": "convex",
+      "expected_certification": "global",
+      "intent": "OA baseline with SHOT profile trace and fixed-integer NLP calls",
+      "key": "convex_minlp",
+      "problem_class": "MINLP",
+      "results": [
+        {
+          "available": true,
+          "backend": "discopt",
+          "bound": 0.050000001146704956,
+          "bound_validity": "global",
+          "certification_caveat": "none",
+          "convex_fast_path": false,
+          "elapsed_seconds": 0.779502,
+          "gap": 0.0,
+          "gap_certified": true,
+          "mip_count": 3,
+          "nlp_bb": false,
+          "node_count": 0,
+          "objective": 0.05,
+          "solution": {
+            "x": 1.9999999997133238,
+            "y": 1.0
+          },
+          "solve_options": {
+            "max_nodes": 100,
+            "mip_nlp_method": "oa",
+            "mip_nlp_profile": "shot",
+            "solver": "mip-nlp",
+            "time_limit": 30
+          },
+          "status": "optimal",
+          "trace_summary": {
+            "cut_count": 12,
+            "feasibility_subproblem_count": 0,
+            "mip_count": 3,
+            "nlp_subproblem_count": 3,
+            "solution_pool_candidates": 3
+          },
+          "wall_time_seconds": 0.773626
+        },
+        {
+          "available": false,
+          "backend": "SHOT",
+          "bound": null,
+          "bound_validity": "not_run",
+          "certification_caveat": "No built SHOT executable found. Set SHOT_EXECUTABLE or build the local checkout.",
+          "gap": null,
+          "gap_certified": false,
+          "objective": null,
+          "shot_root": "/home/bernalde/repos/SHOT",
+          "status": "unavailable",
+          "wall_time_seconds": 0.0
+        }
+      ],
+      "title": "Convex binary MINLP"
+    },
+    {
+      "convexity": "convex",
+      "expected_certification": "global",
+      "intent": "quadratic objective with one binary decision and direct routing pressure",
+      "key": "miqp",
+      "problem_class": "MIQP",
+      "results": [
+        {
+          "available": true,
+          "backend": "discopt",
+          "bound": 4.440892098500626e-16,
+          "bound_validity": "global",
+          "certification_caveat": "none",
+          "convex_fast_path": false,
+          "elapsed_seconds": 0.071592,
+          "gap": 0.0,
+          "gap_certified": true,
+          "mip_count": 0,
+          "nlp_bb": false,
+          "node_count": 1,
+          "objective": 4.440892098500626e-16,
+          "solution": {
+            "x": 1.7500000006689258,
+            "y": 0.0
+          },
+          "solve_options": {
+            "max_nodes": 100,
+            "time_limit": 30
+          },
+          "status": "optimal",
+          "trace_summary": null,
+          "wall_time_seconds": 0.029009
+        },
+        {
+          "available": false,
+          "backend": "SHOT",
+          "bound": null,
+          "bound_validity": "not_run",
+          "certification_caveat": "No built SHOT executable found. Set SHOT_EXECUTABLE or build the local checkout.",
+          "gap": null,
+          "gap_certified": false,
+          "objective": null,
+          "shot_root": "/home/bernalde/repos/SHOT",
+          "status": "unavailable",
+          "wall_time_seconds": 0.0
+        }
+      ],
+      "title": "Convex MIQP-style model"
+    },
+    {
+      "convexity": "nonconvex",
+      "expected_certification": "heuristic",
+      "intent": "feasibility-pump incumbent with explicit uncertified bound caveat",
+      "key": "nonconvex_fp",
+      "problem_class": "MINLP",
+      "results": [
+        {
+          "available": true,
+          "backend": "discopt",
+          "bound": null,
+          "bound_validity": "heuristic",
+          "certification_caveat": "reported incumbent is not supported by a certified finite dual bound",
+          "convex_fast_path": false,
+          "elapsed_seconds": 0.13506,
+          "gap": null,
+          "gap_certified": false,
+          "mip_count": 0,
+          "nlp_bb": false,
+          "node_count": 0,
+          "objective": -4.000000054987344,
+          "solution": {
+            "x": 2.0,
+            "y": 0.0
+          },
+          "solve_options": {
+            "max_nodes": 20,
+            "mip_nlp_method": "fp",
+            "solver": "mip-nlp",
+            "time_limit": 30
+          },
+          "status": "feasible",
+          "trace_summary": {
+            "cut_count": null,
+            "mip_count": 0,
+            "nlp_subproblem_count": 0,
+            "solution_pool_candidates": 0
+          },
+          "wall_time_seconds": 0.134431
+        },
+        {
+          "available": false,
+          "backend": "SHOT",
+          "bound": null,
+          "bound_validity": "not_run",
+          "certification_caveat": "No built SHOT executable found. Set SHOT_EXECUTABLE or build the local checkout.",
+          "gap": null,
+          "gap_certified": false,
+          "objective": null,
+          "shot_root": "/home/bernalde/repos/SHOT",
+          "status": "unavailable",
+          "wall_time_seconds": 0.0
+        }
+      ],
+      "title": "Nonconvex heuristic MINLP"
+    }
+  ],
+  "generated_at": "2026-06-30T15:47:28.807049+00:00",
+  "schema_version": 1,
+  "shot_executable": null,
+  "shot_root": "/home/bernalde/repos/SHOT",
+  "workdir": "/tmp/discopt-shot-baseline-7nc1s9dp",
+  "workdir_persistent": false
+}

--- a/docs/dev/shot-parity-audit.md
+++ b/docs/dev/shot-parity-audit.md
@@ -1,0 +1,78 @@
+# SHOT parity audit and benchmark baseline
+
+Issue: [#138](https://github.com/bernalde/discopt/issues/138)
+
+This audit establishes the read-only baseline for the SHOT port roadmap on
+`feature/mip-nlp-solver`. It compares current discopt behavior against the SHOT
+capability surface before deeper solver changes land. The target is
+discopt-native behavioral parity, not a translation of SHOT C++ internals.
+
+## Feature matrix
+
+| Area | SHOT capability | discopt status | Current discopt evidence and gap |
+| --- | --- | --- | --- |
+| Strategy selection | MultiTree and SingleTree strategies, direct NLP/MIQP/MIQCQP handling, and solver-specific master routing | Partial | `solver="mip-nlp"` exposes OA, ECP, FP, GOA, and LP/NLP-BB method selection. The SHOT profile validates reserved strategy controls, but automatic SHOT-style direct routing and adaptive MultiTree phases remain follow-ups. |
+| Reformulation | Objective epigraphs, nonlinear/quadratic partitioning, signomial and monomial handling, integer-bilinear strategy choices, and optional use of reformulated primal NLPs | Partial | discopt has GDP reformulation, entropy canonicalization, `.nl` export, McCormick infrastructure, and selected integer-product reformulations. SHOT's full reformulation policy surface is not yet mapped into MIP-NLP options. |
+| Bound tightening | FBBT/OBBT and initial relaxation tightening before cut loops | Partial | root presolve, FBBT, OBBT, and nonlinear bound-tightening modules exist. The SHOT-style initial POA plus bound-tightening seed sequence is not yet implemented for the profile. |
+| Cut generation | ESH/ECP/objective/external cuts, cut selection, hyperplane provenance, validity flags, and deduplication | Partial | OA/ECP cuts and selected no-good/integer cuts are present, and MIP-NLP traces count cuts. A unified cut/provenance model with ESH/rootsearch/objective hyperplanes is missing. |
+| Primal heuristics | Fixed-integer NLP candidates from MIP optima, LP relaxations, solution pools, rootsearch, and external candidates | Partial | fixed-NLP calls, feasibility pump, initialization strategies, and some solution-pool plumbing exist. The full candidate manager, dynamic frequency, rootsearch, and external candidate sources remain missing. |
+| Master repair | Infeasible-master repair, cutoff reset, repair-loop detection, and nonconvex reduction cuts | Missing | No dedicated SHOT-style master repair/reduction-cut loop is wired into the MIP-NLP profile. |
+| Convex bounding | Secondary globally valid master for nonconvex runs and explicit bound-validity reporting | Partial | `SolveResult.gap_certified` and `mip_nlp_trace.bound_validity` distinguish certified from heuristic results. A separate SHOT-style convex-bounding master for nonconvex problems remains missing. |
+| Callbacks | Lazy cut callbacks, incumbent callbacks, external hyperplanes, external primal candidates, dual bounds, and termination hooks | Partial | discopt has general solve callbacks and a Gurobi LP/NLP-BB callback path, but the SHOT external-event hook surface is not implemented. |
+| Backend support | MIP backends including CPLEX/Gurobi/Cbc/HiGHS, NLP backends including Ipopt/GAMS/SHOT, AMPL/GAMS/OSiL interfaces, NEOS workflows | Partial / deferred | discopt supports HiGHS/POUNCE and optional Gurobi/cyipopt paths plus `.nl`, GAMS-link, and Pyomo interfaces. OSiL, NEOS, CPLEX, and Cbc parity are intentionally deferred by the roadmap. |
+| Trace and diagnostics | Iteration reports, primal/dual bound updates, cut counts, NLP-call counts, solution-pool counts, and certification caveats | Partial | `SolveResult.mip_nlp_trace` records the current stable envelope for MIP-NLP runs. SHOT-equivalent trace fields for rootsearch, repair, external hooks, and convex bounding will be added as those features land. |
+
+## Benchmark command
+
+Run the committed baseline with:
+
+```bash
+PYTHONPATH=python python scripts/shot_parity_baseline.py \
+  --output docs/dev/data/shot-parity-baseline.json
+```
+
+If SHOT is built locally, provide the executable explicitly:
+
+```bash
+SHOT_EXECUTABLE=/home/bernalde/repos/SHOT/build/SHOT \
+PYTHONPATH=python python scripts/shot_parity_baseline.py \
+  --output docs/dev/data/shot-parity-baseline.json \
+  --workdir /tmp/discopt-shot-baseline
+```
+
+When SHOT is available, the script exports each fixture to AMPL `.nl` and runs
+the executable. When no executable is found, it records SHOT as `unavailable`.
+That condition is part of the baseline; it should not be treated as a discopt
+solver failure.
+
+## Fixture set
+
+| Fixture | Class | Convexity | Purpose |
+| --- | --- | --- | --- |
+| `convex_nlp` | NLP | Convex | Continuous nonlinear objective, direct KKT-certified solve. |
+| `convex_minlp` | MINLP | Convex | OA baseline through `solver="mip-nlp"` with `mip_nlp_profile="shot"`. |
+| `miqp` | MIQP-style | Convex | Quadratic objective with one binary variable to pressure direct quadratic routing. |
+| `nonconvex_fp` | MINLP | Nonconvex | Feasibility-pump incumbent with no certified dual bound, exercising bound-validity reporting. |
+
+## Current baseline notes
+
+The committed JSON baseline is
+`docs/dev/data/shot-parity-baseline.json`. On this workstation, the local SHOT
+checkout is present at `/home/bernalde/repos/SHOT`, but `SHOTpy` is not
+importable and no built SHOT executable was discoverable under the checkout.
+The SHOT rows are therefore recorded as `unavailable` with an explicit caveat.
+
+discopt solved the three certified fixtures as `optimal` and the nonconvex
+feasibility-pump fixture as `feasible` with `gap_certified=false`. That
+uncertified row is intentional: it is the baseline that later nonconvex
+convex-bounding work must improve without overstating global guarantees.
+
+## Certification caveats
+
+- A finite objective without a finite certified bound is a heuristic incumbent,
+  not a proof of optimality.
+- Nonconvex rows must be read together with `gap_certified` and
+  `bound_validity`; objective agreement alone is not enough.
+- SHOT command-line results are parsed from stdout and OSrL best-effort fields.
+  When SHOT is available, inspect the OSrL/trace files from `--workdir` for
+  authoritative solver diagnostics.

--- a/docs/dev/shot-parity-audit.md
+++ b/docs/dev/shot-parity-audit.md
@@ -67,6 +67,13 @@ feasibility-pump fixture as `feasible` with `gap_certified=false`. That
 uncertified row is intentional: it is the baseline that later nonconvex
 convex-bounding work must improve without overstating global guarantees.
 
+A local SHOT-enabled run on June 30, 2026 matched the convex MINLP,
+MIQP-style, and nonconvex incumbent rows, and exposed one parser caveat: SHOT
+can report a feasible convex NLP incumbent while also stating that optimality
+is not guaranteed. The benchmark script therefore records SHOT certification
+from explicit global-optimality language and OSrL dual/primal bound fields
+rather than treating any occurrence of the word "optimal" as proof.
+
 ## Certification caveats
 
 - A finite objective without a finite certified bound is a heuristic incumbent,

--- a/python/tests/test_shot_parity_baseline.py
+++ b/python/tests/test_shot_parity_baseline.py
@@ -53,3 +53,63 @@ def test_collect_baseline_empty_selection_has_stable_schema(tmp_path):
     assert baseline["fixtures"] == []
     assert baseline["shot_executable"] is None
     assert baseline["workdir"] == str(tmp_path / "work")
+
+
+def test_shot_status_does_not_treat_optimality_caveat_as_optimal():
+    module = _load_baseline_module()
+    output = """
+    Feasible primal solution found to convex problem.
+    Can not guarantee optimality to the given termination criteria.
+    Objective bound (minimization) [dual, primal]:  [-9.6875, 1.5625].
+    Objective gap absolute / relative:              11.25 / 7.2.
+    """
+
+    status = module._parse_shot_status(output, 0)
+
+    assert status == "feasible"
+    assert module._parse_shot_gap_certified(output, status, 0) is False
+    assert module._parse_shot_bound_pair(output) == (-9.6875, 1.5625)
+    assert module._parse_shot_gap_pair(output) == (11.25, 7.2)
+
+
+def test_shot_status_recognizes_global_optimality_report():
+    module = _load_baseline_module()
+    output = """
+    Terminated since absolute gap met requirements.
+    Globally optimal primal solution found.
+    Objective bound (minimization) [dual, primal]:  [0.0496452, 0.0500009].
+    Objective gap absolute / relative:              0.000355636 / 0.0071126.
+    Unfulfilled termination criteria:
+     - solution time limit (s)                      0.446913 <= 30
+    Termination.TimeLimit = 30
+    """
+
+    status = module._parse_shot_status(output, 0)
+
+    assert status == "optimal"
+    assert module._parse_shot_gap_certified(output, status, 0) is True
+
+
+def test_shot_osrl_metrics_prefer_structured_bounds(tmp_path):
+    module = _load_baseline_module()
+    osrl_path = tmp_path / "result.osrl"
+    osrl_path.write_text(
+        """<osrl xmlns="os.optimizationservices.org">
+  <general>
+    <otherResults>
+      <other name="DualObjectiveBound" value="0.049645244896349541"/>
+      <other name="PrimalObjectiveBound" value="0.050000880952378424"/>
+      <other name="AbsoluteOptimalityGap" value="0.00035563605602888237"/>
+      <other name="RelativeOptimalityGap" value="0.0071125957891889106"/>
+    </otherResults>
+  </general>
+</osrl>
+"""
+    )
+
+    metrics = module._parse_shot_osrl_metrics(osrl_path)
+
+    assert metrics["DualObjectiveBound"] == 0.049645244896349541
+    assert metrics["PrimalObjectiveBound"] == 0.050000880952378424
+    assert metrics["AbsoluteOptimalityGap"] == 0.00035563605602888237
+    assert metrics["RelativeOptimalityGap"] == 0.0071125957891889106

--- a/python/tests/test_shot_parity_baseline.py
+++ b/python/tests/test_shot_parity_baseline.py
@@ -1,0 +1,55 @@
+import importlib.util
+import sys
+from pathlib import Path
+
+
+def _load_baseline_module():
+    path = Path(__file__).resolve().parents[2] / "scripts" / "shot_parity_baseline.py"
+    spec = importlib.util.spec_from_file_location("shot_parity_baseline", path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_shot_parity_fixture_set_covers_issue_acceptance_classes():
+    module = _load_baseline_module()
+
+    fixtures = module.fixture_specs()
+    classes = {fixture.problem_class for fixture in fixtures}
+
+    assert "NLP" in classes
+    assert "MIQP" in classes
+    assert any(f.problem_class == "MINLP" and f.convexity == "convex" for f in fixtures)
+    assert any(f.problem_class == "MINLP" and f.convexity == "nonconvex" for f in fixtures)
+    assert any(f.expected_certification == "heuristic" for f in fixtures)
+    assert all("time_limit" in fixture.solve_options for fixture in fixtures)
+
+
+def test_shot_unavailable_result_records_explicit_caveat(tmp_path):
+    module = _load_baseline_module()
+
+    result = module.unavailable_shot_result("not built", tmp_path / "SHOT")
+
+    assert result["backend"] == "SHOT"
+    assert result["available"] is False
+    assert result["status"] == "unavailable"
+    assert result["bound_validity"] == "not_run"
+    assert result["certification_caveat"] == "not built"
+
+
+def test_collect_baseline_empty_selection_has_stable_schema(tmp_path):
+    module = _load_baseline_module()
+
+    baseline = module.collect_baseline(
+        set(),
+        include_shot=False,
+        shot_root=tmp_path / "SHOT",
+        workdir=tmp_path / "work",
+    )
+
+    assert baseline["schema_version"] == 1
+    assert baseline["fixtures"] == []
+    assert baseline["shot_executable"] is None
+    assert baseline["workdir"] == str(tmp_path / "work")

--- a/scripts/shot_parity_baseline.py
+++ b/scripts/shot_parity_baseline.py
@@ -1,0 +1,486 @@
+#!/usr/bin/env python
+"""Build the SHOT parity baseline for the MIP-NLP port roadmap.
+
+The command is intentionally read-only with respect to solver behavior. It
+solves a curated fixture set with discopt, exports AMPL ``.nl`` files for SHOT,
+and runs SHOT when a built executable is available.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import os
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+import time
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Callable, Iterable
+
+os.environ.setdefault("JAX_PLATFORMS", "cpu")
+os.environ.setdefault("JAX_ENABLE_X64", "1")
+os.environ.setdefault("JAX_COMPILATION_CACHE_DIR", "/tmp/discopt-jax-cache")
+
+ROOT = Path(__file__).resolve().parents[1]
+PYTHON_DIR = ROOT / "python"
+if str(PYTHON_DIR) not in sys.path:
+    sys.path.insert(0, str(PYTHON_DIR))
+
+import discopt.modeling as dm  # noqa: E402
+from discopt.export.nl import to_nl  # noqa: E402
+from discopt.result_io import serialize_result  # noqa: E402
+
+
+@dataclass(frozen=True)
+class Fixture:
+    key: str
+    title: str
+    problem_class: str
+    convexity: str
+    intent: str
+    builder: Callable[[], dm.Model]
+    solve_options: dict[str, object]
+    expected_certification: str
+
+
+def _convex_nlp() -> dm.Model:
+    m = dm.Model("shot_convex_nlp_quadratic")
+    x = m.continuous("x", lb=0.0, ub=4.0)
+    m.subject_to(x >= 0.25)
+    m.minimize((x - 1.5) ** 2)
+    return m
+
+
+def _convex_minlp() -> dm.Model:
+    m = dm.Model("shot_convex_minlp_onoff")
+    x = m.continuous("x", lb=0.0, ub=4.0)
+    y = m.binary("y")
+    m.subject_to(x <= 0.75 + 2.5 * y)
+    m.subject_to(x >= 0.25)
+    m.minimize((x - 2.0) ** 2 + 0.05 * y)
+    return m
+
+
+def _miqp() -> dm.Model:
+    m = dm.Model("shot_miqp_binary_quadratic")
+    x = m.continuous("x", lb=0.0, ub=3.0)
+    y = m.binary("y")
+    m.subject_to(x >= 0.25 + y)
+    m.minimize((x - 1.75) ** 2 + 0.2 * y)
+    return m
+
+
+def _nonconvex_fp() -> dm.Model:
+    m = dm.Model("shot_nonconvex_fp_uncertified")
+    x = m.continuous("x", lb=0.0, ub=2.0)
+    y = m.binary("y")
+    m.minimize(x * y - 2.0 * x)
+    return m
+
+
+def fixture_specs() -> list[Fixture]:
+    return [
+        Fixture(
+            key="convex_nlp",
+            title="Convex continuous NLP",
+            problem_class="NLP",
+            convexity="convex",
+            intent="continuous convex NLP routing and KKT-certified objective",
+            builder=_convex_nlp,
+            solve_options={"time_limit": 30},
+            expected_certification="global",
+        ),
+        Fixture(
+            key="convex_minlp",
+            title="Convex binary MINLP",
+            problem_class="MINLP",
+            convexity="convex",
+            intent="OA baseline with SHOT profile trace and fixed-integer NLP calls",
+            builder=_convex_minlp,
+            solve_options={
+                "solver": "mip-nlp",
+                "mip_nlp_method": "oa",
+                "mip_nlp_profile": "shot",
+                "time_limit": 30,
+                "max_nodes": 100,
+            },
+            expected_certification="global",
+        ),
+        Fixture(
+            key="miqp",
+            title="Convex MIQP-style model",
+            problem_class="MIQP",
+            convexity="convex",
+            intent="quadratic objective with one binary decision and direct routing pressure",
+            builder=_miqp,
+            solve_options={"time_limit": 30, "max_nodes": 100},
+            expected_certification="global",
+        ),
+        Fixture(
+            key="nonconvex_fp",
+            title="Nonconvex heuristic MINLP",
+            problem_class="MINLP",
+            convexity="nonconvex",
+            intent="feasibility-pump incumbent with explicit uncertified bound caveat",
+            builder=_nonconvex_fp,
+            solve_options={
+                "solver": "mip-nlp",
+                "mip_nlp_method": "fp",
+                "time_limit": 30,
+                "max_nodes": 20,
+            },
+            expected_certification="heuristic",
+        ),
+    ]
+
+
+def _json_float(value: object) -> object:
+    if value is None:
+        return None
+    if isinstance(value, (int, str, bool)):
+        return value
+    try:
+        number = float(value)
+    except (TypeError, ValueError):
+        return value
+    if math.isfinite(number):
+        return number
+    return None
+
+
+def _tail(text: str, limit: int = 4000) -> str:
+    if len(text) <= limit:
+        return text
+    return text[-limit:]
+
+
+def summarize_discopt_result(fixture: Fixture, result, elapsed: float) -> dict[str, object]:
+    payload = serialize_result(result)
+    trace = payload.get("mip_nlp_trace") or {}
+    bound_validity = trace.get("bound_validity")
+    if bound_validity is None:
+        bound_validity = "global" if payload.get("gap_certified") else "heuristic"
+    caveat = "none"
+    if not payload.get("gap_certified"):
+        caveat = "reported incumbent is not supported by a certified finite dual bound"
+    return {
+        "backend": "discopt",
+        "available": True,
+        "status": payload.get("status"),
+        "objective": _json_float(payload.get("objective")),
+        "bound": _json_float(payload.get("bound")),
+        "gap": _json_float(payload.get("gap")),
+        "wall_time_seconds": round(float(payload.get("wall_time") or elapsed), 6),
+        "elapsed_seconds": round(elapsed, 6),
+        "node_count": payload.get("node_count"),
+        "mip_count": payload.get("mip_count"),
+        "gap_certified": payload.get("gap_certified"),
+        "bound_validity": bound_validity,
+        "certification_caveat": caveat,
+        "convex_fast_path": payload.get("convex_fast_path"),
+        "nlp_bb": payload.get("nlp_bb"),
+        "solution": payload.get("x"),
+        "trace_summary": trace.get("summary"),
+        "solve_options": fixture.solve_options,
+    }
+
+
+def run_discopt(fixture: Fixture) -> dict[str, object]:
+    model = fixture.builder()
+    start = time.perf_counter()
+    try:
+        result = model.solve(**fixture.solve_options)
+    except Exception as exc:
+        elapsed = time.perf_counter() - start
+        return {
+            "backend": "discopt",
+            "available": True,
+            "status": "error",
+            "objective": None,
+            "bound": None,
+            "gap": None,
+            "wall_time_seconds": round(elapsed, 6),
+            "gap_certified": False,
+            "bound_validity": "unknown",
+            "certification_caveat": f"{type(exc).__name__}: {exc}",
+            "solve_options": fixture.solve_options,
+        }
+    return summarize_discopt_result(fixture, result, time.perf_counter() - start)
+
+
+def discover_shot_executable(explicit: str | None, shot_root: Path) -> str | None:
+    candidates: list[str | Path] = []
+    if explicit:
+        candidates.append(explicit)
+    env_exe = os.environ.get("SHOT_EXECUTABLE")
+    if env_exe:
+        candidates.append(env_exe)
+    candidates.extend(
+        [
+            shot_root / "build" / "SHOT",
+            shot_root / "build" / "src" / "SHOT",
+            shot_root / "build" / "bin" / "SHOT",
+            shot_root / "bin" / "SHOT",
+        ]
+    )
+    on_path = shutil.which("SHOT")
+    if on_path:
+        candidates.append(on_path)
+
+    for candidate in candidates:
+        path = Path(candidate).expanduser()
+        if path.is_file() and os.access(path, os.X_OK):
+            return str(path)
+    return None
+
+
+def unavailable_shot_result(reason: str, shot_root: Path) -> dict[str, object]:
+    return {
+        "backend": "SHOT",
+        "available": False,
+        "status": "unavailable",
+        "objective": None,
+        "bound": None,
+        "gap": None,
+        "wall_time_seconds": 0.0,
+        "gap_certified": False,
+        "bound_validity": "not_run",
+        "certification_caveat": reason,
+        "shot_root": str(shot_root),
+    }
+
+
+def _parse_shot_metric(patterns: Iterable[str], text: str) -> float | None:
+    for pattern in patterns:
+        match = re.search(pattern, text, flags=re.IGNORECASE)
+        if match:
+            try:
+                return float(match.group(1))
+            except ValueError:
+                continue
+    return None
+
+
+def _parse_shot_status(text: str, returncode: int) -> str:
+    if returncode != 0:
+        return "error"
+    lowered = text.lower()
+    if "optimal" in lowered:
+        return "optimal"
+    if "infeasible" in lowered:
+        return "infeasible"
+    if "time limit" in lowered or "timelimit" in lowered:
+        return "time_limit"
+    if "solution" in lowered:
+        return "feasible"
+    return "completed"
+
+
+def run_shot(
+    fixture: Fixture,
+    executable: str | None,
+    shot_root: Path,
+    workdir: Path,
+) -> dict[str, object]:
+    if executable is None:
+        return unavailable_shot_result(
+            "No built SHOT executable found. Set SHOT_EXECUTABLE or build the local checkout.",
+            shot_root,
+        )
+
+    model = fixture.builder()
+    nl_path = workdir / f"{fixture.key}.nl"
+    osrl_path = workdir / f"{fixture.key}.osrl"
+    trace_path = workdir / f"{fixture.key}.trc"
+    to_nl(model, nl_path)
+
+    time_limit = int(float(fixture.solve_options.get("time_limit", 30)))
+    cmd = [
+        executable,
+        str(nl_path),
+        "--AMPL",
+        f"--timelimit={time_limit}",
+        "--osrl",
+        str(osrl_path),
+        "--trc",
+        str(trace_path),
+        "Console.LogLevel=0",
+    ]
+    start = time.perf_counter()
+    completed = subprocess.run(
+        cmd,
+        cwd=workdir,
+        text=True,
+        capture_output=True,
+        timeout=time_limit + 30,
+        check=False,
+    )
+    elapsed = time.perf_counter() - start
+    combined = "\n".join([completed.stdout, completed.stderr])
+    if osrl_path.exists():
+        combined = "\n".join([combined, osrl_path.read_text(errors="replace")])
+
+    objective = _parse_shot_metric(
+        [
+            r"primal bound\s*[:=]\s*([-+0-9.eE]+)",
+            r"objective value\s*[:=]?\s*([-+0-9.eE]+)",
+            r"<obj[^>]*>\s*([-+0-9.eE]+)\s*</obj>",
+        ],
+        combined,
+    )
+    bound = _parse_shot_metric(
+        [
+            r"dual bound\s*[:=]\s*([-+0-9.eE]+)",
+            r"lower bound\s*[:=]\s*([-+0-9.eE]+)",
+        ],
+        combined,
+    )
+    gap = _parse_shot_metric(
+        [
+            r"absolute objective gap\s*[:=]\s*([-+0-9.eE]+)",
+            r"relative objective gap\s*[:=]\s*([-+0-9.eE]+)",
+        ],
+        combined,
+    )
+    return {
+        "backend": "SHOT",
+        "available": True,
+        "status": _parse_shot_status(combined, completed.returncode),
+        "objective": _json_float(objective),
+        "bound": _json_float(bound),
+        "gap": _json_float(gap),
+        "wall_time_seconds": round(elapsed, 6),
+        "gap_certified": None,
+        "bound_validity": "reported_by_shot",
+        "certification_caveat": (
+            "parsed from SHOT stdout/OSrL; inspect OSrL for authoritative details"
+        ),
+        "returncode": completed.returncode,
+        "command": cmd,
+        "nl_file": str(nl_path),
+        "osrl_file": str(osrl_path) if osrl_path.exists() else None,
+        "trace_file": str(trace_path) if trace_path.exists() else None,
+        "stdout_tail": _tail(completed.stdout),
+        "stderr_tail": _tail(completed.stderr),
+    }
+
+
+def collect_baseline(
+    fixture_keys: set[str] | None = None,
+    *,
+    include_shot: bool = True,
+    shot_executable: str | None = None,
+    shot_root: Path = Path("/home/bernalde/repos/SHOT"),
+    workdir: Path | None = None,
+) -> dict[str, object]:
+    specs = fixture_specs()
+    if fixture_keys is not None:
+        unknown = sorted(fixture_keys - {fixture.key for fixture in specs})
+        if unknown:
+            raise ValueError(f"unknown fixture(s): {', '.join(unknown)}")
+        specs = [fixture for fixture in specs if fixture.key in fixture_keys]
+
+    shot_exe = discover_shot_executable(shot_executable, shot_root) if include_shot else None
+    own_tempdir = None
+    if workdir is None:
+        own_tempdir = tempfile.TemporaryDirectory(prefix="discopt-shot-baseline-")
+        workdir = Path(own_tempdir.name)
+    else:
+        workdir.mkdir(parents=True, exist_ok=True)
+
+    try:
+        fixtures = []
+        for fixture in specs:
+            results = [run_discopt(fixture)]
+            if include_shot:
+                results.append(run_shot(fixture, shot_exe, shot_root, workdir))
+            fixtures.append(
+                {
+                    "key": fixture.key,
+                    "title": fixture.title,
+                    "problem_class": fixture.problem_class,
+                    "convexity": fixture.convexity,
+                    "intent": fixture.intent,
+                    "expected_certification": fixture.expected_certification,
+                    "results": results,
+                }
+            )
+        return {
+            "schema_version": 1,
+            "generated_at": datetime.now(timezone.utc).isoformat(),
+            "command": " ".join(sys.argv),
+            "shot_root": str(shot_root),
+            "shot_executable": shot_exe,
+            "workdir": str(workdir),
+            "workdir_persistent": own_tempdir is None,
+            "fixtures": fixtures,
+        }
+    finally:
+        if own_tempdir is not None:
+            own_tempdir.cleanup()
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=Path("docs/dev/data/shot-parity-baseline.json"),
+        help="JSON baseline path.",
+    )
+    parser.add_argument(
+        "--fixtures",
+        default=None,
+        help="Comma-separated fixture keys to run. Defaults to all fixtures.",
+    )
+    parser.add_argument(
+        "--shot-executable",
+        default=None,
+        help="Path to a built SHOT executable. Also honored via SHOT_EXECUTABLE.",
+    )
+    parser.add_argument(
+        "--shot-root",
+        type=Path,
+        default=Path("/home/bernalde/repos/SHOT"),
+        help="Local SHOT checkout used for discovery and audit metadata.",
+    )
+    parser.add_argument(
+        "--workdir",
+        type=Path,
+        default=None,
+        help="Directory for exported .nl, OSrL, and trace files.",
+    )
+    parser.add_argument(
+        "--discopt-only",
+        action="store_true",
+        help="Skip SHOT execution and only record discopt results.",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(sys.argv[1:] if argv is None else argv)
+    keys = None
+    if args.fixtures:
+        keys = {key.strip() for key in args.fixtures.split(",") if key.strip()}
+    baseline = collect_baseline(
+        keys,
+        include_shot=not args.discopt_only,
+        shot_executable=args.shot_executable,
+        shot_root=args.shot_root,
+        workdir=args.workdir,
+    )
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(json.dumps(baseline, indent=2, sort_keys=True) + "\n")
+    print(f"wrote {args.output}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/shot_parity_baseline.py
+++ b/scripts/shot_parity_baseline.py
@@ -18,6 +18,7 @@ import subprocess
 import sys
 import tempfile
 import time
+import xml.etree.ElementTree as ET
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
@@ -267,19 +268,131 @@ def _parse_shot_metric(patterns: Iterable[str], text: str) -> float | None:
     return None
 
 
+_SHOT_NUMBER = r"([-+]?(?:\d+(?:\.\d*)?|\.\d+)(?:[eE][-+]?\d+)?)"
+
+
+def _parse_shot_bound_pair(text: str) -> tuple[float | None, float | None]:
+    match = re.search(
+        rf"objective bound\s*\([^)]*\)\s*\[dual,\s*primal\]\s*:\s*"
+        rf"\[\s*{_SHOT_NUMBER}\s*,\s*{_SHOT_NUMBER}\s*\]",
+        text,
+        flags=re.IGNORECASE,
+    )
+    if not match:
+        return None, None
+    return float(match.group(1)), float(match.group(2))
+
+
+def _parse_shot_gap_pair(text: str) -> tuple[float | None, float | None]:
+    match = re.search(
+        rf"objective gap\s+absolute\s*/\s*relative\s*:\s*"
+        rf"{_SHOT_NUMBER}\s*/\s*{_SHOT_NUMBER}",
+        text,
+        flags=re.IGNORECASE,
+    )
+    if not match:
+        return None, None
+    return float(match.group(1)), float(match.group(2))
+
+
+def _parse_shot_osrl_metrics(path: Path) -> dict[str, float]:
+    if not path.exists():
+        return {}
+    try:
+        root = ET.parse(path).getroot()
+    except ET.ParseError:
+        return {}
+
+    metrics = {}
+    metric_names = {
+        "DualObjectiveBound",
+        "PrimalObjectiveBound",
+        "AbsoluteOptimalityGap",
+        "RelativeOptimalityGap",
+    }
+    for node in root.iter():
+        if node.tag.rsplit("}", maxsplit=1)[-1] != "other":
+            continue
+        name = node.attrib.get("name")
+        if name not in metric_names:
+            continue
+        value = node.attrib.get("value")
+        if value is None:
+            continue
+        try:
+            metrics[name] = float(value)
+        except ValueError:
+            continue
+    return metrics
+
+
+def _shot_output_denies_optimality_proof(text: str) -> bool:
+    lowered = text.lower()
+    return any(
+        phrase in lowered
+        for phrase in (
+            "can not guarantee optimality",
+            "cannot guarantee optimality",
+            "not guarantee optimality",
+            "no guarantee of global optimality",
+        )
+    )
+
+
+def _shot_output_reports_time_limit(text: str) -> bool:
+    lowered = text.lower()
+    return any(
+        phrase in lowered
+        for phrase in (
+            "terminated since time limit",
+            "terminated due to time limit",
+            "time limit reached",
+            "time limit exceeded",
+            "timelimit reached",
+            "timelimit exceeded",
+        )
+    )
+
+
 def _parse_shot_status(text: str, returncode: int) -> str:
     if returncode != 0:
         return "error"
     lowered = text.lower()
-    if "optimal" in lowered:
-        return "optimal"
-    if "infeasible" in lowered:
+    if re.search(r"\binfeasible\b", lowered):
         return "infeasible"
-    if "time limit" in lowered or "timelimit" in lowered:
+    if _shot_output_reports_time_limit(text):
         return "time_limit"
+    if _shot_output_denies_optimality_proof(text):
+        return "feasible"
+    if "globally optimal primal solution found" in lowered:
+        return "optimal"
+    if re.search(r"\boptimal (?:primal )?solution found\b", lowered):
+        return "optimal"
+    if "feasible primal solution found" in lowered:
+        return "feasible"
     if "solution" in lowered:
         return "feasible"
     return "completed"
+
+
+def _parse_shot_gap_certified(text: str, status: str, returncode: int) -> bool | None:
+    if returncode != 0:
+        return False
+    if _shot_output_denies_optimality_proof(text):
+        return False
+    if status == "optimal":
+        return True
+    if status in {"feasible", "infeasible", "time_limit"}:
+        return False
+    return None
+
+
+def _shot_certification_caveat(gap_certified: bool | None) -> str:
+    if gap_certified is True:
+        return "SHOT reports a globally optimal primal solution; parsed from stdout/OSrL"
+    if gap_certified is False:
+        return "SHOT did not report a global optimality guarantee; inspect stdout/OSrL"
+    return "parsed from SHOT stdout/OSrL; inspect OSrL for authoritative details"
 
 
 def run_shot(
@@ -326,6 +439,9 @@ def run_shot(
     if osrl_path.exists():
         combined = "\n".join([combined, osrl_path.read_text(errors="replace")])
 
+    osrl_metrics = _parse_shot_osrl_metrics(osrl_path)
+    stdout_bound, stdout_objective = _parse_shot_bound_pair(combined)
+    stdout_gap, stdout_relative_gap = _parse_shot_gap_pair(combined)
     objective = _parse_shot_metric(
         [
             r"primal bound\s*[:=]\s*([-+0-9.eE]+)",
@@ -334,6 +450,11 @@ def run_shot(
         ],
         combined,
     )
+    if stdout_objective is not None:
+        objective = stdout_objective
+    if "PrimalObjectiveBound" in osrl_metrics:
+        objective = osrl_metrics["PrimalObjectiveBound"]
+
     bound = _parse_shot_metric(
         [
             r"dual bound\s*[:=]\s*([-+0-9.eE]+)",
@@ -341,6 +462,11 @@ def run_shot(
         ],
         combined,
     )
+    if stdout_bound is not None:
+        bound = stdout_bound
+    if "DualObjectiveBound" in osrl_metrics:
+        bound = osrl_metrics["DualObjectiveBound"]
+
     gap = _parse_shot_metric(
         [
             r"absolute objective gap\s*[:=]\s*([-+0-9.eE]+)",
@@ -348,19 +474,28 @@ def run_shot(
         ],
         combined,
     )
+    if stdout_gap is not None:
+        gap = stdout_gap
+    if "AbsoluteOptimalityGap" in osrl_metrics:
+        gap = osrl_metrics["AbsoluteOptimalityGap"]
+    relative_gap = stdout_relative_gap
+    if "RelativeOptimalityGap" in osrl_metrics:
+        relative_gap = osrl_metrics["RelativeOptimalityGap"]
+
+    status = _parse_shot_status(combined, completed.returncode)
+    gap_certified = _parse_shot_gap_certified(combined, status, completed.returncode)
     return {
         "backend": "SHOT",
         "available": True,
-        "status": _parse_shot_status(combined, completed.returncode),
+        "status": status,
         "objective": _json_float(objective),
         "bound": _json_float(bound),
         "gap": _json_float(gap),
+        "relative_gap": _json_float(relative_gap),
         "wall_time_seconds": round(elapsed, 6),
-        "gap_certified": None,
+        "gap_certified": gap_certified,
         "bound_validity": "reported_by_shot",
-        "certification_caveat": (
-            "parsed from SHOT stdout/OSrL; inspect OSrL for authoritative details"
-        ),
+        "certification_caveat": _shot_certification_caveat(gap_certified),
         "returncode": completed.returncode,
         "command": cmd,
         "nl_file": str(nl_path),


### PR DESCRIPTION
## Summary

- Adds `docs/dev/shot-parity-audit.md` with the SHOT-to-discopt feature matrix for the roadmap baseline.
- Adds `scripts/shot_parity_baseline.py`, a reproducible benchmark command that runs the curated fixture set through discopt and records SHOT results when a built SHOT executable is available.
- Commits `docs/dev/data/shot-parity-baseline.json` from the current local run. SHOT is recorded as unavailable because the local checkout exists but no built executable was discoverable.

Closes #138

## Tests

- `PYTHONPATH=python python scripts/shot_parity_baseline.py --output docs/dev/data/shot-parity-baseline.json`
- `PYTHONPATH=python pytest python/tests/test_shot_parity_baseline.py -q`
- `python -m ruff check scripts/shot_parity_baseline.py python/tests/test_shot_parity_baseline.py`
- `python -m ruff format --check scripts/shot_parity_baseline.py python/tests/test_shot_parity_baseline.py`
- `PYTHONPATH=python pytest python/tests/test_mip_nlp.py -q`

`python/tests/test_mip_nlp.py` passed with sandbox-related JAX persistent-cache warnings for `/home/bernalde/.cache/discopt/jax-cache`.

## Branch Hygiene

- Base branch: `feature/mip-nlp-solver`
- Source branch: `fix/issue-138-shot-parity-baseline`
- Source branch point: `origin/feature/mip-nlp-solver` at `48b4372be491ea00e4ad0c1e5cb0da0db845f9e2`
- Stacked status: child PR for the SHOT-port integration branch; no prerequisite PRs for this baseline document/script.
- Upstream sync: `upstream/main` at `c618b0228a3b797e5b046e56255bf0755d043b24` is not contained in `origin/feature/mip-nlp-solver`; this PR intentionally preserves the integration branch base.

Because this targets non-default base `feature/mip-nlp-solver`, GitHub may not auto-close #138 until that integration branch reaches the default branch.
