### PR TITLE
Add fixed-NLP primal candidate manager

### DIFF
--- a/docs/mip_nlp.md
+++ b/docs/mip_nlp.md
@@ -182,9 +182,14 @@ not receive silent no-op parameters; the trace records degraded features under
 `master_controls` and `summary["unsupported_backend_features"]`.
 
 `fixed_nlp_strategy="solution_pool"` or an explicit `solution_pool_capacity`
-uses the existing Gurobi solution-pool candidate ingestion path when
-`milp_solver="gurobi"`. Other backends keep the single incumbent candidate and
-record the degradation in the trace.
+uses the Gurobi solution-pool candidate ingestion path when
+`milp_solver="gurobi"`. Fixed-NLP candidates are ordered deterministically from
+the master optimum, relaxation candidates, solution pool points, rootsearch
+points, and external providers, with duplicate integer assignments removed
+before NLP solves. The per-iteration trace records each fixed-NLP call source,
+status, objective, warm-start source, and whether it improved the incumbent.
+Other backends keep the single incumbent candidate and record the degradation in
+the trace.
 
 The remaining reformulation controls are validated and traced under the SHOT
 profile so follow-up SHOT parity PRs can attach behavior without changing the

--- a/python/discopt/solvers/mip_nlp_candidates.py
+++ b/python/discopt/solvers/mip_nlp_candidates.py
@@ -1,0 +1,325 @@
+"""Fixed-integer NLP candidate management for MIP-NLP decomposition."""
+
+from __future__ import annotations
+
+import time
+from collections import Counter
+from dataclasses import dataclass, field
+from typing import Any, Optional
+
+import numpy as np
+
+_SOURCE_ORDER = {
+    "mip_optimum": 0,
+    "lp_relaxation": 1,
+    "solution_pool": 2,
+    "rootsearch": 3,
+    "external": 4,
+}
+
+
+def _round_integral_to_bounds(value: float, lb: float, ub: float) -> float:
+    rounded = float(np.floor(float(value) + 0.5))
+    lo = float(np.ceil(lb))
+    hi = float(np.floor(ub))
+    if lo <= hi:
+        return float(np.clip(rounded, lo, hi))
+    return float(np.clip(rounded, lb, ub))
+
+
+@dataclass(frozen=True)
+class FixedNLPCandidate:
+    """One candidate integer assignment for a fixed-integer NLP solve."""
+
+    point: np.ndarray
+    source: str
+    objective: Optional[float] = None
+    iteration: Optional[int] = None
+    nlp_source: str = "active"
+    provider: Optional[str] = None
+    sequence: int = 0
+    integer_assignment: tuple[float, ...] = field(default_factory=tuple)
+
+    def trace_dict(self) -> dict[str, object]:
+        return {
+            "source": self.source,
+            "objective": None if self.objective is None else float(self.objective),
+            "iteration": self.iteration,
+            "nlp_source": self.nlp_source,
+            "provider": self.provider,
+            "integer_assignment": [float(v) for v in self.integer_assignment],
+            "sequence": int(self.sequence),
+        }
+
+
+class FixedNLPCandidateManager:
+    """Queue and schedule fixed-NLP candidates.
+
+    The manager keeps ordering deterministic, deduplicates integer assignments,
+    and exposes a small scheduler that mirrors SHOT's always/iteration/time/pool
+    activation modes without coupling to a particular MIP or NLP backend.
+    """
+
+    def __init__(
+        self,
+        *,
+        n_vars: int,
+        int_indices: list[int],
+        lb,
+        ub,
+        strategy: str = "always",
+        iteration_frequency: int = 1,
+        time_frequency: float = 0.0,
+        candidate_limit: Optional[int] = None,
+        deduplicate_used_assignments: bool = False,
+    ) -> None:
+        self.n_vars = int(n_vars)
+        self.int_indices = list(int_indices)
+        self.lb = np.asarray(lb, dtype=np.float64)
+        self.ub = np.asarray(ub, dtype=np.float64)
+        self.strategy = self._normalize_strategy(strategy)
+        self.iteration_frequency = max(1, int(iteration_frequency))
+        self.time_frequency = max(0.0, float(time_frequency))
+        self.candidate_limit = None if candidate_limit is None else max(1, int(candidate_limit))
+        self.deduplicate_used_assignments = bool(deduplicate_used_assignments)
+        self._pending: list[FixedNLPCandidate] = []
+        self._pending_keys: set[tuple[float, ...]] = set()
+        self._used_keys: set[tuple[float, ...]] = set()
+        self._sequence = 0
+        self._last_call_iteration: Optional[int] = None
+        self._last_call_time: Optional[float] = None
+        self._last_success: Optional[bool] = None
+        self.added_source_counts: Counter[str] = Counter()
+        self.skipped_duplicate_count = 0
+
+    @staticmethod
+    def _normalize_strategy(strategy: str) -> str:
+        key = str(strategy).strip().lower().replace("-", "_")
+        if key in {"auto", "adaptive", "always", "iteration", "time", "solution_pool", "none"}:
+            return key
+        raise ValueError(
+            "fixed_nlp_strategy must be one of: adaptive, always, auto, "
+            "iteration, none, solution_pool, time."
+        )
+
+    @property
+    def pending_count(self) -> int:
+        return len(self._pending)
+
+    @staticmethod
+    def _sort_key(candidate: FixedNLPCandidate) -> tuple[int, float, int]:
+        return (
+            _SOURCE_ORDER.get(candidate.source, 50),
+            float("inf") if candidate.objective is None else float(candidate.objective),
+            candidate.sequence,
+        )
+
+    def assignment_key(self, point) -> tuple[float, ...]:
+        x = np.asarray(point, dtype=np.float64).reshape(-1)
+        return tuple(
+            _round_integral_to_bounds(float(x[idx]), float(self.lb[idx]), float(self.ub[idx]))
+            for idx in self.int_indices
+        )
+
+    def add(
+        self,
+        point,
+        *,
+        source: str,
+        objective: Optional[float] = None,
+        iteration: Optional[int] = None,
+        nlp_source: str = "active",
+        provider: Optional[str] = None,
+    ) -> bool:
+        x = np.asarray(point, dtype=np.float64).reshape(-1)
+        if x.size < self.n_vars:
+            return False
+        x = np.clip(x[: self.n_vars].copy(), self.lb, self.ub)
+        key = self.assignment_key(x)
+        candidate = FixedNLPCandidate(
+            point=x,
+            source=str(source),
+            objective=None if objective is None else float(objective),
+            iteration=iteration,
+            nlp_source=str(nlp_source),
+            provider=provider,
+            sequence=self._sequence,
+            integer_assignment=key,
+        )
+        if key in self._pending_keys:
+            for idx, existing in enumerate(self._pending):
+                if existing.integer_assignment == key:
+                    if self._sort_key(candidate) < self._sort_key(existing):
+                        self._pending[idx] = candidate
+                        self._sequence += 1
+                        self.added_source_counts[str(source)] += 1
+                        return True
+                    break
+            self.skipped_duplicate_count += 1
+            return False
+        if self.deduplicate_used_assignments and key in self._used_keys:
+            self.skipped_duplicate_count += 1
+            return False
+        self._sequence += 1
+        self._pending.append(candidate)
+        self._pending_keys.add(key)
+        self.added_source_counts[str(source)] += 1
+        return True
+
+    def add_external_candidates(
+        self,
+        candidates,
+        *,
+        iteration: Optional[int] = None,
+        provider: Optional[str] = None,
+        nlp_source: str = "active",
+    ) -> int:
+        added = 0
+        for candidate in candidates or []:
+            objective = None
+            point = candidate
+            source = "external"
+            if isinstance(candidate, dict):
+                point = candidate.get("point")
+                objective = candidate.get("objective")
+                source = str(candidate.get("source", "external"))
+                provider = candidate.get("provider", provider)
+                nlp_source = str(candidate.get("nlp_source", nlp_source))
+            if point is None:
+                continue
+            if self.add(
+                point,
+                source=source,
+                objective=objective,
+                iteration=iteration,
+                nlp_source=nlp_source,
+                provider=provider,
+            ):
+                added += 1
+        return added
+
+    def add_master_result(
+        self,
+        master_result: Any,
+        *,
+        iteration: int,
+        solution_pool: bool,
+        limit: int,
+        nlp_source: str = "active",
+    ) -> int:
+        if getattr(master_result, "x", None) is None:
+            return 0
+        before = self.pending_count
+        incumbent = np.asarray(master_result.x, dtype=np.float64).reshape(-1)
+        self.add(
+            incumbent,
+            source="mip_optimum",
+            objective=getattr(master_result, "objective", None),
+            iteration=iteration,
+            nlp_source=nlp_source,
+        )
+        if solution_pool:
+            pool = list(getattr(master_result, "solution_pool", None) or [])
+            pool_objectives = list(getattr(master_result, "solution_pool_objectives", None) or [])
+            for idx, raw in enumerate(pool):
+                objective = pool_objectives[idx] if idx < len(pool_objectives) else None
+                self.add(
+                    raw,
+                    source="solution_pool",
+                    objective=objective,
+                    iteration=iteration,
+                    nlp_source=nlp_source,
+                )
+                if self.candidate_limit is not None and self.pending_count - before >= limit:
+                    break
+        return self.pending_count - before
+
+    def should_call(
+        self,
+        *,
+        iteration: int,
+        elapsed: Optional[float] = None,
+        has_solution_pool_candidate: bool = False,
+    ) -> bool:
+        if self.strategy == "none" or not self._pending:
+            return False
+        if self.strategy == "always":
+            return True
+        if self.strategy == "solution_pool":
+            return bool(has_solution_pool_candidate)
+        if self.strategy == "iteration":
+            if self._last_call_iteration is None:
+                return True
+            return (int(iteration) - self._last_call_iteration) >= self.iteration_frequency
+        if self.strategy == "time":
+            now = time.perf_counter() if elapsed is None else float(elapsed)
+            if self._last_call_time is None:
+                return True
+            return (now - self._last_call_time) >= self.time_frequency
+        # adaptive/auto: call immediately after a productive solve, and otherwise
+        # fall back to the iteration/time gates.
+        if self._last_success is True:
+            return True
+        if self._last_call_iteration is None:
+            return True
+        iter_ready = (int(iteration) - self._last_call_iteration) >= self.iteration_frequency
+        now = time.perf_counter() if elapsed is None else float(elapsed)
+        time_ready = (now - float(self._last_call_time or 0.0)) >= self.time_frequency
+        return bool(iter_ready or time_ready)
+
+    def take_ready(
+        self,
+        *,
+        iteration: int,
+        elapsed: Optional[float] = None,
+        has_solution_pool_candidate: bool = False,
+    ) -> list[FixedNLPCandidate]:
+        if not self.should_call(
+            iteration=iteration,
+            elapsed=elapsed,
+            has_solution_pool_candidate=has_solution_pool_candidate,
+        ):
+            return []
+        ordered = sorted(
+            self._pending,
+            key=self._sort_key,
+        )
+        if self.candidate_limit is not None:
+            ready = ordered[: self.candidate_limit]
+            keep = ordered[self.candidate_limit :]
+        else:
+            ready = ordered
+            keep = []
+        self._pending = keep
+        self._pending_keys = {cand.integer_assignment for cand in keep}
+        for cand in ready:
+            self._used_keys.add(cand.integer_assignment)
+        return ready
+
+    def record_call_result(
+        self,
+        candidate: FixedNLPCandidate,
+        *,
+        iteration: int,
+        elapsed: Optional[float],
+        success: bool,
+    ) -> None:
+        del candidate
+        self._last_call_iteration = int(iteration)
+        self._last_call_time = time.perf_counter() if elapsed is None else float(elapsed)
+        self._last_success = bool(success)
+
+    def scheduler_trace(self) -> dict[str, object]:
+        return {
+            "strategy": self.strategy,
+            "iteration_frequency": int(self.iteration_frequency),
+            "time_frequency": float(self.time_frequency),
+            "candidate_limit": self.candidate_limit,
+            "pending": int(self.pending_count),
+            "deduplicate_used_assignments": bool(self.deduplicate_used_assignments),
+            "skipped_duplicates": int(self.skipped_duplicate_count),
+            "added_source_counts": {
+                str(source): int(count)
+                for source, count in sorted(self.added_source_counts.items())
+            },
+        }

