### PR TITLE
SHOT port 04: add reformulation controls

### DIFF
--- a/docs/dev/shot-parity-audit.md
+++ b/docs/dev/shot-parity-audit.md
@@ -22,6 +22,27 @@ discopt-native behavioral parity, not a translation of SHOT C++ internals.
 | Backend support | MIP backends including CPLEX/Gurobi/Cbc/HiGHS, NLP backends including Ipopt/GAMS/SHOT, AMPL/GAMS/OSiL interfaces, NEOS workflows | Partial / deferred | discopt supports HiGHS/POUNCE and optional Gurobi/cyipopt paths plus `.nl`, GAMS-link, and Pyomo interfaces. OSiL, NEOS, CPLEX, and Cbc parity are intentionally deferred by the roadmap. |
 | Trace and diagnostics | Iteration reports, primal/dual bound updates, cut counts, NLP-call counts, solution-pool counts, and certification caveats | Partial | `SolveResult.mip_nlp_trace` records the current stable envelope for MIP-NLP runs. SHOT-equivalent trace fields for rootsearch, repair, external hooks, and convex bounding will be added as those features land. |
 
+## Reformulation parity table
+
+Issue [#141](https://github.com/bernalde/discopt/issues/141) adds the
+validated `mip_nlp_profile="shot"` control surface for SHOT-style
+reformulation policy. Only controls backed by an existing discopt component or
+needed as stable names for later roadmap PRs are exposed.
+
+| SHOT reformulation mode | SHOT-profile control | discopt equivalent or status |
+| --- | --- | --- |
+| Objective epigraph for nonlinear minimization objectives | `objective_epigraph` | Active when the structural objective-defining-equality proof in `discopt._jax.objective_epigraph` applies; otherwise safely abstains. OA masters already use internal objective epigraph columns for convex nonlinear objectives. |
+| Objective anti-epigraph for nonlinear maximization objectives | `anti_epigraph` | Active through the same objective-defining-equality pass for maximization models when the anti-epigraph inequality is convex. |
+| Nonlinear expression partitioning | `nonlinear_partitioning` | Maps to the AMP/piecewise-McCormick partitioning stack (`solver="amp"` / GOA AMP path). Full SHOT MultiTree phase scheduling is deferred to the POA and MultiTree issues. |
+| Quadratic partitioning | `quadratic_partitioning` | Current relaxation infrastructure supports quadratic and edge-concave relaxations; SHOT-style policy scheduling is traced and deferred. |
+| Absolute-value auxiliaries | `absolute_value_auxiliaries` | `abs` has native convexity and relaxation support. Dedicated SHOT-style auxiliary introduction is traced and deferred until a model requires static aux variables. |
+| Monomial extraction | `monomial_extraction` | Native term classification and McCormick/monomial auxiliary columns already extract integer-power monomials for relaxations. The control records whether SHOT policy wants that surface enabled. |
+| Signomial extraction | `signomial_extraction` | Positive-domain monomial/posynomial recognition and signed-signomial DC envelopes exist; full SHOT signomial policy integration is deferred. |
+| Integer-bilinear strategy | `integer_bilinear_strategy`, `integer_bilinear_max_bits` | Existing `integer_product_reform` can binary-expand bounded integer-factor bilinear terms into exact MILP form with a 12-bit default cap. The SHOT profile validates the strategy and limit for later routing. |
+| Quadratic extraction strategy | `quadratic_extraction` | Structural LP/QP/QCP/MIQP/MIQCQP classification exists in `problem_classifier`; MIP-NLP direct-routing policy is deferred to issue #151. |
+| Direct quadratic backend routing | `direct_quadratic_routing` | Existing top-level `solver="gurobi"` and default problem classification can route LP/QP/QCP/MIQP/MIQCQP when selected safely. Automatic SHOT-style routing from `solver="mip-nlp"` is deferred to issue #151. |
+| Reformulated primal NLP source selection | `fixed_nlp_strategy` plus reformulation controls | Current fixed-NLP calls use the active model passed to OA/GOA. Original-vs-reformulated NLP candidate policy is deferred to issue #146. |
+
 ## Benchmark command
 
 Run the committed baseline with:

--- a/docs/mip_nlp.md
+++ b/docs/mip_nlp.md
@@ -96,9 +96,9 @@ Useful OA options include:
 `mip_nlp_profile="shot"` enables validated SHOT-parity controls and attaches a
 structured `result.mip_nlp_trace` payload. The profile is experimental: the
 options are accepted and traced so later PRs can add SHOT-style ESH,
-rootsearch, repair, convex-bounding, and adaptive master behavior behind a
-stable interface. Default MIP-NLP behavior is unchanged when the profile is not
-set.
+rootsearch, repair, convex-bounding, reformulation policy, and adaptive master
+behavior behind a stable interface. Default MIP-NLP behavior is unchanged when
+the profile is not set.
 
 ```python
 result = model.solve(
@@ -118,6 +118,13 @@ Accepted SHOT-profile controls are:
 | --- | --- |
 | `tree_strategy` | `"auto"`, `"multi_tree"`, `"single_tree"` |
 | `cut_strategy` | `"auto"`, `"oa"`, `"ecp"`, `"esh"` |
+| `objective_epigraph`, `anti_epigraph` | `"auto"`, `"off"`, `"on"` |
+| `nonlinear_partitioning`, `quadratic_partitioning` | `"auto"`, `"off"`, `"static"`, `"adaptive"` |
+| `absolute_value_auxiliaries`, `monomial_extraction`, `signomial_extraction` | `"auto"`, `"off"`, `"on"` |
+| `integer_bilinear_strategy` | `"auto"`, `"off"`, `"binary_expansion"`, `"mccormick"` |
+| `integer_bilinear_max_bits` | Positive integer or `None` |
+| `quadratic_extraction` | `"auto"`, `"off"`, `"native"`, `"relaxation"` |
+| `direct_quadratic_routing` | `"auto"`, `"off"`, `"safe"` |
 | `rootsearch_strategy` | `"auto"`, `"none"`, `"bisection"`, `"toms748"` |
 | `fixed_nlp_strategy` | `"auto"`, `"none"`, `"always"`, `"adaptive"`, `"iteration"`, `"time"`, `"solution_pool"` |
 | `solution_pool_capacity`, `hyperplane_max_per_iter` | Positive integer or `None` |
@@ -128,6 +135,12 @@ Accepted SHOT-profile controls are:
 
 Passing one of these controls without `mip_nlp_profile="shot"` raises a
 `ValueError`, which prevents accidental no-op configuration.
+
+`objective_epigraph` and `anti_epigraph` are wired to discopt's existing
+objective-defining-equality reformulation when the structural proof conditions
+hold. The remaining reformulation controls are validated and traced under the
+SHOT profile so follow-up SHOT parity PRs can attach behavior without changing
+the public option names.
 
 Top-level aliases override duplicate entries in `mip_nlp_options`:
 

--- a/python/discopt/modeling/core.py
+++ b/python/discopt/modeling/core.py
@@ -2853,12 +2853,17 @@ class Model:
             ``solution_pool`` currently requires ``milp_solver="gurobi"``.
             Experimental SHOT-parity controls are accepted only with
             ``mip_nlp_profile="shot"`` and include ``tree_strategy``,
-            ``cut_strategy``, ``rootsearch_strategy``, ``fixed_nlp_strategy``,
-            ``solution_pool_capacity``, ``hyperplane_max_per_iter``,
-            ``hyperplane_selection_factor``, ``relaxation_phase``,
-            ``mip_solution_limit_strategy``, ``convex_bounding``,
-            ``master_repair``, and ``reduction_cuts``. MIP-NLP runs attach a
-            structured ``result.mip_nlp_trace`` payload.
+            ``cut_strategy``, ``objective_epigraph``, ``anti_epigraph``,
+            ``nonlinear_partitioning``, ``quadratic_partitioning``,
+            ``absolute_value_auxiliaries``, ``monomial_extraction``,
+            ``signomial_extraction``, ``integer_bilinear_strategy``,
+            ``integer_bilinear_max_bits``, ``quadratic_extraction``,
+            ``direct_quadratic_routing``, ``rootsearch_strategy``,
+            ``fixed_nlp_strategy``, ``solution_pool_capacity``,
+            ``hyperplane_max_per_iter``, ``hyperplane_selection_factor``,
+            ``relaxation_phase``, ``mip_solution_limit_strategy``,
+            ``convex_bounding``, ``master_repair``, and ``reduction_cuts``.
+            MIP-NLP runs attach a structured ``result.mip_nlp_trace`` payload.
             For ``mip_nlp_method="goa"``,
             convexity-certified MINLPs use OA's valid master bounds and other
             models use AMP/global relaxations. AMP options such as ``rel_gap``,

--- a/python/discopt/solver.py
+++ b/python/discopt/solver.py
@@ -2246,12 +2246,17 @@ def solve_model(
         lazy master callbacks.
         Experimental SHOT-parity controls are accepted only with
         ``mip_nlp_profile="shot"`` and include ``tree_strategy``,
-        ``cut_strategy``, ``rootsearch_strategy``, ``fixed_nlp_strategy``,
-        ``solution_pool_capacity``, ``hyperplane_max_per_iter``,
-        ``hyperplane_selection_factor``, ``relaxation_phase``,
-        ``mip_solution_limit_strategy``, ``convex_bounding``,
-        ``master_repair``, and ``reduction_cuts``. MIP-NLP runs attach a
-        structured ``result.mip_nlp_trace`` payload.
+        ``cut_strategy``, ``objective_epigraph``, ``anti_epigraph``,
+        ``nonlinear_partitioning``, ``quadratic_partitioning``,
+        ``absolute_value_auxiliaries``, ``monomial_extraction``,
+        ``signomial_extraction``, ``integer_bilinear_strategy``,
+        ``integer_bilinear_max_bits``, ``quadratic_extraction``,
+        ``direct_quadratic_routing``, ``rootsearch_strategy``,
+        ``fixed_nlp_strategy``, ``solution_pool_capacity``,
+        ``hyperplane_max_per_iter``, ``hyperplane_selection_factor``,
+        ``relaxation_phase``, ``mip_solution_limit_strategy``,
+        ``convex_bounding``, ``master_repair``, and ``reduction_cuts``.
+        MIP-NLP runs attach a structured ``result.mip_nlp_trace`` payload.
         For ``mip_nlp_method="goa"``, convexity-certified MINLPs use OA's
         valid master bounds and other models use AMP/global relaxations.
         AMP options such as ``rel_gap``, ``abs_tol``, ``max_iter``,

--- a/python/discopt/solvers/mip_nlp.py
+++ b/python/discopt/solvers/mip_nlp.py
@@ -2,12 +2,13 @@
 
 from __future__ import annotations
 
-from typing import Any, Optional
+from typing import Any, Optional, cast
 
-from discopt.modeling.core import Model, SolveResult
+from discopt.modeling.core import Model, ObjectiveSense, SolveResult
 from discopt.solvers.mip_nlp_options import (
     FP_OPTION_KEYS,
     GOA_OPTION_KEYS,
+    MIPNLPShotConfig,
     ensure_mip_nlp_trace,
     split_mip_nlp_profile_options,
 )
@@ -69,6 +70,28 @@ _LP_NLP_BB_OPTION_KEYS = frozenset(
 )
 
 
+def _apply_shot_profile_reformulations(
+    model: Model,
+    shot_config: MIPNLPShotConfig | None,
+) -> Model:
+    """Apply SHOT-profile reformulations that already have proven discopt passes."""
+    if shot_config is None:
+        return model
+    objective = getattr(model, "_objective", None)
+    if objective is None:
+        return model
+    if objective.sense == ObjectiveSense.MINIMIZE:
+        if shot_config.objective_epigraph == "off":
+            return model
+    elif shot_config.anti_epigraph == "off":
+        return model
+
+    from discopt._jax.objective_epigraph import relax_objective_defining_equality
+
+    reformulated, _changed = relax_objective_defining_equality(model)
+    return cast(Model, reformulated)
+
+
 def _normalize_method(method: Any) -> str:
     if not isinstance(method, str):
         raise ValueError(f"mip_nlp_method must be a string, got {type(method).__name__}.")
@@ -122,6 +145,7 @@ def solve_mip_nlp(
                 options[canonical] = options[alias]
             del options[alias]
     profile, shot_config, options = split_mip_nlp_profile_options(options)
+    model = _apply_shot_profile_reformulations(model, shot_config)
 
     if method in _IMPLEMENTED_METHODS:
         if method == "fp":

--- a/python/discopt/solvers/mip_nlp_options.py
+++ b/python/discopt/solvers/mip_nlp_options.py
@@ -64,6 +64,17 @@ MIP_NLP_PROFILE_OPTION_KEYS = ("mip_nlp_profile",)
 SHOT_OPTION_KEYS = (
     "tree_strategy",
     "cut_strategy",
+    "objective_epigraph",
+    "anti_epigraph",
+    "nonlinear_partitioning",
+    "quadratic_partitioning",
+    "absolute_value_auxiliaries",
+    "monomial_extraction",
+    "signomial_extraction",
+    "integer_bilinear_strategy",
+    "integer_bilinear_max_bits",
+    "quadratic_extraction",
+    "direct_quadratic_routing",
     "rootsearch_strategy",
     "fixed_nlp_strategy",
     "solution_pool_capacity",
@@ -85,6 +96,11 @@ _PROFILE_ALIASES = {
 
 _TREE_STRATEGIES = frozenset({"auto", "multi_tree", "single_tree"})
 _CUT_STRATEGIES = frozenset({"auto", "oa", "ecp", "esh"})
+_AUTO_OFF_ON = frozenset({"auto", "off", "on"})
+_PARTITION_STRATEGIES = frozenset({"auto", "off", "static", "adaptive"})
+_INTEGER_BILINEAR_STRATEGIES = frozenset({"auto", "off", "binary_expansion", "mccormick"})
+_QUADRATIC_EXTRACTION_STRATEGIES = frozenset({"auto", "off", "native", "relaxation"})
+_DIRECT_QUADRATIC_ROUTING = frozenset({"auto", "off", "safe"})
 _ROOTSEARCH_STRATEGIES = frozenset({"auto", "none", "bisection", "toms748"})
 _FIXED_NLP_STRATEGIES = frozenset(
     {"auto", "none", "always", "adaptive", "iteration", "time", "solution_pool"}
@@ -99,6 +115,17 @@ class MIPNLPShotConfig:
 
     tree_strategy: str = "multi_tree"
     cut_strategy: str = "auto"
+    objective_epigraph: str = "auto"
+    anti_epigraph: str = "auto"
+    nonlinear_partitioning: str = "auto"
+    quadratic_partitioning: str = "auto"
+    absolute_value_auxiliaries: str = "auto"
+    monomial_extraction: str = "auto"
+    signomial_extraction: str = "auto"
+    integer_bilinear_strategy: str = "auto"
+    integer_bilinear_max_bits: int | None = 12
+    quadratic_extraction: str = "auto"
+    direct_quadratic_routing: str = "auto"
     rootsearch_strategy: str = "auto"
     fixed_nlp_strategy: str = "adaptive"
     solution_pool_capacity: int | None = None
@@ -186,6 +213,72 @@ def normalize_shot_config(raw_options: dict[str, Any]) -> MIPNLPShotConfig:
             "cut_strategy",
             raw_options.get("cut_strategy", MIPNLPShotConfig.cut_strategy),
             _CUT_STRATEGIES,
+        ),
+        objective_epigraph=_normalize_enum(
+            "objective_epigraph",
+            raw_options.get("objective_epigraph", MIPNLPShotConfig.objective_epigraph),
+            _AUTO_OFF_ON,
+        ),
+        anti_epigraph=_normalize_enum(
+            "anti_epigraph",
+            raw_options.get("anti_epigraph", MIPNLPShotConfig.anti_epigraph),
+            _AUTO_OFF_ON,
+        ),
+        nonlinear_partitioning=_normalize_enum(
+            "nonlinear_partitioning",
+            raw_options.get("nonlinear_partitioning", MIPNLPShotConfig.nonlinear_partitioning),
+            _PARTITION_STRATEGIES,
+        ),
+        quadratic_partitioning=_normalize_enum(
+            "quadratic_partitioning",
+            raw_options.get("quadratic_partitioning", MIPNLPShotConfig.quadratic_partitioning),
+            _PARTITION_STRATEGIES,
+        ),
+        absolute_value_auxiliaries=_normalize_enum(
+            "absolute_value_auxiliaries",
+            raw_options.get(
+                "absolute_value_auxiliaries",
+                MIPNLPShotConfig.absolute_value_auxiliaries,
+            ),
+            _AUTO_OFF_ON,
+        ),
+        monomial_extraction=_normalize_enum(
+            "monomial_extraction",
+            raw_options.get("monomial_extraction", MIPNLPShotConfig.monomial_extraction),
+            _AUTO_OFF_ON,
+        ),
+        signomial_extraction=_normalize_enum(
+            "signomial_extraction",
+            raw_options.get("signomial_extraction", MIPNLPShotConfig.signomial_extraction),
+            _AUTO_OFF_ON,
+        ),
+        integer_bilinear_strategy=_normalize_enum(
+            "integer_bilinear_strategy",
+            raw_options.get(
+                "integer_bilinear_strategy",
+                MIPNLPShotConfig.integer_bilinear_strategy,
+            ),
+            _INTEGER_BILINEAR_STRATEGIES,
+        ),
+        integer_bilinear_max_bits=_normalize_optional_positive_int(
+            "integer_bilinear_max_bits",
+            raw_options.get(
+                "integer_bilinear_max_bits",
+                MIPNLPShotConfig.integer_bilinear_max_bits,
+            ),
+        ),
+        quadratic_extraction=_normalize_enum(
+            "quadratic_extraction",
+            raw_options.get("quadratic_extraction", MIPNLPShotConfig.quadratic_extraction),
+            _QUADRATIC_EXTRACTION_STRATEGIES,
+        ),
+        direct_quadratic_routing=_normalize_enum(
+            "direct_quadratic_routing",
+            raw_options.get(
+                "direct_quadratic_routing",
+                MIPNLPShotConfig.direct_quadratic_routing,
+            ),
+            _DIRECT_QUADRATIC_ROUTING,
         ),
         rootsearch_strategy=_normalize_enum(
             "rootsearch_strategy",

--- a/python/tests/test_mip_nlp.py
+++ b/python/tests/test_mip_nlp.py
@@ -62,6 +62,85 @@ def _convex_binary_nonlinear_model(name="mip_nlp_cut_trace"):
     return m
 
 
+def _objective_epigraph_model(name="shot_objective_epigraph"):
+    m = dm.Model(name)
+    x = m.continuous("x", lb=-2, ub=2)
+    z = m.continuous("z", lb=-1e20, ub=1e20)
+    m.subject_to(z - (x - 1) ** 2 == 0.0)
+    m.minimize(z)
+    return m
+
+
+def _anti_epigraph_model(name="shot_anti_epigraph"):
+    m = dm.Model(name)
+    x = m.continuous("x", lb=-2, ub=2)
+    z = m.continuous("z", lb=-1e20, ub=1e20)
+    m.subject_to(z + (x - 1) ** 2 == 0.0)
+    m.maximize(z)
+    return m
+
+
+def _bilinear_partition_model(name="shot_bilinear_partition"):
+    m = dm.Model(name)
+    x = m.continuous("x", lb=0, ub=2)
+    y = m.continuous("y", lb=0, ub=2)
+    m.subject_to(x * y <= 1.0)
+    m.minimize(x + y)
+    return m
+
+
+def _quadratic_partition_model(name="shot_quadratic_partition"):
+    m = dm.Model(name)
+    x = m.continuous("x", lb=-2, ub=2)
+    y = m.continuous("y", lb=0, ub=2)
+    m.subject_to(x**2 + y <= 3.0)
+    m.minimize(y)
+    return m
+
+
+def _absolute_value_model(name="shot_abs_aux"):
+    m = dm.Model(name)
+    x = m.continuous("x", lb=-2, ub=2)
+    m.subject_to(dm.abs(x) <= 1.0)
+    m.minimize(x)
+    return m
+
+
+def _monomial_model(name="shot_monomial"):
+    m = dm.Model(name)
+    x = m.continuous("x", lb=0, ub=2)
+    y = m.continuous("y", lb=0, ub=2)
+    m.subject_to(x**3 + y <= 4.0)
+    m.minimize(y)
+    return m
+
+
+def _signomial_model(name="shot_signomial"):
+    m = dm.Model(name)
+    x = m.continuous("x", lb=0.5, ub=3.0)
+    y = m.continuous("y", lb=0.5, ub=3.0)
+    m.subject_to((x**1.5) * (y**-0.5) <= 4.0)
+    m.minimize(x + y)
+    return m
+
+
+def _integer_bilinear_model(name="shot_integer_bilinear"):
+    m = dm.Model(name)
+    x = m.continuous("x", lb=0, ub=4)
+    y = m.integer("y", lb=0, ub=5)
+    m.subject_to(x * y >= 1.0)
+    m.minimize(x + y)
+    return m
+
+
+def _miqp_style_model(name="shot_miqp_style"):
+    m = dm.Model(name)
+    x = m.continuous("x", lb=-2, ub=2)
+    y = m.binary("y")
+    m.minimize((x - 1) ** 2 + y)
+    return m
+
+
 def test_mip_nlp_cut_record_construction_and_dedup():
     from discopt.solvers.oa import MIPNLPCutProvenance, MIPNLPCutRecord, _append_master_cut
 
@@ -556,6 +635,17 @@ def test_mip_nlp_shot_profile_options_validate_and_attach_trace(monkeypatch):
             "mip_nlp_profile": "shot",
             "tree_strategy": "single-tree",
             "cut_strategy": "esh",
+            "objective_epigraph": "on",
+            "anti_epigraph": "off",
+            "nonlinear_partitioning": "adaptive",
+            "quadratic_partitioning": "static",
+            "absolute_value_auxiliaries": "on",
+            "monomial_extraction": "off",
+            "signomial_extraction": "on",
+            "integer_bilinear_strategy": "binary-expansion",
+            "integer_bilinear_max_bits": 8,
+            "quadratic_extraction": "native",
+            "direct_quadratic_routing": "safe",
             "rootsearch_strategy": "toms748",
             "fixed_nlp_strategy": "solution-pool",
             "solution_pool_capacity": 5,
@@ -573,6 +663,17 @@ def test_mip_nlp_shot_profile_options_validate_and_attach_trace(monkeypatch):
     assert calls["mip_nlp_profile"] == "shot"
     assert cfg.tree_strategy == "single_tree"
     assert cfg.cut_strategy == "esh"
+    assert cfg.objective_epigraph == "on"
+    assert cfg.anti_epigraph == "off"
+    assert cfg.nonlinear_partitioning == "adaptive"
+    assert cfg.quadratic_partitioning == "static"
+    assert cfg.absolute_value_auxiliaries == "on"
+    assert cfg.monomial_extraction == "off"
+    assert cfg.signomial_extraction == "on"
+    assert cfg.integer_bilinear_strategy == "binary_expansion"
+    assert cfg.integer_bilinear_max_bits == 8
+    assert cfg.quadratic_extraction == "native"
+    assert cfg.direct_quadratic_routing == "safe"
     assert cfg.rootsearch_strategy == "toms748"
     assert cfg.fixed_nlp_strategy == "solution_pool"
     assert cfg.solution_pool_capacity == 5
@@ -587,6 +688,121 @@ def test_mip_nlp_shot_profile_options_validate_and_attach_trace(monkeypatch):
     assert result.mip_nlp_trace["schema_version"] == 1
     assert result.mip_nlp_trace["profile"] == "shot"
     assert result.mip_nlp_trace["shot_options"]["cut_strategy"] == "esh"
+    assert result.mip_nlp_trace["shot_options"]["integer_bilinear_strategy"] == ("binary_expansion")
+
+
+@pytest.mark.parametrize(
+    ("model_factory", "options", "trace_key", "trace_value"),
+    [
+        (_objective_epigraph_model, {"objective_epigraph": "on"}, "objective_epigraph", "on"),
+        (_anti_epigraph_model, {"anti_epigraph": "on"}, "anti_epigraph", "on"),
+        (
+            _bilinear_partition_model,
+            {"nonlinear_partitioning": "adaptive"},
+            "nonlinear_partitioning",
+            "adaptive",
+        ),
+        (
+            _quadratic_partition_model,
+            {"quadratic_partitioning": "static"},
+            "quadratic_partitioning",
+            "static",
+        ),
+        (
+            _absolute_value_model,
+            {"absolute_value_auxiliaries": "on"},
+            "absolute_value_auxiliaries",
+            "on",
+        ),
+        (_monomial_model, {"monomial_extraction": "off"}, "monomial_extraction", "off"),
+        (_signomial_model, {"signomial_extraction": "on"}, "signomial_extraction", "on"),
+        (
+            _integer_bilinear_model,
+            {"integer_bilinear_strategy": "mccormick", "integer_bilinear_max_bits": 6},
+            "integer_bilinear_strategy",
+            "mccormick",
+        ),
+        (_miqp_style_model, {"quadratic_extraction": "native"}, "quadratic_extraction", "native"),
+        (
+            _miqp_style_model,
+            {"direct_quadratic_routing": "safe"},
+            "direct_quadratic_routing",
+            "safe",
+        ),
+    ],
+)
+def test_mip_nlp_shot_reformulation_controls_validate_targeted_models(
+    monkeypatch,
+    model_factory,
+    options,
+    trace_key,
+    trace_value,
+):
+    import discopt.solvers.oa as oa_module
+    from discopt.solvers.mip_nlp import solve_mip_nlp
+
+    def fake_solve_oa(model, **kwargs):
+        return SolveResult(status="optimal", objective=0.0, bound=0.0, gap=0.0)
+
+    monkeypatch.setattr(oa_module, "solve_oa", fake_solve_oa)
+
+    result = solve_mip_nlp(
+        model_factory(),
+        method="oa",
+        mip_nlp_options={"mip_nlp_profile": "shot", **options},
+    )
+
+    assert result.mip_nlp_trace["profile"] == "shot"
+    assert result.mip_nlp_trace["shot_options"][trace_key] == trace_value
+    if "integer_bilinear_max_bits" in options:
+        assert result.mip_nlp_trace["shot_options"]["integer_bilinear_max_bits"] == 6
+
+
+def test_mip_nlp_shot_objective_epigraph_reforms_before_oa_and_stays_convex(monkeypatch):
+    import discopt.solvers.oa as oa_module
+    from discopt._jax.convexity import classify_oa_cut_convexity
+    from discopt.solvers.mip_nlp import solve_mip_nlp
+
+    calls = {}
+
+    def fake_solve_oa(model, **kwargs):
+        calls["model"] = model
+        return SolveResult(status="optimal", objective=0.0, bound=0.0, gap=0.0)
+
+    monkeypatch.setattr(oa_module, "solve_oa", fake_solve_oa)
+
+    solve_mip_nlp(
+        _objective_epigraph_model(),
+        method="oa",
+        mip_nlp_options={"mip_nlp_profile": "shot", "objective_epigraph": "on"},
+    )
+
+    transformed = calls["model"]
+    assert transformed._constraints[0].sense == ">="
+    convexity = classify_oa_cut_convexity(transformed)
+    assert convexity.objective_is_convex
+    assert convexity.constraint_mask == [True]
+
+
+def test_mip_nlp_shot_objective_epigraph_off_leaves_defining_equality(monkeypatch):
+    import discopt.solvers.oa as oa_module
+    from discopt.solvers.mip_nlp import solve_mip_nlp
+
+    calls = {}
+
+    def fake_solve_oa(model, **kwargs):
+        calls["model"] = model
+        return SolveResult(status="optimal", objective=0.0, bound=0.0, gap=0.0)
+
+    monkeypatch.setattr(oa_module, "solve_oa", fake_solve_oa)
+
+    solve_mip_nlp(
+        _objective_epigraph_model(),
+        method="oa",
+        mip_nlp_options={"mip_nlp_profile": "shot", "objective_epigraph": "off"},
+    )
+
+    assert calls["model"]._constraints[0].sense == "=="
 
 
 def test_mip_nlp_trace_gap_certification_requires_finite_bound():


### PR DESCRIPTION
## Summary

- Add validated SHOT-profile reformulation controls for objective epigraphs, anti-epigraphs, nonlinear/quadratic partitioning, absolute-value auxiliaries, monomial/signomial extraction, integer-bilinear strategy limits, quadratic extraction, and safe direct quadratic routing policy.
- Wire SHOT-profile MIP-NLP solves to discopt's existing structurally proven objective-defining-equality epigraph/anti-epigraph reformulation when enabled.
- Document the reformulation parity table, accepted profile options, active behavior, and deferred routing work.

## Tests

- `PYTHONPATH=python pytest python/tests/test_mip_nlp.py`
- `PYTHONPATH=python pytest python/tests/test_factorable_reform.py python/tests/test_objective_epigraph.py python/tests/test_convexity.py -k "objective or epigraph or factorable or monomial or signomial"`
- `python -m ruff check python/discopt/solvers/mip_nlp.py python/discopt/solvers/mip_nlp_options.py python/tests/test_mip_nlp.py`
- `python -m ruff format --check python/discopt/solvers/mip_nlp.py python/discopt/solvers/mip_nlp_options.py python/tests/test_mip_nlp.py`
- Commit hook: ruff, ruff format, mypy passed; cargo fmt skipped because no Rust files were changed.

The pytest runs emitted sandbox-local JAX persistent-cache warnings for `~/.cache/discopt/jax-cache` being read-only, but the tests passed.

## Branch Hygiene

- Base branch: `feature/mip-nlp-solver` (non-default SHOT roadmap integration branch).
- Source branch point: `origin/feature/mip-nlp-solver` at `2b2bfffd6a6e9e0a1386aa8d6fa02616becd4535`, the #140 merge commit noted on issue #140.
- Head branch: `fix/issue-141-reformulation-controls`.
- Stacked status: stacked after #140 on the roadmap branch; no open prerequisite PR remains.
- Upstream sync: `upstream/main` was fetched at `c618b0228a3b797e5b046e56255bf0755d043b24`; that tip is not contained in `feature/mip-nlp-solver`. No maintainer sync policy was present, so this PR intentionally remains on the roadmap base.

Because this targets a non-default base, GitHub may not auto-close the issue until the integration branch reaches the default branch.

Closes #141
