### PR TITLE
SHOT port 06: implement interior-point and rootsearch services

### DIFF
--- a/docs/mip_nlp.md
+++ b/docs/mip_nlp.md
@@ -148,6 +148,14 @@ back to the existing initialization path with details in
 `result.mip_nlp_trace["initial_poa"]`. `relaxation_phase="periodic"` remains a
 reserved roadmap value and does not schedule periodic POA solves yet.
 
+SHOT-profile runs also maintain an internal provenance-aware interior-point
+store for feasible relaxation, incumbent, and initial-POA points. Reusable
+rootsearch helpers in `discopt.solvers.mip_nlp_rootsearch` support bisection and
+optional TOMS748-compatible segment searches between stored interior points and
+candidate MIP/NLP points, including fixed-discrete compatibility checks and
+structured fallback statuses. ESH and objective-rootsearch cut generation remain
+separate roadmap work.
+
 The remaining reformulation controls are validated and traced under the SHOT
 profile so follow-up SHOT parity PRs can attach behavior without changing the
 public option names.

--- a/python/discopt/solvers/mip_nlp_rootsearch.py
+++ b/python/discopt/solvers/mip_nlp_rootsearch.py
@@ -1,0 +1,566 @@
+"""Interior-point storage and rootsearch helpers for MIP-NLP methods."""
+
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any, Iterable, Optional, Sequence
+
+import numpy as np
+
+_CONSTRAINT_INF = 1e19
+VectorLike = Sequence[float] | np.ndarray
+
+
+class MIPNLPRootSearchStatus(str, Enum):
+    """Structured rootsearch outcomes safe to place in traces."""
+
+    DISABLED = "disabled"
+    MISSING_INTERIOR_POINT = "missing_interior_point"
+    INCOMPATIBLE_DISCRETE = "incompatible_discrete"
+    INTERIOR_INFEASIBLE = "interior_infeasible"
+    CANDIDATE_FEASIBLE = "candidate_feasible"
+    NO_BRACKET = "no_bracket"
+    CONVERGED = "converged"
+    TIME_LIMIT = "time_limit"
+    MAX_ITERATIONS = "max_iterations"
+    EVALUATION_ERROR = "evaluation_error"
+
+
+@dataclass
+class MIPNLPInteriorPointRecord:
+    """One stored MIP-NLP interior-point candidate with provenance metadata."""
+
+    point: np.ndarray
+    source: str
+    metadata: dict[str, Any] = field(default_factory=dict)
+    discrete_signature: tuple[float, ...] = ()
+    max_residual: Optional[float] = None
+
+    def as_trace_dict(self) -> dict[str, Any]:
+        return {
+            "source": self.source,
+            "metadata": dict(self.metadata),
+            "discrete_signature": self.discrete_signature,
+            "max_residual": self.max_residual,
+        }
+
+
+@dataclass
+class MIPNLPRootSearchResult:
+    """Result of line rootsearch between an interior point and a candidate."""
+
+    status: MIPNLPRootSearchStatus
+    point: Optional[np.ndarray] = None
+    t: Optional[float] = None
+    residual: Optional[float] = None
+    iterations: int = 0
+    strategy: str = "bisection"
+    interior_source: Optional[str] = None
+    message: Optional[str] = None
+
+    def as_trace_dict(self) -> dict[str, Any]:
+        return {
+            "status": self.status.value,
+            "t": self.t,
+            "residual": self.residual,
+            "iterations": int(self.iterations),
+            "strategy": self.strategy,
+            "interior_source": self.interior_source,
+            "message": self.message,
+        }
+
+
+class MIPNLPInteriorPointStore:
+    """Small provenance-aware store for feasible MIP-NLP reference points."""
+
+    def __init__(
+        self,
+        n_vars: int,
+        *,
+        int_indices: Iterable[int] = (),
+        lb: Optional[VectorLike] = None,
+        ub: Optional[VectorLike] = None,
+        integer_tol: float = 1e-6,
+    ) -> None:
+        self.n_vars = int(n_vars)
+        self.int_indices = tuple(int(i) for i in int_indices)
+        self.integer_tol = float(integer_tol)
+        self.lb = None if lb is None else _as_vector("lb", lb, self.n_vars)
+        self.ub = None if ub is None else _as_vector("ub", ub, self.n_vars)
+        self.records: list[MIPNLPInteriorPointRecord] = []
+
+    def add(
+        self,
+        point: VectorLike,
+        *,
+        source: str,
+        metadata: Optional[dict[str, Any]] = None,
+        evaluator=None,
+        constraint_bounds=None,
+        constraint_senses: Optional[Sequence[str]] = None,
+        require_feasible: bool = False,
+        feasibility_tol: float = 1e-7,
+    ) -> Optional[MIPNLPInteriorPointRecord]:
+        """Store a point, optionally only when it satisfies evaluator constraints."""
+        x = _as_vector("point", point, self.n_vars)
+        max_residual = None
+        if evaluator is not None:
+            try:
+                max_residual = _max_constraint_residual(
+                    evaluator,
+                    x,
+                    constraint_bounds=constraint_bounds,
+                    constraint_senses=constraint_senses,
+                )
+            except Exception:
+                if require_feasible:
+                    return None
+            else:
+                if require_feasible and max_residual > float(feasibility_tol):
+                    return None
+
+        record = MIPNLPInteriorPointRecord(
+            point=x.copy(),
+            source=str(source),
+            metadata=dict(metadata or {}),
+            discrete_signature=self.discrete_signature(x),
+            max_residual=max_residual,
+        )
+        self.records.append(record)
+        return record
+
+    def discrete_signature(self, point: VectorLike) -> tuple[float, ...]:
+        x = _as_vector("point", point, self.n_vars)
+        return tuple(
+            _rounded_discrete_value(x[idx], self._lb_at(idx), self._ub_at(idx))
+            for idx in self.int_indices
+        )
+
+    def is_compatible(
+        self,
+        record: MIPNLPInteriorPointRecord,
+        candidate: VectorLike,
+        *,
+        fixed_discrete: bool = True,
+    ) -> bool:
+        if not fixed_discrete or not self.int_indices:
+            return True
+        return record.discrete_signature == self.discrete_signature(candidate)
+
+    def select(
+        self,
+        candidate: VectorLike,
+        *,
+        fixed_discrete: bool = True,
+    ) -> Optional[MIPNLPInteriorPointRecord]:
+        for record in reversed(self.records):
+            if self.is_compatible(record, candidate, fixed_discrete=fixed_discrete):
+                return record
+        return None
+
+    def _lb_at(self, idx: int) -> Optional[float]:
+        return None if self.lb is None else float(self.lb[idx])
+
+    def _ub_at(self, idx: int) -> Optional[float]:
+        return None if self.ub is None else float(self.ub[idx])
+
+
+def rootsearch_from_store(
+    evaluator,
+    candidate: VectorLike,
+    store: MIPNLPInteriorPointStore,
+    *,
+    strategy: str = "bisection",
+    fixed_discrete: bool = True,
+    constraint_bounds=None,
+    constraint_senses: Optional[Sequence[str]] = None,
+    feasibility_tol: float = 1e-7,
+    residual_tol: float = 1e-7,
+    x_tol: float = 1e-8,
+    max_iterations: int = 60,
+    time_limit: Optional[float] = None,
+) -> MIPNLPRootSearchResult:
+    """Run rootsearch using the newest compatible interior point in ``store``."""
+    record = store.select(candidate, fixed_discrete=fixed_discrete)
+    if record is None:
+        status = (
+            MIPNLPRootSearchStatus.INCOMPATIBLE_DISCRETE
+            if fixed_discrete and store.records and store.int_indices
+            else MIPNLPRootSearchStatus.MISSING_INTERIOR_POINT
+        )
+        return MIPNLPRootSearchResult(status=status, strategy=_normalize_strategy(strategy))
+
+    result = rootsearch_between_points(
+        evaluator,
+        record.point,
+        candidate,
+        strategy=strategy,
+        int_indices=store.int_indices,
+        fixed_discrete=fixed_discrete,
+        lb=store.lb,
+        ub=store.ub,
+        constraint_bounds=constraint_bounds,
+        constraint_senses=constraint_senses,
+        feasibility_tol=feasibility_tol,
+        residual_tol=residual_tol,
+        x_tol=x_tol,
+        max_iterations=max_iterations,
+        time_limit=time_limit,
+    )
+    result.interior_source = record.source
+    return result
+
+
+def rootsearch_between_points(
+    evaluator,
+    interior_point: VectorLike,
+    candidate: VectorLike,
+    *,
+    strategy: str = "bisection",
+    int_indices: Iterable[int] = (),
+    fixed_discrete: bool = False,
+    lb: Optional[VectorLike] = None,
+    ub: Optional[VectorLike] = None,
+    constraint_bounds=None,
+    constraint_senses: Optional[Sequence[str]] = None,
+    feasibility_tol: float = 1e-7,
+    residual_tol: float = 1e-7,
+    x_tol: float = 1e-8,
+    max_iterations: int = 60,
+    time_limit: Optional[float] = None,
+) -> MIPNLPRootSearchResult:
+    """Find the first nonlinear-constraint boundary point on a segment.
+
+    ``interior_point`` is expected to satisfy the model constraints and
+    ``candidate`` is usually a MIP/NLP candidate outside the nonlinear feasible
+    region. With ``fixed_discrete=True``, integer slots are held at the
+    candidate values for the entire segment.
+    """
+    strategy_name = _normalize_strategy(strategy)
+    if strategy_name == "none":
+        return MIPNLPRootSearchResult(status=MIPNLPRootSearchStatus.DISABLED, strategy="none")
+
+    n_vars = int(getattr(evaluator, "n_variables", len(np.asarray(candidate).reshape(-1))))
+    start = _as_vector("interior_point", interior_point, n_vars)
+    end = _as_vector("candidate", candidate, n_vars)
+    int_idx = tuple(int(i) for i in int_indices)
+    lb_vec = None if lb is None else _as_vector("lb", lb, n_vars)
+    ub_vec = None if ub is None else _as_vector("ub", ub, n_vars)
+
+    if fixed_discrete and int_idx:
+        start_sig = tuple(
+            _rounded_discrete_value(start[idx], _bound_at(lb_vec, idx), _bound_at(ub_vec, idx))
+            for idx in int_idx
+        )
+        end_sig = tuple(
+            _rounded_discrete_value(end[idx], _bound_at(lb_vec, idx), _bound_at(ub_vec, idx))
+            for idx in int_idx
+        )
+        if start_sig != end_sig:
+            return MIPNLPRootSearchResult(
+                status=MIPNLPRootSearchStatus.INCOMPATIBLE_DISCRETE,
+                strategy=strategy_name,
+            )
+        for idx in int_idx:
+            start[idx] = end[idx]
+
+    deadline = None if time_limit is None else time.perf_counter() + max(0.0, float(time_limit))
+    if _timed_out(deadline):
+        return MIPNLPRootSearchResult(
+            status=MIPNLPRootSearchStatus.TIME_LIMIT,
+            strategy=strategy_name,
+        )
+
+    try:
+        phi_start = _max_constraint_residual(
+            evaluator,
+            start,
+            constraint_bounds=constraint_bounds,
+            constraint_senses=constraint_senses,
+        )
+        phi_end = _max_constraint_residual(
+            evaluator,
+            end,
+            constraint_bounds=constraint_bounds,
+            constraint_senses=constraint_senses,
+        )
+    except Exception as exc:
+        return MIPNLPRootSearchResult(
+            status=MIPNLPRootSearchStatus.EVALUATION_ERROR,
+            strategy=strategy_name,
+            message=f"{type(exc).__name__}: {exc}",
+        )
+
+    if phi_start > float(feasibility_tol):
+        return MIPNLPRootSearchResult(
+            status=MIPNLPRootSearchStatus.INTERIOR_INFEASIBLE,
+            point=start,
+            t=0.0,
+            residual=float(phi_start),
+            strategy=strategy_name,
+        )
+    if phi_end <= float(feasibility_tol):
+        return MIPNLPRootSearchResult(
+            status=MIPNLPRootSearchStatus.CANDIDATE_FEASIBLE,
+            point=end,
+            t=1.0,
+            residual=float(phi_end),
+            strategy=strategy_name,
+        )
+
+    def point_at(t: float) -> np.ndarray:
+        return np.asarray(start + float(t) * (end - start), dtype=np.float64)
+
+    def phi(t: float) -> float:
+        if _timed_out(deadline):
+            raise _RootSearchTimeout
+        return _max_constraint_residual(
+            evaluator,
+            point_at(t),
+            constraint_bounds=constraint_bounds,
+            constraint_senses=constraint_senses,
+        )
+
+    if strategy_name == "toms748":
+        toms_result = _try_toms748(
+            phi,
+            point_at,
+            residual_tol=float(residual_tol),
+            x_tol=float(x_tol),
+            max_iterations=int(max_iterations),
+        )
+        if toms_result.status is not MIPNLPRootSearchStatus.NO_BRACKET:
+            return toms_result
+
+    return _bisect_root(
+        phi,
+        point_at,
+        residual_tol=float(residual_tol),
+        x_tol=float(x_tol),
+        max_iterations=int(max_iterations),
+        strategy="bisection" if strategy_name == "auto" else strategy_name,
+    )
+
+
+def _bisect_root(
+    phi,
+    point_at,
+    *,
+    residual_tol: float,
+    x_tol: float,
+    max_iterations: int,
+    strategy: str,
+) -> MIPNLPRootSearchResult:
+    lo = 0.0
+    hi = 1.0
+    last_t = 0.5
+    last_residual = None
+    for iteration in range(1, max(1, max_iterations) + 1):
+        last_t = 0.5 * (lo + hi)
+        try:
+            last_residual = float(phi(last_t))
+        except _RootSearchTimeout:
+            return MIPNLPRootSearchResult(
+                status=MIPNLPRootSearchStatus.TIME_LIMIT,
+                point=point_at(lo),
+                t=lo,
+                residual=last_residual,
+                iterations=iteration - 1,
+                strategy=strategy,
+            )
+        if abs(last_residual) <= residual_tol or (hi - lo) <= x_tol:
+            return MIPNLPRootSearchResult(
+                status=MIPNLPRootSearchStatus.CONVERGED,
+                point=point_at(last_t),
+                t=last_t,
+                residual=last_residual,
+                iterations=iteration,
+                strategy=strategy,
+            )
+        if last_residual <= 0.0:
+            lo = last_t
+        else:
+            hi = last_t
+
+    return MIPNLPRootSearchResult(
+        status=MIPNLPRootSearchStatus.MAX_ITERATIONS,
+        point=point_at(last_t),
+        t=last_t,
+        residual=last_residual,
+        iterations=max(1, max_iterations),
+        strategy=strategy,
+    )
+
+
+def _try_toms748(
+    phi,
+    point_at,
+    *,
+    residual_tol: float,
+    x_tol: float,
+    max_iterations: int,
+) -> MIPNLPRootSearchResult:
+    try:
+        from scipy.optimize import toms748
+
+        root = float(toms748(phi, 0.0, 1.0, xtol=x_tol, rtol=x_tol, maxiter=max_iterations))
+        residual = float(phi(root))
+    except _RootSearchTimeout:
+        return MIPNLPRootSearchResult(
+            status=MIPNLPRootSearchStatus.TIME_LIMIT,
+            strategy="toms748",
+        )
+    except Exception as exc:
+        return MIPNLPRootSearchResult(
+            status=MIPNLPRootSearchStatus.NO_BRACKET,
+            strategy="toms748",
+            message=f"toms748_fallback: {type(exc).__name__}: {exc}",
+        )
+    return MIPNLPRootSearchResult(
+        status=MIPNLPRootSearchStatus.CONVERGED,
+        point=point_at(root),
+        t=root,
+        residual=residual,
+        iterations=0,
+        strategy="toms748",
+    )
+
+
+def _max_constraint_residual(
+    evaluator,
+    x: np.ndarray,
+    *,
+    constraint_bounds=None,
+    constraint_senses: Optional[Sequence[str]] = None,
+) -> float:
+    residuals = _constraint_residuals(
+        evaluator,
+        x,
+        constraint_bounds=constraint_bounds,
+        constraint_senses=constraint_senses,
+    )
+    if residuals.size == 0:
+        return float("-inf")
+    return float(np.max(residuals))
+
+
+def _constraint_residuals(
+    evaluator,
+    x: np.ndarray,
+    *,
+    constraint_bounds=None,
+    constraint_senses: Optional[Sequence[str]] = None,
+) -> np.ndarray:
+    m = int(getattr(evaluator, "n_constraints", 0))
+    if m == 0:
+        return np.empty(0, dtype=np.float64)
+    cons = np.asarray(evaluator.evaluate_constraints(x), dtype=np.float64).reshape(-1)
+    if cons.size != m:
+        raise ValueError(f"evaluator returned {cons.size} constraints; expected {m}.")
+    cl, cu = _constraint_bounds(
+        evaluator,
+        constraint_bounds=constraint_bounds,
+        constraint_senses=constraint_senses,
+    )
+    residual_parts: list[np.ndarray] = []
+    upper_mask = cu < _CONSTRAINT_INF
+    lower_mask = cl > -_CONSTRAINT_INF
+    if np.any(upper_mask):
+        residual_parts.append(cons[upper_mask] - cu[upper_mask])
+    if np.any(lower_mask):
+        residual_parts.append(cl[lower_mask] - cons[lower_mask])
+    if not residual_parts:
+        return np.empty(0, dtype=np.float64)
+    return np.concatenate(residual_parts)
+
+
+def _constraint_bounds(
+    evaluator,
+    *,
+    constraint_bounds=None,
+    constraint_senses: Optional[Sequence[str]] = None,
+) -> tuple[np.ndarray, np.ndarray]:
+    m = int(getattr(evaluator, "n_constraints", 0))
+    if constraint_bounds is not None:
+        if isinstance(constraint_bounds, tuple) and len(constraint_bounds) == 2:
+            cl = np.asarray(constraint_bounds[0], dtype=np.float64).reshape(-1)
+            cu = np.asarray(constraint_bounds[1], dtype=np.float64).reshape(-1)
+        else:
+            bounds = np.asarray(constraint_bounds, dtype=np.float64)
+            if bounds.shape != (m, 2):
+                raise ValueError(f"constraint_bounds must have shape ({m}, 2).")
+            cl = bounds[:, 0]
+            cu = bounds[:, 1]
+        if cl.shape != (m,) or cu.shape != (m,):
+            raise ValueError(f"constraint bounds must have length {m}.")
+        return cl, cu
+
+    if constraint_senses is not None:
+        if len(constraint_senses) != m:
+            raise ValueError(
+                f"constraint_senses has length {len(constraint_senses)}; expected {m}."
+            )
+        cl = np.full(m, -_CONSTRAINT_INF, dtype=np.float64)
+        cu = np.full(m, _CONSTRAINT_INF, dtype=np.float64)
+        for i, sense in enumerate(constraint_senses):
+            if sense == "<=":
+                cu[i] = 0.0
+            elif sense == ">=":
+                cl[i] = 0.0
+            elif sense == "==":
+                cl[i] = 0.0
+                cu[i] = 0.0
+            else:
+                raise ValueError(f"Unknown constraint sense: {sense!r}.")
+        return cl, cu
+
+    from discopt.solvers.nlp_ipopt import _infer_constraint_bounds
+
+    return _infer_constraint_bounds(evaluator)
+
+
+def _normalize_strategy(strategy: str) -> str:
+    key = str(strategy).strip().lower().replace("-", "_")
+    if key in {"", "auto"}:
+        return "bisection"
+    if key in {"none", "bisection", "toms748"}:
+        return key
+    raise ValueError("rootsearch strategy must be one of: auto, none, bisection, toms748.")
+
+
+def _as_vector(name: str, values: VectorLike, n_vars: Optional[int] = None) -> np.ndarray:
+    arr = np.asarray(values, dtype=np.float64).reshape(-1)
+    if n_vars is not None and arr.shape != (int(n_vars),):
+        raise ValueError(f"{name} has shape {arr.shape}; expected ({int(n_vars)},).")
+    if not np.all(np.isfinite(arr)):
+        raise ValueError(f"{name} must contain only finite values.")
+    return arr
+
+
+def _rounded_discrete_value(
+    value: float,
+    lb: Optional[float] = None,
+    ub: Optional[float] = None,
+) -> float:
+    rounded = float(np.floor(float(value) + 0.5))
+    if lb is None or ub is None:
+        return rounded
+    lo = float(np.ceil(lb))
+    hi = float(np.floor(ub))
+    if lo <= hi:
+        return float(np.clip(rounded, lo, hi))
+    return rounded
+
+
+def _bound_at(values: Optional[np.ndarray], idx: int) -> Optional[float]:
+    return None if values is None else float(values[idx])
+
+
+def _timed_out(deadline: Optional[float]) -> bool:
+    return deadline is not None and time.perf_counter() >= deadline
+
+
+class _RootSearchTimeout(Exception):
+    pass