--- a/python/discopt/solvers/mip_nlp_candidates.py
+++ b/python/discopt/solvers/mip_nlp_candidates.py
@@ -136,9 +136,10 @@ class FixedNLPCandidateManager:
             return False
         x = np.clip(x[: self.n_vars].copy(), self.lb, self.ub)
         key = self.assignment_key(x)
+        source_name = str(source)
         candidate = FixedNLPCandidate(
             point=x,
-            source=str(source),
+            source=source_name,
             objective=None if objective is None else float(objective),
             iteration=iteration,
             nlp_source=str(nlp_source),
@@ -150,9 +151,13 @@ class FixedNLPCandidateManager:
             for idx, existing in enumerate(self._pending):
                 if existing.integer_assignment == key:
                     if self._sort_key(candidate) < self._sort_key(existing):
+                        existing_source = str(existing.source)
+                        self.added_source_counts[existing_source] -= 1
+                        if self.added_source_counts[existing_source] <= 0:
+                            del self.added_source_counts[existing_source]
                         self._pending[idx] = candidate
                         self._sequence += 1
-                        self.added_source_counts[str(source)] += 1
+                        self.added_source_counts[source_name] += 1
                         return True
                     break
             self.skipped_duplicate_count += 1
@@ -163,7 +168,7 @@ class FixedNLPCandidateManager:
         self._sequence += 1
         self._pending.append(candidate)
         self._pending_keys.add(key)
-        self.added_source_counts[str(source)] += 1
+        self.added_source_counts[source_name] += 1
         return True
 
     def add_external_candidates(
@@ -179,12 +184,14 @@ class FixedNLPCandidateManager:
             objective = None
             point = candidate
             source = "external"
+            candidate_provider = provider
+            candidate_nlp_source = nlp_source
             if isinstance(candidate, dict):
                 point = candidate.get("point")
                 objective = candidate.get("objective")
                 source = str(candidate.get("source", "external"))
-                provider = candidate.get("provider", provider)
-                nlp_source = str(candidate.get("nlp_source", nlp_source))
+                candidate_provider = candidate.get("provider", provider)
+                candidate_nlp_source = str(candidate.get("nlp_source", nlp_source))
             if point is None:
                 continue
             if self.add(
@@ -192,8 +199,8 @@ class FixedNLPCandidateManager:
                 source=source,
                 objective=objective,
                 iteration=iteration,
-                nlp_source=nlp_source,
-                provider=provider,
+                nlp_source=candidate_nlp_source,
+                provider=candidate_provider,
             ):
                 added += 1
         return added

--- a/python/discopt/solvers/oa.py
+++ b/python/discopt/solvers/oa.py
@@ -31,6 +31,7 @@ from typing import TYPE_CHECKING, Any, Optional
 import numpy as np
 
 from discopt.modeling.core import Constraint, Model, ObjectiveSense, SolveResult, VarType
+from discopt.solvers.mip_nlp_candidates import FixedNLPCandidate, FixedNLPCandidateManager
 from discopt.solvers.mip_nlp_options import (
     FP_OPTION_KEYS,
     GOA_AMP_ONLY_OPTION_KEYS,
@@ -938,6 +939,14 @@ def _maybe_return_nlp_attempt(attempt: _NLPAttempt, return_attempt: bool):
     return attempt.x, attempt.objective
 
 
+def _coerce_nlp_attempt(result) -> _NLPAttempt:
+    if isinstance(result, _NLPAttempt):
+        return result
+    if isinstance(result, tuple) and len(result) >= 2:
+        return _NLPAttempt(x=result[0], objective=result[1], multipliers=None)
+    raise TypeError(f"Expected _NLPAttempt or (x, objective), got {type(result).__name__}.")
+
+
 def _solve_nlp_relaxation(
     evaluator,
     lb,
@@ -972,6 +981,43 @@ def _solve_nlp_subproblem(
     proxy = _BoundsProxy(evaluator, sub_lb, sub_ub)
     attempt = _solve_nlp_attempt(proxy, sub_lb, sub_ub, nlp_solver, x0=initial_point)
     return _maybe_return_nlp_attempt(attempt, return_attempt)
+
+
+def _solve_fixed_nlp_subproblem_attempt(
+    evaluator,
+    lb,
+    ub,
+    int_indices,
+    x_master,
+    nlp_solver,
+    *,
+    initial_point=None,
+) -> _NLPAttempt:
+    """Call the fixed-NLP helper and retain status when the implementation supports it."""
+    try:
+        result = _solve_nlp_subproblem(
+            evaluator,
+            lb,
+            ub,
+            int_indices,
+            x_master,
+            nlp_solver,
+            initial_point=initial_point,
+            return_attempt=True,
+        )
+    except TypeError as exc:
+        if "return_attempt" not in str(exc):
+            raise
+        result = _solve_nlp_subproblem(
+            evaluator,
+            lb,
+            ub,
+            int_indices,
+            x_master,
+            nlp_solver,
+            initial_point=initial_point,
+        )
+    return _coerce_nlp_attempt(result)
 
 
 def _regularization_requires_derivatives(add_regularization: Optional[str]) -> bool:
@@ -3832,6 +3878,21 @@ def solve_oa(
             "interior_points_stored": 0,
             "node_count": 0,
         }
+    fixed_nlp_strategy = "always"
+    if mip_nlp_profile == "shot" and mip_nlp_shot_config is not None:
+        fixed_nlp_strategy = mip_nlp_shot_config.fixed_nlp_strategy
+    fixed_nlp_manager = FixedNLPCandidateManager(
+        n_vars=n_vars,
+        int_indices=decomp.int_indices,
+        lb=decomp.lb,
+        ub=decomp.ub,
+        strategy=fixed_nlp_strategy,
+        candidate_limit=num_solution_iteration,
+        deduplicate_used_assignments=(mip_nlp_profile == "shot"),
+    )
+    fixed_nlp_call_count = 0
+    fixed_nlp_call_source_counts: Counter[str] = Counter()
+    fixed_nlp_call_status_counts: Counter[str] = Counter()
 
     def _trace_value(value: Optional[float]) -> Optional[float]:
         if value is None:
@@ -3889,6 +3950,22 @@ def solve_oa(
             summary["mip_solution_limit"] = shot_solution_limit_state.as_trace_dict()
         if shot_unsupported_backend_features:
             summary["unsupported_backend_features"] = sorted(shot_unsupported_backend_features)
+        fixed_nlp_candidates_added = sum(fixed_nlp_manager.added_source_counts.values())
+        summary["fixed_nlp_candidate_count"] = int(fixed_nlp_candidates_added)
+        summary["fixed_nlp_candidate_source_counts"] = {
+            str(source): int(count)
+            for source, count in sorted(fixed_nlp_manager.added_source_counts.items())
+        }
+        summary["fixed_nlp_call_count"] = int(fixed_nlp_call_count)
+        summary["fixed_nlp_call_source_counts"] = {
+            str(source): int(count)
+            for source, count in sorted(fixed_nlp_call_source_counts.items())
+        }
+        summary["fixed_nlp_call_status_counts"] = {
+            str(status): int(count)
+            for status, count in sorted(fixed_nlp_call_status_counts.items())
+        }
+        summary["fixed_nlp_scheduler"] = fixed_nlp_manager.scheduler_trace()
         if interior_point_store is not None:
             interior_counts = Counter(record.source for record in interior_point_store.records)
             summary["interior_point_count"] = int(len(interior_point_store.records))
@@ -3925,6 +4002,46 @@ def solve_oa(
         if initial_poa_trace is not None:
             trace["initial_poa"] = dict(initial_poa_trace)
         return trace
+
+    def _fixed_nlp_status_name(attempt: _NLPAttempt) -> str:
+        status = attempt.status
+        if status is not None:
+            return _trace_status(status)
+        if attempt.x is not None:
+            return "feasible"
+        return "failed"
+
+    def _fixed_nlp_warm_start(
+        candidate: FixedNLPCandidate,
+        preferred_start: Optional[np.ndarray],
+    ) -> tuple[np.ndarray, str]:
+        if preferred_start is not None:
+            return np.asarray(preferred_start, dtype=np.float64), "regularized_master"
+        return candidate.point.copy(), candidate.source
+
+    def _record_fixed_nlp_trace(
+        iteration_record: dict[str, object],
+        candidate: FixedNLPCandidate,
+        *,
+        status: str,
+        objective: Optional[float],
+        incumbent_update: str,
+        warm_start_source: str,
+    ) -> None:
+        calls = iteration_record.get("fixed_nlp_calls")
+        if not isinstance(calls, list):
+            calls = []
+            iteration_record["fixed_nlp_calls"] = calls
+        trace = candidate.trace_dict()
+        trace.update(
+            {
+                "status": status,
+                "objective": _trace_value(objective),
+                "incumbent_update": incumbent_update,
+                "warm_start_source": warm_start_source,
+            }
+        )
+        calls.append(trace)
 
     def _record_interior_point(
         x: np.ndarray,
@@ -4115,6 +4232,13 @@ def solve_oa(
             )
             # Check if relaxation solution is already integer-feasible.
             _record_interior_point(x_relax, "nlp_relaxation", {"objective": float(obj_relax)})
+            if mip_nlp_profile == "shot":
+                fixed_nlp_manager.add(
+                    x_relax,
+                    source="lp_relaxation",
+                    objective=obj_relax,
+                    iteration=-1,
+                )
             is_int_feasible = all(
                 abs(x_relax[idx] - round(x_relax[idx])) < 1e-5 for idx in decomp.int_indices
             )
@@ -4339,6 +4463,12 @@ def solve_oa(
                                 "node_count": int(getattr(poa_result, "node_count", 0) or 0),
                             },
                         )
+                        fixed_nlp_manager.add(
+                            x_poa,
+                            source="lp_relaxation",
+                            objective=objective_bound,
+                            iteration=-1,
+                        )
                         interior_candidates = 1 if stored_poa_interior else 0
                         _add_oa_cuts(
                             evaluator,
@@ -4482,6 +4612,12 @@ def solve_oa(
                                 "iteration": int(iteration),
                                 "node_count": int(getattr(relax_result, "node_count", 0) or 0),
                             },
+                        )
+                        fixed_nlp_manager.add(
+                            x_relax_phase,
+                            source="lp_relaxation",
+                            objective=objective_bound,
+                            iteration=int(iteration),
                         )
                         _add_oa_cuts(
                             evaluator,
@@ -4795,20 +4931,50 @@ def solve_oa(
                     add_regularization,
                 )
 
-        master_candidates = _master_solution_candidates(
-            master_result,
-            n_vars,
-            solution_pool=solution_pool,
-            num_solution_iteration=num_solution_iteration,
+        if ecp_mode:
+            fixed_nlp_candidates = [
+                FixedNLPCandidate(
+                    point=point,
+                    source="mip_optimum" if idx == 0 else "solution_pool",
+                    objective=None,
+                    iteration=int(iteration),
+                    sequence=idx,
+                    integer_assignment=fixed_nlp_manager.assignment_key(point),
+                )
+                for idx, point in enumerate(
+                    _master_solution_candidates(
+                        master_result,
+                        n_vars,
+                        solution_pool=solution_pool,
+                        num_solution_iteration=num_solution_iteration,
+                    )
+                )
+            ]
+        else:
+            fixed_nlp_manager.add_master_result(
+                master_result,
+                iteration=int(iteration),
+                solution_pool=solution_pool,
+                limit=num_solution_iteration,
+            )
+            fixed_nlp_candidates = fixed_nlp_manager.take_ready(
+                iteration=int(iteration),
+                elapsed=time.perf_counter() - t_start,
+                has_solution_pool_candidate=bool(solution_pool),
+            )
+        processed_master_candidates = sum(
+            1 for cand in fixed_nlp_candidates if cand.source in {"mip_optimum", "solution_pool"}
         )
-        solution_pool_candidate_count += len(master_candidates)
+        solution_pool_candidate_count += processed_master_candidates
         incumbent_obj_before_iteration = incumbent_obj
         iteration_record: dict[str, object] = {
             "index": int(iteration),
             "master_status": _trace_status(master_result.status),
             "lb_before": lb_before,
             "ub_before": ub_before,
-            "solution_pool_candidates": int(len(master_candidates)),
+            "solution_pool_candidates": int(processed_master_candidates),
+            "fixed_nlp_candidates": int(len(fixed_nlp_candidates)),
+            "fixed_nlp_scheduler": fixed_nlp_manager.scheduler_trace(),
             "node_count": int(getattr(master_result, "node_count", 0) or 0),
             "repair_actions": [],
             "relaxation_phase": relaxation_phase_record,
@@ -4817,7 +4983,29 @@ def solve_oa(
         stop_after_master_pool = False
         pool_integer_assignments_seen: set[tuple[float, ...]] = set()
 
-        for candidate_index, x_master in enumerate(master_candidates):
+        if not ecp_mode and not fixed_nlp_candidates:
+            x_master = np.asarray(master_result.x, dtype=np.float64).reshape(-1)[:n_vars].copy()
+            n_violated = _add_ecp_cuts(
+                evaluator,
+                x_master,
+                n_vars,
+                decomp.constraint_senses,
+                oa_A_rows,
+                oa_b_rows,
+                decomp.obj_is_linear,
+                decomp.oa_constraint_mask,
+                decomp.oa_objective_is_convex,
+                equality_relaxation=equality_relaxation,
+                oa_cut_relaxable=oa_cut_relaxable,
+                cut_provenance=cut_provenance,
+            )
+            iteration_record["fixed_nlp_skipped"] = {
+                "reason": f"fixed_nlp_strategy={fixed_nlp_strategy}",
+                "ecp_cuts_added": int(n_violated),
+            }
+
+        for candidate_index, candidate in enumerate(fixed_nlp_candidates):
+            x_master = candidate.point
             elapsed = time.perf_counter() - t_start
             if elapsed >= time_limit:
                 logger.info("OA: Time limit reached during iteration %d", iteration)
@@ -4825,10 +5013,7 @@ def solve_oa(
                 stop_after_master_pool = True
                 break
 
-            int_assignment = tuple(
-                _round_integral_to_bounds(x_master[idx], decomp.lb[idx], decomp.ub[idx])
-                for idx in decomp.int_indices
-            )
+            int_assignment = candidate.integer_assignment
             if solution_pool:
                 if int_assignment in pool_integer_assignments_seen:
                     logger.info(
@@ -4939,36 +5124,31 @@ def solve_oa(
                 continue
 
             # c. Fix integers, solve NLP subproblem
-            nlp_attempt = None
-            if derivative_regularization:
-                nlp_subproblem_count += 1
-                nlp_attempt = _solve_nlp_subproblem(
-                    evaluator,
-                    decomp.lb,
-                    decomp.ub,
-                    decomp.int_indices,
-                    x_master,
-                    nlp_solver,
-                    initial_point=nlp_initial_point,
-                    return_attempt=True,
-                )
-                x_nlp, obj_nlp = nlp_attempt.x, nlp_attempt.objective
-            else:
-                nlp_subproblem_count += 1
-                x_nlp, obj_nlp = _solve_nlp_subproblem(
-                    evaluator,
-                    decomp.lb,
-                    decomp.ub,
-                    decomp.int_indices,
-                    x_master,
-                    nlp_solver,
-                    initial_point=nlp_initial_point,
-                )
+            warm_start, warm_start_source = _fixed_nlp_warm_start(candidate, nlp_initial_point)
+            nlp_subproblem_count += 1
+            fixed_nlp_call_count += 1
+            fixed_nlp_call_source_counts[candidate.source] += 1
+            nlp_attempt = _solve_fixed_nlp_subproblem_attempt(
+                evaluator,
+                decomp.lb,
+                decomp.ub,
+                decomp.int_indices,
+                x_master,
+                nlp_solver,
+                initial_point=warm_start,
+            )
+            x_nlp, obj_nlp = nlp_attempt.x, nlp_attempt.objective
+            nlp_status_name = _fixed_nlp_status_name(nlp_attempt)
+            fixed_nlp_call_status_counts[nlp_status_name] += 1
+            incumbent_update = "not_feasible"
 
             if x_nlp is not None:
-                if obj_nlp < UB:
-                    multipliers = nlp_attempt.multipliers if nlp_attempt is not None else None
+                if obj_nlp is not None and obj_nlp < UB:
+                    multipliers = nlp_attempt.multipliers
                     accept_incumbent(x_nlp, obj_nlp, multipliers)
+                    incumbent_update = "improved"
+                else:
+                    incumbent_update = "not_improved"
 
                 # Generate OA cuts at NLP solution
                 _add_oa_cuts(
@@ -5012,7 +5192,17 @@ def solve_oa(
                             cut_provenance=cut_provenance,
                         )
 
-                if add_no_good_cuts and not decomp.general_integer_indices:
+                safe_integer_cut_status = nlp_status_name in {
+                    "failed",
+                    "infeasible",
+                    "unbounded",
+                    "error",
+                }
+                if (
+                    safe_integer_cut_status
+                    and add_no_good_cuts
+                    and not decomp.general_integer_indices
+                ):
                     _add_no_good_cut(
                         x_master,
                         decomp.binary_indices,
@@ -5039,6 +5229,21 @@ def solve_oa(
                     oa_cut_relaxable=oa_cut_relaxable,
                     cut_provenance=cut_provenance,
                 )
+
+            fixed_nlp_manager.record_call_result(
+                candidate,
+                iteration=int(iteration),
+                elapsed=time.perf_counter() - t_start,
+                success=x_nlp is not None,
+            )
+            _record_fixed_nlp_trace(
+                iteration_record,
+                candidate,
+                status=nlp_status_name,
+                objective=obj_nlp,
+                incumbent_update=incumbent_update,
+                warm_start_source=warm_start_source,
+            )
 
             # d. Check convergence
             gap = _compute_gap(LB, UB)

--- a/python/tests/test_mip_nlp.py
+++ b/python/tests/test_mip_nlp.py
@@ -2409,6 +2409,46 @@ def test_fixed_nlp_candidate_manager_orders_and_deduplicates_assignments():
     assert ready[2].objective == pytest.approx(10.0)
 
 
+def test_fixed_nlp_candidate_manager_trace_counts_and_external_defaults():
+    from discopt.solvers.mip_nlp_candidates import FixedNLPCandidateManager
+
+    kwargs = {
+        "n_vars": 2,
+        "int_indices": [1],
+        "lb": np.array([0.0, 0.0]),
+        "ub": np.array([10.0, 5.0]),
+        "strategy": "always",
+    }
+
+    replaced = FixedNLPCandidateManager(**kwargs)
+    replaced.add([0.0, 2.0], source="solution_pool", objective=20.0, iteration=0)
+    replaced.add([0.0, 2.1], source="mip_optimum", objective=5.0, iteration=0)
+
+    assert replaced.scheduler_trace()["added_source_counts"] == {"mip_optimum": 1}
+    assert replaced.scheduler_trace()["pending"] == 1
+
+    external = FixedNLPCandidateManager(**kwargs)
+    external.add_external_candidates(
+        [
+            {
+                "point": [0.0, 1.0],
+                "provider": "candidate-provider",
+                "nlp_source": "original",
+            },
+            {"point": [0.0, 2.0]},
+        ],
+        iteration=0,
+        provider="default-provider",
+        nlp_source="active",
+    )
+
+    ready = external.take_ready(iteration=0, elapsed=0.0)
+    assert [(candidate.provider, candidate.nlp_source) for candidate in ready] == [
+        ("candidate-provider", "original"),
+        ("default-provider", "active"),
+    ]
+
+
 def test_fixed_nlp_candidate_manager_scheduling_modes():
     from discopt.solvers.mip_nlp_candidates import FixedNLPCandidateManager
 

--- a/python/tests/test_mip_nlp.py
+++ b/python/tests/test_mip_nlp.py
@@ -2369,6 +2369,208 @@ def test_mip_nlp_shot_solution_pool_strategy_uses_candidate_pool(monkeypatch):
     assert result.mip_nlp_trace["summary"]["solution_pool_candidates"] == 2
 
 
+def test_fixed_nlp_candidate_manager_orders_and_deduplicates_assignments():
+    from discopt.solvers.mip_nlp_candidates import FixedNLPCandidateManager
+
+    manager = FixedNLPCandidateManager(
+        n_vars=3,
+        int_indices=[1],
+        lb=np.array([0.0, 0.0, 0.0]),
+        ub=np.array([10.0, 4.0, 10.0]),
+        strategy="always",
+    )
+
+    manager.add([0.0, 2.0, 0.0], source="solution_pool", objective=20.0, iteration=0)
+    manager.add([0.0, 2.1, 0.0], source="solution_pool", objective=10.0, iteration=0)
+    manager.add([0.0, 0.0, 0.0], source="mip_optimum", objective=5.0, iteration=0)
+    manager.add([0.0, 1.0, 0.0], source="lp_relaxation", objective=3.0, iteration=0)
+    manager.add([0.0, 3.0, 0.0], source="rootsearch", objective=1.0, iteration=0)
+    manager.add_external_candidates(
+        [{"point": [0.0, 4.0, 0.0], "objective": 0.5, "provider": "unit"}],
+        iteration=0,
+    )
+
+    ready = manager.take_ready(iteration=0, elapsed=0.0)
+
+    assert [candidate.source for candidate in ready] == [
+        "mip_optimum",
+        "lp_relaxation",
+        "solution_pool",
+        "rootsearch",
+        "external",
+    ]
+    assert [candidate.integer_assignment for candidate in ready] == [
+        (0.0,),
+        (1.0,),
+        (2.0,),
+        (3.0,),
+        (4.0,),
+    ]
+    assert ready[2].objective == pytest.approx(10.0)
+
+
+def test_fixed_nlp_candidate_manager_scheduling_modes():
+    from discopt.solvers.mip_nlp_candidates import FixedNLPCandidateManager
+
+    kwargs = {
+        "n_vars": 1,
+        "int_indices": [0],
+        "lb": np.array([0.0]),
+        "ub": np.array([5.0]),
+    }
+    by_iteration = FixedNLPCandidateManager(
+        **kwargs,
+        strategy="iteration",
+        iteration_frequency=2,
+    )
+    by_iteration.add([0.0], source="mip_optimum", iteration=0)
+    first = by_iteration.take_ready(iteration=0, elapsed=0.0)
+    assert first
+    by_iteration.record_call_result(
+        first[0],
+        iteration=0,
+        elapsed=0.0,
+        success=False,
+    )
+
+    by_iteration.add([1.0], source="mip_optimum", iteration=1)
+    assert by_iteration.take_ready(iteration=1, elapsed=0.1) == []
+    assert by_iteration.take_ready(iteration=2, elapsed=0.2)
+
+    by_time = FixedNLPCandidateManager(**kwargs, strategy="time", time_frequency=5.0)
+    by_time.add([0.0], source="mip_optimum", iteration=0)
+    first = by_time.take_ready(iteration=0, elapsed=0.0)
+    assert first
+    by_time.record_call_result(first[0], iteration=0, elapsed=0.0, success=False)
+    by_time.add([1.0], source="mip_optimum", iteration=1)
+    assert by_time.take_ready(iteration=1, elapsed=4.9) == []
+    assert by_time.take_ready(iteration=1, elapsed=5.0)
+
+    pool_driven = FixedNLPCandidateManager(**kwargs, strategy="solution_pool")
+    pool_driven.add([0.0], source="mip_optimum", iteration=0)
+    assert pool_driven.take_ready(iteration=0, elapsed=0.0) == []
+    assert pool_driven.take_ready(
+        iteration=0,
+        elapsed=0.0,
+        has_solution_pool_candidate=True,
+    )
+
+
+def test_oa_fixed_nlp_candidate_trace_and_safe_failed_cuts(monkeypatch):
+    import discopt.solvers.oa as oa_module
+    from discopt.solvers import MILPResult, SolveStatus
+
+    m = dm.Model("fixed_nlp_candidate_trace")
+    x = m.continuous("x", lb=0, ub=5)
+    y = m.binary("y", shape=(2,))
+    m.minimize(x + y[0] + y[1])
+
+    warm_starts = []
+    no_good_points = []
+
+    def fake_relaxation(*args, **kwargs):
+        if kwargs.get("return_attempt"):
+            return oa_module._NLPAttempt(x=None, objective=None, multipliers=None)
+        return None, None
+
+    def fake_master(*args, **kwargs):
+        return MILPResult(
+            status=SolveStatus.OPTIMAL,
+            x=np.array([0.0, 0.0, 0.0], dtype=float),
+            objective=0.0,
+            bound=-100.0,
+            solution_pool=[
+                np.array([0.0, 0.0, 0.0], dtype=float),
+                np.array([1.0, 1.0, 0.0], dtype=float),
+                np.array([2.0, 0.0, 1.0], dtype=float),
+                np.array([3.0, 1.0, 0.0], dtype=float),
+            ],
+            solution_pool_objectives=[0.0, 1.0, 2.0, 3.0],
+        )
+
+    def fake_nlp_subproblem(
+        evaluator,
+        lb,
+        ub,
+        int_indices,
+        x_master,
+        nlp_solver,
+        initial_point=None,
+        return_attempt=False,
+    ):
+        del evaluator, lb, ub, int_indices, nlp_solver
+        warm_starts.append(np.asarray(initial_point, dtype=float).copy())
+        key = tuple(np.asarray(x_master, dtype=float)[1:].astype(int).tolist())
+        if key == (0, 0):
+            attempt = oa_module._NLPAttempt(
+                x=np.asarray(x_master, dtype=float).copy(),
+                objective=10.0,
+                multipliers=None,
+                status=SolveStatus.OPTIMAL,
+            )
+        elif key == (1, 0):
+            attempt = oa_module._NLPAttempt(
+                x=None,
+                objective=None,
+                multipliers=None,
+                status=SolveStatus.INFEASIBLE,
+            )
+        else:
+            attempt = oa_module._NLPAttempt(
+                x=None,
+                objective=None,
+                multipliers=None,
+                status=SolveStatus.TIME_LIMIT,
+            )
+        if return_attempt:
+            return attempt
+        return attempt.x, attempt.objective
+
+    def fake_no_good(x_master, *args, **kwargs):
+        del args, kwargs
+        no_good_points.append(np.asarray(x_master, dtype=float).copy())
+        return True
+
+    monkeypatch.setattr(oa_module, "_solve_nlp_relaxation", fake_relaxation)
+    monkeypatch.setattr(oa_module, "_solve_master_milp", fake_master)
+    monkeypatch.setattr(oa_module, "_solve_nlp_subproblem", fake_nlp_subproblem)
+    monkeypatch.setattr(oa_module, "_solve_feasibility_subproblem", lambda *args, **kwargs: None)
+    monkeypatch.setattr(oa_module, "_add_oa_cuts", lambda *args, **kwargs: None)
+    monkeypatch.setattr(oa_module, "_add_no_good_cut", fake_no_good)
+
+    result = oa_module.solve_oa(
+        m,
+        init_strategy="rNLP",
+        max_iterations=1,
+        solution_pool=True,
+        num_solution_iteration=3,
+        milp_solver="gurobi",
+        add_no_good_cuts=True,
+        gap_tolerance=0.0,
+    )
+
+    calls = result.mip_nlp_trace["iterations"][0]["fixed_nlp_calls"]
+    assert [call["source"] for call in calls] == [
+        "mip_optimum",
+        "solution_pool",
+        "solution_pool",
+    ]
+    assert [call["status"] for call in calls] == ["optimal", "infeasible", "time_limit"]
+    assert [call["incumbent_update"] for call in calls] == [
+        "improved",
+        "not_feasible",
+        "not_feasible",
+    ]
+    assert [point.tolist() for point in warm_starts] == [
+        [0.0, 0.0, 0.0],
+        [1.0, 1.0, 0.0],
+        [2.0, 0.0, 1.0],
+    ]
+    assert [point.tolist() for point in no_good_points] == [[1.0, 1.0, 0.0]]
+    assert result.mip_nlp_trace["summary"]["fixed_nlp_call_count"] == 3
+    assert result.mip_nlp_trace["summary"]["solution_pool_candidates"] == 3
+
+
 def test_oa_initial_binary_seed_rounds_and_clamps_discrete_values():
     from discopt.solvers.oa import _build_initial_strategy_point, _decompose_model
 


### PR DESCRIPTION
Closes #146.

## Summary

- Add a fixed-NLP candidate manager for deterministic candidate ordering, integer-assignment deduplication, scheduling, and source/status trace metadata.
- Route OA fixed-integer NLP calls through structured candidates with warm starts from the selected candidate point, while preserving regularized-master starts when available.
- Record per-call fixed-NLP source, status, objective, warm-start source, and incumbent-update outcome; avoid binary no-good cuts for time-limited fixed-NLP attempts.
- Document the SHOT-profile fixed-NLP candidate behavior and add focused coverage for candidate ordering, scheduling, solution-pool deduplication, warm starts, and failed-NLP outcomes.

## Tests

- `env PYTHONPATH=python pytest python/tests/test_mip_nlp.py -q`
- `env PYTHONPATH=python pytest python/tests/test_oa.py -q`
- `env PYTHONPATH=python python -m ruff check python/discopt/solvers/mip_nlp_candidates.py python/discopt/solvers/oa.py python/tests/test_mip_nlp.py`
- `env PYTHONPATH=python python -m ruff format --check python/discopt/solvers/mip_nlp_candidates.py python/discopt/solvers/oa.py python/tests/test_mip_nlp.py`

Notes: pytest emitted JAX persistent-cache warnings because `/home/bernalde/.cache/discopt/jax-cache` is read-only in this environment; tests otherwise passed.

## Branch Hygiene

- Base branch: `feature/mip-nlp-solver`
- Source branch: `fix/issue-146-fixed-nlp-candidates`
- Source branch point: `origin/feature/mip-nlp-solver` at `6fc22fba548cef508311b37ef5dfdfefb0c488bb`
- Stacked status: follows issue #145 / PR #161, already merged into `feature/mip-nlp-solver`
- Upstream sync: `origin/feature/mip-nlp-solver` contains `origin/main` but not the current `upstream/main` tip `62a79ce7e501af0e69ad4e4189cda263886ea436`; left intact because this roadmap targets the integration branch.

Because this PR targets a non-default base, GitHub may not auto-close #146 until `feature/mip-nlp-solver` reaches the default branch.