--- a/python/discopt/solvers/oa.py
+++ b/python/discopt/solvers/oa.py
@@ -3352,7 +3352,16 @@ def solve_oa(
     feasibility_subproblem_count = 0
     solution_pool_candidate_count = 0
     initial_poa_trace: Optional[dict[str, object]] = None
+    interior_point_store = None
     if mip_nlp_profile == "shot":
+        from discopt.solvers.mip_nlp_rootsearch import MIPNLPInteriorPointStore
+
+        interior_point_store = MIPNLPInteriorPointStore(
+            n_vars,
+            int_indices=decomp.int_indices,
+            lb=decomp.lb,
+            ub=decomp.ub,
+        )
         phase = mip_nlp_shot_config.relaxation_phase if mip_nlp_shot_config is not None else "off"
         initial_poa_enabled = mip_nlp_shot_config is not None and phase in _INITIAL_POA_PHASES
         initial_poa_trace = {
@@ -3366,6 +3375,7 @@ def solve_oa(
             "objective_bound": None,
             "objective_bound_valid": False,
             "interior_point_candidates": 0,
+            "interior_points_stored": 0,
             "node_count": 0,
         }
 
@@ -3404,6 +3414,12 @@ def solve_oa(
             "cut_source_counts": cut_provenance.source_counts(),
             "solution_pool_candidates": int(solution_pool_candidate_count),
         }
+        if interior_point_store is not None:
+            interior_counts = Counter(record.source for record in interior_point_store.records)
+            summary["interior_point_count"] = int(len(interior_point_store.records))
+            summary["interior_point_source_counts"] = {
+                str(source): int(count) for source, count in sorted(interior_counts.items())
+            }
         if initial_poa_trace is not None:
             poa_cuts = initial_poa_trace.get("cuts_added", 0)
             poa_provenance_cuts = initial_poa_trace.get("provenance_cuts_added", 0)
@@ -3432,6 +3448,23 @@ def solve_oa(
         if initial_poa_trace is not None:
             trace["initial_poa"] = dict(initial_poa_trace)
         return trace
+
+    def _record_interior_point(
+        x: np.ndarray,
+        source: str,
+        metadata: Optional[dict[str, object]] = None,
+    ) -> bool:
+        if interior_point_store is None:
+            return False
+        record = interior_point_store.add(
+            x,
+            source=source,
+            metadata=metadata,
+            evaluator=evaluator,
+            constraint_senses=decomp.constraint_senses,
+            require_feasible=True,
+        )
+        return record is not None
 
     # If no integer variables, just solve the NLP directly
     if len(decomp.int_indices) == 0:
@@ -3482,6 +3515,7 @@ def solve_oa(
                 incumbent,
                 multipliers,
             )
+        _record_interior_point(incumbent, "incumbent", {"objective": float(obj)})
 
     if init_strategy == "rNLP":
         relax_attempt = None
@@ -3521,6 +3555,7 @@ def solve_oa(
                 cut_provenance=cut_provenance,
             )
             # Check if relaxation solution is already integer-feasible.
+            _record_interior_point(x_relax, "nlp_relaxation", {"objective": float(obj_relax)})
             is_int_feasible = all(
                 abs(x_relax[idx] - round(x_relax[idx])) < 1e-5 for idx in decomp.int_indices
             )
@@ -3736,10 +3771,15 @@ def solve_oa(
                         if master_bound_valid and poa_result.bound is not None:
                             objective_bound = float(poa_result.bound)
                             LB = max(LB, objective_bound)
-                        try:
-                            interior_candidates = 1 if _is_primal_feasible(evaluator, x_poa) else 0
-                        except Exception:
-                            interior_candidates = 0
+                        stored_poa_interior = _record_interior_point(
+                            x_poa,
+                            "initial_poa",
+                            {
+                                "objective_bound": _trace_value(objective_bound),
+                                "node_count": int(getattr(poa_result, "node_count", 0) or 0),
+                            },
+                        )
+                        interior_candidates = 1 if stored_poa_interior else 0
                         _add_oa_cuts(
                             evaluator,
                             x_poa,
@@ -3770,6 +3810,7 @@ def solve_oa(
                                 ),
                                 "bound_after": _trace_value(LB),
                                 "interior_point_candidates": int(interior_candidates),
+                                "interior_points_stored": int(interior_candidates),
                                 "node_count": int(getattr(poa_result, "node_count", 0) or 0),
                             }
                         )
@@ -4051,6 +4092,11 @@ def solve_oa(
                     UB = master_obj
                     incumbent = x_master.copy()
                     incumbent_obj = master_obj
+                    _record_interior_point(
+                        incumbent,
+                        "ecp_candidate",
+                        {"objective": float(master_obj)},
+                    )
 
                 gap = _compute_gap(LB, UB)
                 logger.info(

--- a/python/tests/test_mip_nlp_rootsearch.py
+++ b/python/tests/test_mip_nlp_rootsearch.py
@@ -1,0 +1,134 @@
+import numpy as np
+import pytest
+from discopt.solvers.mip_nlp_rootsearch import (
+    MIPNLPInteriorPointStore,
+    MIPNLPRootSearchStatus,
+    rootsearch_between_points,
+    rootsearch_from_store,
+)
+
+
+class _CircleEvaluator:
+    n_variables = 2
+    n_constraints = 1
+
+    def evaluate_constraints(self, x):
+        x = np.asarray(x, dtype=float)
+        return np.array([x[0] ** 2 + x[1] ** 2 - 1.0], dtype=float)
+
+
+def test_mip_nlp_rootsearch_bisection_converges_on_known_circle_crossing():
+    evaluator = _CircleEvaluator()
+    store = MIPNLPInteriorPointStore(2)
+    record = store.add(
+        [0.0, 0.0],
+        source="initial_poa",
+        metadata={"node_count": 3},
+        evaluator=evaluator,
+        constraint_senses=["<="],
+        require_feasible=True,
+    )
+
+    result = rootsearch_from_store(
+        evaluator,
+        [2.0, 0.0],
+        store,
+        constraint_senses=["<="],
+        residual_tol=1e-10,
+        x_tol=1e-10,
+    )
+
+    assert record is not None
+    assert record.source == "initial_poa"
+    assert record.metadata["node_count"] == 3
+    assert result.status is MIPNLPRootSearchStatus.CONVERGED
+    assert result.interior_source == "initial_poa"
+    assert result.t == pytest.approx(0.5, abs=1e-6)
+    assert result.point == pytest.approx(np.array([1.0, 0.0]), abs=1e-6)
+    assert abs(result.residual) <= 1e-6
+
+
+def test_mip_nlp_rootsearch_reports_infeasible_interior_endpoint():
+    result = rootsearch_between_points(
+        _CircleEvaluator(),
+        [1.2, 0.0],
+        [2.0, 0.0],
+        constraint_senses=["<="],
+    )
+
+    assert result.status is MIPNLPRootSearchStatus.INTERIOR_INFEASIBLE
+    assert result.t == 0.0
+    assert result.residual > 0.0
+
+
+def test_mip_nlp_rootsearch_fixed_discrete_keeps_candidate_value():
+    evaluator = _CircleEvaluator()
+    store = MIPNLPInteriorPointStore(
+        2,
+        int_indices=[1],
+        lb=[0.0, 0.0],
+        ub=[3.0, 1.0],
+    )
+    store.add(
+        [0.0, 1.0],
+        source="incumbent",
+        evaluator=evaluator,
+        constraint_senses=["<="],
+        require_feasible=True,
+    )
+
+    result = rootsearch_from_store(
+        evaluator,
+        [2.0, 1.0],
+        store,
+        fixed_discrete=True,
+        constraint_senses=["<="],
+    )
+
+    assert result.status is MIPNLPRootSearchStatus.CONVERGED
+    assert result.point[1] == pytest.approx(1.0)
+
+
+def test_mip_nlp_rootsearch_rejects_incompatible_fixed_discrete_reference():
+    store = MIPNLPInteriorPointStore(
+        2,
+        int_indices=[1],
+        lb=[0.0, 0.0],
+        ub=[3.0, 1.0],
+    )
+    store.add([0.0, 0.0], source="incumbent")
+
+    result = rootsearch_from_store(
+        _CircleEvaluator(),
+        [2.0, 1.0],
+        store,
+        fixed_discrete=True,
+        constraint_senses=["<="],
+    )
+
+    assert result.status is MIPNLPRootSearchStatus.INCOMPATIBLE_DISCRETE
+    assert result.point is None
+
+
+def test_mip_nlp_rootsearch_missing_interior_point_fallback():
+    result = rootsearch_from_store(
+        _CircleEvaluator(),
+        [2.0, 0.0],
+        MIPNLPInteriorPointStore(2),
+        constraint_senses=["<="],
+    )
+
+    assert result.status is MIPNLPRootSearchStatus.MISSING_INTERIOR_POINT
+    assert result.point is None
+
+
+def test_mip_nlp_rootsearch_time_limit_status():
+    result = rootsearch_between_points(
+        _CircleEvaluator(),
+        [0.0, 0.0],
+        [2.0, 0.0],
+        constraint_senses=["<="],
+        time_limit=0.0,
+    )
+
+    assert result.status is MIPNLPRootSearchStatus.TIME_LIMIT


### PR DESCRIPTION
Closes #143

## Summary

- Add `discopt.solvers.mip_nlp_rootsearch` with provenance-aware interior-point storage, fixed-discrete compatibility checks, structured rootsearch statuses, bisection rootsearch, and optional TOMS748-compatible segment search.
- Record feasible SHOT-profile relaxation, incumbent, ECP, and initial-POA points in the OA trace summary without changing the OA cut loop.
- Document the current rootsearch service scope and defer ESH/objective-rootsearch cut generation to the next roadmap item.

## Tests

- `python -m ruff check python/discopt/solvers/mip_nlp_rootsearch.py python/discopt/solvers/oa.py python/tests/test_mip_nlp_rootsearch.py python/tests/test_mip_nlp.py`
- `python -m ruff format --check python/discopt/solvers/mip_nlp_rootsearch.py python/discopt/solvers/oa.py python/tests/test_mip_nlp_rootsearch.py python/tests/test_mip_nlp.py`
- `PYTHONPATH=python pytest python/tests/test_mip_nlp_rootsearch.py python/tests/test_mip_nlp.py -q`
- Commit hook: ruff, ruff format, mypy, cargo fmt

## Branch Hygiene

- Base branch: `feature/mip-nlp-solver`
- Source branch point: `origin/feature/mip-nlp-solver` at `fed8318a6a3f42fd9a54184571c340ebd6da78da`
- Stacked status: issue #143 follows #142; #142 has already been merged into `feature/mip-nlp-solver`.
- Upstream/default sync: `origin/feature/mip-nlp-solver` and `upstream/main` are currently diverged. This PR intentionally remains on the roadmap feature branch.

Because this PR targets non-default branch `feature/mip-nlp-solver`, GitHub may not auto-close #143 until the feature branch reaches the default branch.
