### PR TITLE
SHOT port 13: upgrade single-tree callback parity

### DIFF
--- a/docs/mip_nlp.md
+++ b/docs/mip_nlp.md
@@ -206,6 +206,16 @@ status, objective, warm-start source, and whether it improved the incumbent.
 Other backends keep the single incumbent candidate and record the degradation in
 the trace.
 
+`tree_strategy="single_tree"` routes SHOT-profile OA/ECP requests to the
+Gurobi-backed LP/NLP-BB callback solver. In that mode, discopt keeps the MIP
+tree open, separates MIPNODE relaxation cuts where Gurobi exposes an optimal
+node relaxation, and runs fixed-NLP incumbent handling from MIPSOL callbacks.
+Callback-generated OA/ECP/feasibility/integer rows enter the same MIP-NLP cut
+provenance ledger as MultiTree runs, and the result trace records callback
+events, source counts, node counts, and whether an incumbent MIP start was
+applied. Non-Gurobi MILP backends are explicitly MultiTree-only for this profile
+until they expose equivalent persistent callback support.
+
 The remaining reformulation and convex-bounding controls are validated and
 traced under the SHOT profile so follow-up SHOT parity PRs can attach behavior
 without changing the public option names.

--- a/python/discopt/solvers/__init__.py
+++ b/python/discopt/solvers/__init__.py
@@ -87,6 +87,7 @@ class MILPResult:
     wall_time: float = 0.0
     solution_pool: Optional[list[np.ndarray]] = None
     solution_pool_objectives: Optional[list[float]] = None
+    callback_stats: Optional[dict[str, object]] = None
 
 
 @dataclass

--- a/python/discopt/solvers/gurobi.py
+++ b/python/discopt/solvers/gurobi.py
@@ -536,19 +536,30 @@ def solve_milp_with_lazy_cuts(
     threads: Optional[int] = None,
     options: Optional[dict] = None,
     lazy_callback: Optional[Callable[[np.ndarray], object]] = None,
+    node_callback: Optional[Callable[[np.ndarray], object]] = None,
+    terminate_callback: Optional[Callable[[dict[str, object]], bool]] = None,
+    mip_start: Optional[np.ndarray] = None,
 ) -> MILPResult:
-    """Solve a MILP using Gurobi lazy constraints.
+    """Solve a MILP using Gurobi lazy constraints and optional node cuts.
 
     ``lazy_callback`` is called at integer incumbents with the current solution
     vector. It should return an iterable of ``(coefficients, rhs)`` rows in
     ``coefficients @ x <= rhs`` form. The callback may return ``None`` or an
     empty iterable when no lazy rows are violated.
+
+    ``node_callback`` is called at MIPNODE relaxation points when Gurobi exposes
+    an optimal node relaxation. Returned rows are added as user cuts with
+    ``cbCut``. ``terminate_callback`` receives a mutable callback-stat snapshot
+    and may request early model termination.
     """
     c_arr, _n = _validate_linear_data(c, A_ub, b_ub, A_eq, b_eq, bounds)
     gp, GRB = _load_gurobi()
 
     merged_options = dict(options or {})
-    merged_options["LazyConstraints"] = 1
+    if lazy_callback is not None:
+        merged_options["LazyConstraints"] = 1
+    if node_callback is not None:
+        merged_options.setdefault("PreCrush", 1)
 
     env, model, x, _ub_con, _eq_con = _build_model(
         gp,
@@ -566,24 +577,100 @@ def solve_milp_with_lazy_cuts(
         threads=threads,
         options=merged_options,
     )
+    callback_stats: dict[str, object] = {
+        "mipsol_calls": 0,
+        "mipnode_calls": 0,
+        "lazy_cuts": 0,
+        "node_cuts": 0,
+        "terminated": False,
+        "terminate_context": None,
+    }
+
+    def _validate_callback_cut(coeffs, rhs) -> np.ndarray:
+        row = np.asarray(coeffs, dtype=np.float64).ravel()
+        if row.shape[0] != len(c_arr):
+            raise ValueError(
+                f"callback cut has {row.shape[0]} coefficients but model has {len(c_arr)} variables"
+            )
+        return row
+
+    def _maybe_terminate(grb_model, context: str) -> bool:
+        if terminate_callback is None:
+            return False
+        snapshot = dict(callback_stats)
+        snapshot["context"] = context
+        if not bool(terminate_callback(snapshot)):
+            return False
+        callback_stats["terminated"] = True
+        callback_stats["terminate_context"] = context
+        terminate = getattr(grb_model, "terminate", None)
+        if terminate is not None:
+            terminate()
+        return True
+
+    def _mipnode_relaxation_is_available(grb_model) -> bool:
+        status_attr = getattr(GRB.Callback, "MIPNODE_STATUS", None)
+        if status_attr is None:
+            return True
+        cb_get = getattr(grb_model, "cbGet", None)
+        if cb_get is None:
+            return False
+        try:
+            return int(cb_get(status_attr)) == int(GRB.OPTIMAL)
+        except Exception:
+            return False
 
     def _callback(grb_model, where):
-        if lazy_callback is None or where != GRB.Callback.MIPSOL:
+        if _maybe_terminate(grb_model, "callback"):
             return
-        incumbent = np.asarray(grb_model.cbGetSolution(x), dtype=np.float64).ravel()
-        cuts = lazy_callback(incumbent)
-        if cuts is None:
+        if lazy_callback is not None and where == GRB.Callback.MIPSOL:
+            callback_stats["mipsol_calls"] = int(callback_stats["mipsol_calls"]) + 1
+            incumbent = np.asarray(grb_model.cbGetSolution(x), dtype=np.float64).ravel()
+            cuts = lazy_callback(incumbent)
+            if cuts is None:
+                return
+            for coeffs, rhs in cuts:
+                row = _validate_callback_cut(coeffs, rhs)
+                grb_model.cbLazy(row @ x <= float(rhs))
+                callback_stats["lazy_cuts"] = int(callback_stats["lazy_cuts"]) + 1
             return
-        for coeffs, rhs in cuts:
-            row = np.asarray(coeffs, dtype=np.float64).ravel()
-            if row.shape[0] != len(c_arr):
-                raise ValueError(
-                    f"lazy cut has {row.shape[0]} coefficients but model has {len(c_arr)} variables"
-                )
-            grb_model.cbLazy(row @ x <= float(rhs))
+
+        mipnode_where = getattr(GRB.Callback, "MIPNODE", None)
+        if node_callback is not None and mipnode_where is not None and where == mipnode_where:
+            callback_stats["mipnode_calls"] = int(callback_stats["mipnode_calls"]) + 1
+            if not _mipnode_relaxation_is_available(grb_model):
+                return
+            cb_get_node_rel = getattr(grb_model, "cbGetNodeRel", None)
+            cb_cut = getattr(grb_model, "cbCut", None)
+            if cb_get_node_rel is None or cb_cut is None:
+                return
+            relaxation = np.asarray(cb_get_node_rel(x), dtype=np.float64).ravel()
+            cuts = node_callback(relaxation)
+            if cuts is None:
+                return
+            for coeffs, rhs in cuts:
+                row = _validate_callback_cut(coeffs, rhs)
+                cb_cut(row @ x <= float(rhs))
+                callback_stats["node_cuts"] = int(callback_stats["node_cuts"]) + 1
 
     try:
-        status_code = _optimize(model, GRB, _callback if lazy_callback is not None else None)
+        if mip_start is not None:
+            start = np.asarray(mip_start, dtype=np.float64).ravel()
+            if start.shape[0] != c_arr.shape[0]:
+                raise ValueError(
+                    f"mip_start has {start.shape[0]} entries but c has {c_arr.shape[0]}"
+                )
+            x.Start = start
+        active_callback = (
+            _callback
+            if (
+                lazy_callback is not None
+                or node_callback is not None
+                or terminate_callback is not None
+            )
+            else None
+        )
+        status_code = _optimize(model, GRB, active_callback)
         status = _status_map(GRB).get(status_code, SolveStatus.ERROR)
         node_count = int(_safe_attr(model, "NodeCount") or 0)
         wall_time = float(_safe_attr(model, "Runtime") or 0.0)
@@ -609,6 +696,7 @@ def solve_milp_with_lazy_cuts(
                 gap=0.0,
                 node_count=node_count,
                 wall_time=wall_time,
+                callback_stats=callback_stats,
             )
 
         return MILPResult(
@@ -619,6 +707,7 @@ def solve_milp_with_lazy_cuts(
             gap=gap,
             node_count=node_count,
             wall_time=wall_time,
+            callback_stats=callback_stats,
         )
     finally:
         model.dispose()

--- a/python/discopt/solvers/mip_nlp.py
+++ b/python/discopt/solvers/mip_nlp.py
@@ -167,6 +167,57 @@ def solve_mip_nlp(
                 + ", ".join(sorted(supported_keys))
             )
 
+        if (
+            profile == "shot"
+            and shot_config is not None
+            and shot_config.tree_strategy == "single_tree"
+            and method in {"oa", "ecp"}
+        ):
+            milp_solver = str(options.get("milp_solver", "gurobi")).strip().lower()
+            if milp_solver != "gurobi":
+                raise RuntimeError(
+                    "SHOT tree_strategy='single_tree' requires milp_solver='gurobi' "
+                    "because the current single-tree implementation depends on "
+                    "Gurobi MIPSOL/MIPNODE callbacks. Use tree_strategy='multi_tree' "
+                    "for non-Gurobi MILP backends."
+                )
+            unsupported_single_tree = sorted(set(options) - _LP_NLP_BB_OPTION_KEYS)
+            if unsupported_single_tree:
+                raise ValueError(
+                    "SHOT tree_strategy='single_tree' routes to the LP/NLP-BB "
+                    "callback solver and does not support option(s): "
+                    + ", ".join(unsupported_single_tree)
+                    + ". Supported single-tree options are: "
+                    + ", ".join(sorted(_LP_NLP_BB_OPTION_KEYS))
+                )
+            from discopt.solvers.oa import _normalize_init_strategy, solve_lp_nlp_bb
+
+            options["milp_solver"] = "gurobi"
+            options["init_strategy"] = _normalize_init_strategy(
+                options.get("init_strategy", "rNLP")
+            )
+            options.setdefault("add_no_good_cuts", True)
+            if shot_config.integer_bilinear_strategy == "binary_expansion":
+                options.setdefault("integer_to_binary", True)
+            result = solve_lp_nlp_bb(
+                model,
+                time_limit=time_limit,
+                gap_tolerance=gap_tolerance,
+                max_iterations=max_iterations,
+                nlp_solver=nlp_solver,
+                initial_point=initial_point,
+                mip_nlp_profile=profile,
+                mip_nlp_shot_config=shot_config,
+                **options,
+            )
+            ensure_mip_nlp_trace(
+                result,
+                method="lp_nlp_bb",
+                profile=profile,
+                shot_config=shot_config,
+            )
+            return result
+
         if method == "fp":
             from discopt.solvers.oa import _normalize_init_strategy, solve_feasibility_pump
 
@@ -233,6 +284,10 @@ def solve_mip_nlp(
             options["init_strategy"] = _normalize_init_strategy(
                 options.get("init_strategy", "rNLP")
             )
+            if profile == "shot" and shot_config is not None:
+                options.setdefault("add_no_good_cuts", True)
+                if shot_config.integer_bilinear_strategy == "binary_expansion":
+                    options.setdefault("integer_to_binary", True)
             result = solve_lp_nlp_bb(
                 model,
                 time_limit=time_limit,
@@ -240,6 +295,8 @@ def solve_mip_nlp(
                 max_iterations=max_iterations,
                 nlp_solver=nlp_solver,
                 initial_point=initial_point,
+                mip_nlp_profile=profile,
+                mip_nlp_shot_config=shot_config,
                 **options,
             )
             ensure_mip_nlp_trace(

--- a/python/discopt/solvers/oa.py
+++ b/python/discopt/solvers/oa.py
@@ -3527,6 +3527,8 @@ def solve_lp_nlp_bb(
     feasibility_norm: str = "L_infinity",
     milp_solver: str = "gurobi",
     integer_to_binary: bool = False,
+    mip_nlp_profile: str = "default",
+    mip_nlp_shot_config: Optional[MIPNLPShotConfig] = None,
     **kwargs,
 ) -> SolveResult:
     """Solve a convex MINLP with the LP/NLP branch-and-bound variant.
@@ -3546,7 +3548,8 @@ def solve_lp_nlp_bb(
             + ". Supported options are: add_no_good_cuts, add_slack, equality_relaxation, "
             "feasibility_cuts, feasibility_norm, heuristic_nonconvex, init_strategy, "
             "integer_to_binary, "
-            "max_slack, milp_solver, oa_penalty_factor."
+            "max_slack, milp_solver, mip_nlp_profile, mip_nlp_shot_config, "
+            "oa_penalty_factor."
         )
     _require_lp_nlp_bb_gurobi_backend(milp_solver)
     t_start = time.perf_counter()
@@ -3596,6 +3599,89 @@ def solve_lp_nlp_bb(
             "disabling certified bound/gap reporting and skipping objective OA cuts"
         )
     master_bound_valid = decomp.master_bound_valid and not heuristic_nonconvex
+    shot_config = mip_nlp_shot_config if mip_nlp_profile == "shot" else None
+    shot_profile = shot_config is not None
+    shot_cut_strategy = shot_config.cut_strategy if shot_config is not None else "oa"
+    cut_provenance = MIPNLPCutProvenance()
+    callback_events: list[dict[str, object]] = []
+
+    if shot_profile:
+        from discopt.solvers.mip_nlp_rootsearch import MIPNLPInteriorPointStore
+
+        interior_point_store = MIPNLPInteriorPointStore(
+            n_vars,
+            int_indices=decomp.int_indices,
+            lb=decomp.lb,
+            ub=decomp.ub,
+        )
+    else:
+        interior_point_store = None
+
+    def _trace_value(value: Optional[float]) -> Optional[float]:
+        if value is None:
+            return None
+        out = float(value)
+        if not np.isfinite(out) or abs(out) >= 1e19:
+            return None
+        return out
+
+    def _trace_status(status) -> str:
+        name = getattr(status, "name", None)
+        if isinstance(name, str):
+            return name.lower()
+        return str(status).lower()
+
+    def _linear_objective_offset() -> float:
+        if decomp.obj_is_linear and decomp.obj_coeffs is not None:
+            return float(decomp.obj_coeffs[1])
+        return 0.0
+
+    def _master_objective_from_evaluator(value: Optional[float]) -> Optional[float]:
+        if value is None:
+            return None
+        return float(value) - _linear_objective_offset()
+
+    def _record_interior_point(
+        point,
+        source: str,
+        metadata: Optional[dict[str, object]] = None,
+        *,
+        require_feasible: bool = False,
+    ) -> None:
+        if interior_point_store is None:
+            return
+        interior_point_store.add(
+            point,
+            source=source,
+            metadata=metadata,
+            evaluator=evaluator,
+            constraint_senses=decomp.constraint_senses,
+            require_feasible=require_feasible,
+        )
+
+    def _record_callback_event(
+        *,
+        context: str,
+        cuts_start: int,
+        provenance_start: int,
+        cuts_returned: int,
+        fixed_nlp_status: Optional[str] = None,
+        rootsearch_trace: Optional[dict[str, object]] = None,
+        integer_cut_added: bool = False,
+    ) -> None:
+        event: dict[str, object] = {
+            "context": context,
+            "cuts_generated": int(len(oa_A_rows) - cuts_start),
+            "cuts_returned": int(cuts_returned),
+            "provenance_cuts_added": int(len(cut_provenance.records) - provenance_start),
+            "provenance_cuts_total": int(len(cut_provenance.records)),
+            "fixed_nlp_status": fixed_nlp_status,
+            "integer_cut_added": bool(integer_cut_added),
+            "cut_source_counts": cut_provenance.source_counts(),
+        }
+        if rootsearch_trace is not None:
+            event["rootsearch"] = rootsearch_trace
+        callback_events.append(event)
 
     if len(decomp.int_indices) == 0:
         x_sol, obj = _solve_nlp_relaxation(
@@ -3638,6 +3724,12 @@ def solve_lp_nlp_bb(
         if incumbent_obj is None or obj < incumbent_obj:
             incumbent = np.asarray(x, dtype=np.float64).copy()
             incumbent_obj = float(obj)
+            _record_interior_point(
+                incumbent,
+                "callback_incumbent",
+                {"objective": float(obj)},
+                require_feasible=True,
+            )
 
     def add_oa_cuts_at(x_cut: np.ndarray) -> None:
         _add_oa_cuts(
@@ -3653,6 +3745,7 @@ def solve_lp_nlp_bb(
             decomp.oa_objective_is_convex,
             equality_relaxation=equality_relaxation,
             oa_cut_relaxable=oa_cut_relaxable,
+            cut_provenance=cut_provenance,
         )
 
     if init_strategy == "rNLP":
@@ -3664,6 +3757,13 @@ def solve_lp_nlp_bb(
             initial_point=initial_point,
         )
         if x_relax is not None:
+            if obj_relax is not None:
+                _record_interior_point(
+                    x_relax,
+                    "nlp_relaxation",
+                    {"objective": float(obj_relax)},
+                    require_feasible=True,
+                )
             add_oa_cuts_at(x_relax)
             if _is_integer_feasible(decomp, x_relax) and obj_relax is not None:
                 accept_incumbent(x_relax, obj_relax)
@@ -3708,6 +3808,12 @@ def solve_lp_nlp_bb(
         )
         add_oa_cuts_at(x_init if x_init is not None else x_seed)
         if x_init is not None and obj_init is not None:
+            _record_interior_point(
+                x_init,
+                "initial_fixed_nlp",
+                {"objective": float(obj_init)},
+                require_feasible=True,
+            )
             accept_incumbent(x_init, obj_init)
 
     elapsed = time.perf_counter() - t_start
@@ -3751,8 +3857,39 @@ def solve_lp_nlp_bb(
     def lazy_callback(master_x: np.ndarray) -> list[tuple[np.ndarray, float]]:
         nonlocal nlp_subproblem_count
         x_master = np.asarray(master_x[:n_vars], dtype=np.float64)
+        cuts_start = len(oa_A_rows)
+        provenance_start = len(cut_provenance.records)
         start = len(oa_A_rows)
+        rootsearch_trace = None
+        if (
+            shot_profile
+            and shot_cut_strategy in {"auto", "esh"}
+            and interior_point_store is not None
+        ):
+            assert shot_config is not None
+            _esh_added, rootsearch_trace = _add_esh_cuts(
+                evaluator,
+                x_master,
+                n_vars,
+                decomp.constraint_senses,
+                oa_A_rows,
+                oa_b_rows,
+                decomp.obj_is_linear,
+                decomp.oa_constraint_mask,
+                decomp.oa_objective_is_convex,
+                interior_point_store,
+                rootsearch_strategy=shot_config.rootsearch_strategy,
+                equality_relaxation=equality_relaxation,
+                oa_cut_relaxable=oa_cut_relaxable,
+                cut_provenance=cut_provenance,
+                incumbent=incumbent,
+                incumbent_obj=incumbent_obj,
+                hyperplane_max_per_iter=shot_config.hyperplane_max_per_iter,
+                hyperplane_selection_factor=shot_config.hyperplane_selection_factor,
+            )
         nlp_subproblem_count += 1
+        fixed_nlp_status = "failed"
+        integer_cut_added = False
         x_nlp, obj_nlp = _solve_nlp_subproblem(
             evaluator,
             decomp.lb,
@@ -3763,8 +3900,15 @@ def solve_lp_nlp_bb(
             initial_point=x_master,
         )
         if x_nlp is not None:
+            fixed_nlp_status = "feasible"
             if obj_nlp is not None:
                 accept_incumbent(x_nlp, obj_nlp)
+                _record_interior_point(
+                    x_nlp,
+                    "callback_fixed_nlp",
+                    {"objective": float(obj_nlp)},
+                    require_feasible=True,
+                )
             add_oa_cuts_at(x_nlp)
         else:
             if feasibility_cuts:
@@ -3787,11 +3931,12 @@ def solve_lp_nlp_bb(
                         oa_b_rows,
                         decomp.oa_constraint_mask,
                         oa_cut_relaxable=oa_cut_relaxable,
+                        cut_provenance=cut_provenance,
                     )
             if add_no_good_cuts and (
                 not decomp.general_integer_indices or integer_binary_expansion is not None
             ):
-                _add_no_good_cut(
+                integer_cut_added = _add_no_good_cut(
                     x_master,
                     decomp.binary_indices,
                     oa_A_rows,
@@ -3799,13 +3944,65 @@ def solve_lp_nlp_bb(
                     n_vars,
                     oa_cut_relaxable=oa_cut_relaxable,
                     integer_binary_expansion=integer_binary_expansion,
+                    cut_provenance=cut_provenance,
                 )
             add_oa_cuts_at(x_master)
 
-        return collect_new_lazy_cuts(start, np.asarray(master_x, dtype=np.float64))
+        rows = collect_new_lazy_cuts(start, np.asarray(master_x, dtype=np.float64))
+        _record_callback_event(
+            context="mipsol",
+            cuts_start=cuts_start,
+            provenance_start=provenance_start,
+            cuts_returned=len(rows),
+            fixed_nlp_status=fixed_nlp_status,
+            rootsearch_trace=rootsearch_trace,
+            integer_cut_added=integer_cut_added,
+        )
+        return rows
+
+    def node_callback(master_x: np.ndarray) -> list[tuple[np.ndarray, float]]:
+        full_master_x = np.asarray(master_x, dtype=np.float64)
+        x_master = full_master_x[:n_vars]
+        cuts_start = len(oa_A_rows)
+        provenance_start = len(cut_provenance.records)
+        start = len(oa_A_rows)
+        _add_ecp_cuts(
+            evaluator,
+            x_master,
+            n_vars,
+            decomp.constraint_senses,
+            oa_A_rows,
+            oa_b_rows,
+            decomp.obj_is_linear,
+            decomp.oa_constraint_mask,
+            decomp.oa_objective_is_convex,
+            equality_relaxation=equality_relaxation,
+            oa_cut_relaxable=oa_cut_relaxable,
+            cut_provenance=cut_provenance,
+        )
+        rows = collect_new_lazy_cuts(start, full_master_x)
+        _record_callback_event(
+            context="mipnode",
+            cuts_start=cuts_start,
+            provenance_start=provenance_start,
+            cuts_returned=len(rows),
+        )
+        return rows
 
     from discopt.solvers import SolveStatus
     from discopt.solvers.gurobi import solve_milp_with_lazy_cuts
+
+    master_mip_start = None
+    if shot_profile and incumbent is not None:
+        master_mip_start = _extend_master_mip_start(
+            master,
+            n_vars=n_vars,
+            mip_start=incumbent,
+            mip_start_objective=_master_objective_from_evaluator(incumbent_obj),
+        )
+
+    def callback_terminate(_snapshot: dict[str, object]) -> bool:
+        return (time.perf_counter() - t_start) >= float(time_limit)
 
     master_result = solve_milp_with_lazy_cuts(
         c=master.c,
@@ -3818,6 +4015,9 @@ def solve_lp_nlp_bb(
         time_limit=remaining,
         gap_tolerance=gap_tolerance,
         lazy_callback=lazy_callback,
+        node_callback=node_callback if shot_profile else None,
+        terminate_callback=callback_terminate,
+        mip_start=master_mip_start,
     )
     wall_time = time.perf_counter() - t_start
 
@@ -3843,6 +4043,55 @@ def solve_lp_nlp_bb(
     elif incumbent is None:
         status = "no_feasible_point"
 
+    callback_stats = dict(master_result.callback_stats or {})
+    trace_bound_validity = (
+        "global"
+        if master_bound_valid and bound is not None
+        else ("heuristic" if bound is not None else "unavailable")
+    )
+    single_tree_trace: dict[str, object] = {
+        "schema_version": 1,
+        "solver": "mip-nlp",
+        "method": "lp_nlp_bb",
+        "profile": mip_nlp_profile,
+        "shot_options": (
+            mip_nlp_shot_config.as_trace_dict() if mip_nlp_shot_config is not None else {}
+        ),
+        "iterations": [
+            {
+                "index": 0,
+                "master_status": _trace_status(master_result.status),
+                "lb": _trace_value(bound),
+                "ub": _trace_value(incumbent_obj),
+                "gap": _trace_value(gap),
+                "cuts_total": int(len(oa_A_rows)),
+                "provenance_cuts_total": int(len(cut_provenance.records)),
+                "cut_source_counts": cut_provenance.source_counts(),
+                "callback_events": callback_events,
+                "callback_stats": callback_stats,
+                "node_count": int(master_result.node_count),
+                "mip_start_applied": bool(master_mip_start is not None),
+            }
+        ],
+        "summary": {
+            "mip_count": 1,
+            "nlp_subproblem_count": int(nlp_subproblem_count),
+            "cut_count": int(len(oa_A_rows)),
+            "provenance_cut_count": int(len(cut_provenance.records)),
+            "cut_source_counts": cut_provenance.source_counts(),
+            "callback_event_count": int(len(callback_events)),
+            "callback_stats": callback_stats,
+            "node_count": int(master_result.node_count),
+        },
+        "termination_reason": status,
+        "master_bound_valid": bool(master_bound_valid),
+        "gap_certified": bool(master_bound_valid),
+        "bound_validity": trace_bound_validity,
+        "final_lb": _trace_value(bound),
+        "final_ub": _trace_value(incumbent_obj),
+        "final_gap": _trace_value(gap),
+    }
+
     if incumbent is not None and incumbent_obj is not None:
         return SolveResult(
             status=status,
@@ -3855,6 +4104,7 @@ def solve_lp_nlp_bb(
             mip_count=1,
             subnlp_calls=nlp_subproblem_count,
             gap_certified=master_bound_valid,
+            mip_nlp_trace=single_tree_trace,
         )
 
     return SolveResult(
@@ -3868,6 +4118,7 @@ def solve_lp_nlp_bb(
         mip_count=1,
         subnlp_calls=nlp_subproblem_count,
         gap_certified=master_bound_valid,
+        mip_nlp_trace=single_tree_trace,
     )
 
 

--- a/python/discopt/solvers/oa.py
+++ b/python/discopt/solvers/oa.py
@@ -4031,8 +4031,14 @@ def solve_lp_nlp_bb(
         if bound is not None and incumbent_obj is not None
         else None
     )
+    callback_stats = dict(master_result.callback_stats or {})
+    callback_terminated = bool(callback_stats.get("terminated"))
     status = "feasible"
-    if master_result.status == SolveStatus.INFEASIBLE:
+    termination_reason: Optional[str] = None
+    if callback_terminated:
+        termination_reason = "time_limit"
+        status = "time_limit" if incumbent is None else "feasible"
+    elif master_result.status == SolveStatus.INFEASIBLE:
         status = "infeasible"
     elif master_result.status == SolveStatus.TIME_LIMIT:
         status = "time_limit" if incumbent is None else "feasible"
@@ -4042,8 +4048,9 @@ def solve_lp_nlp_bb(
         status = "optimal" if gap is not None and gap <= gap_tolerance else "feasible"
     elif incumbent is None:
         status = "no_feasible_point"
+    if termination_reason is None:
+        termination_reason = status
 
-    callback_stats = dict(master_result.callback_stats or {})
     trace_bound_validity = (
         "global"
         if master_bound_valid and bound is not None
@@ -4083,7 +4090,7 @@ def solve_lp_nlp_bb(
             "callback_stats": callback_stats,
             "node_count": int(master_result.node_count),
         },
-        "termination_reason": status,
+        "termination_reason": termination_reason,
         "master_bound_valid": bool(master_bound_valid),
         "gap_certified": bool(master_bound_valid),
         "bound_validity": trace_bound_validity,

--- a/python/tests/test_gurobi_backend.py
+++ b/python/tests/test_gurobi_backend.py
@@ -351,9 +351,11 @@ def test_gurobi_milp_solution_pool_sets_params_and_returns_candidates(monkeypatc
     assert [candidate.tolist() for candidate in result.solution_pool] == [[0.0], [0.5], [1.0]]
 
 
-def test_gurobi_milp_lazy_callback_adds_lazy_cut(monkeypatch):
+def test_gurobi_milp_callbacks_add_lazy_and_node_cuts(monkeypatch):
     class FakeCallback:
         MIPSOL = 1
+        MIPNODE = 2
+        MIPNODE_STATUS = 3
 
     class FakeGRB:
         CONTINUOUS = "C"
@@ -402,6 +404,7 @@ def test_gurobi_milp_lazy_callback_adds_lazy_cut(monkeypatch):
         def __init__(self, *_args, **_kwargs):
             self.params = {}
             self.lazy_constraints = []
+            self.node_cuts = []
             FakeModel.last = self
 
         def setParam(self, key, value):
@@ -416,11 +419,22 @@ def test_gurobi_milp_lazy_callback_adds_lazy_cut(monkeypatch):
         def cbGetSolution(self, _x):
             return np.array([0.0])
 
+        def cbGet(self, attr):
+            assert attr == FakeGRB.Callback.MIPNODE_STATUS
+            return FakeGRB.OPTIMAL
+
+        def cbGetNodeRel(self, _x):
+            return np.array([0.25])
+
         def cbLazy(self, expr):
             self.lazy_constraints.append(expr)
 
+        def cbCut(self, expr):
+            self.node_cuts.append(expr)
+
         def optimize(self, callback=None):
             if callback is not None:
+                callback(self, FakeGRB.Callback.MIPNODE)
                 callback(self, FakeGRB.Callback.MIPSOL)
 
         def dispose(self):
@@ -435,17 +449,31 @@ def test_gurobi_milp_lazy_callback_adds_lazy_cut(monkeypatch):
         callback_candidates.append(candidate)
         return [(np.array([1.0]), -0.5)]
 
+    node_candidates = []
+
+    def node_callback(candidate):
+        node_candidates.append(candidate)
+        return [(np.array([1.0]), 0.0)]
+
     result = gurobi_backend.solve_milp_with_lazy_cuts(
         c=np.array([1.0]),
         bounds=[(0.0, 1.0)],
         integrality=np.array([1], dtype=np.int32),
         lazy_callback=lazy_callback,
+        node_callback=node_callback,
     )
 
     assert result.status == SolveStatus.OPTIMAL
     assert callback_candidates
+    assert node_candidates
     assert FakeModel.last.params["LazyConstraints"] == 1
+    assert FakeModel.last.params["PreCrush"] == 1
     assert len(FakeModel.last.lazy_constraints) == 1
+    assert len(FakeModel.last.node_cuts) == 1
+    assert result.callback_stats["mipsol_calls"] == 1
+    assert result.callback_stats["mipnode_calls"] == 1
+    assert result.callback_stats["lazy_cuts"] == 1
+    assert result.callback_stats["node_cuts"] == 1
 
 
 def test_amp_bound_tolerance_closes_small_master_bound_inversion():

--- a/python/tests/test_mip_nlp.py
+++ b/python/tests/test_mip_nlp.py
@@ -1930,7 +1930,7 @@ def test_mip_nlp_shot_profile_options_validate_and_attach_trace(monkeypatch):
         method="oa",
         mip_nlp_options={
             "mip_nlp_profile": "shot",
-            "tree_strategy": "single-tree",
+            "tree_strategy": "multi-tree",
             "cut_strategy": "esh",
             "objective_epigraph": "on",
             "anti_epigraph": "off",
@@ -1958,7 +1958,7 @@ def test_mip_nlp_shot_profile_options_validate_and_attach_trace(monkeypatch):
 
     cfg = calls["mip_nlp_shot_config"]
     assert calls["mip_nlp_profile"] == "shot"
-    assert cfg.tree_strategy == "single_tree"
+    assert cfg.tree_strategy == "multi_tree"
     assert cfg.cut_strategy == "esh"
     assert cfg.objective_epigraph == "on"
     assert cfg.anti_epigraph == "off"
@@ -1986,6 +1986,50 @@ def test_mip_nlp_shot_profile_options_validate_and_attach_trace(monkeypatch):
     assert result.mip_nlp_trace["profile"] == "shot"
     assert result.mip_nlp_trace["shot_options"]["cut_strategy"] == "esh"
     assert result.mip_nlp_trace["shot_options"]["integer_bilinear_strategy"] == ("binary_expansion")
+
+
+def test_mip_nlp_shot_single_tree_routes_to_callback_solver(monkeypatch):
+    import discopt.solvers.oa as oa_module
+    from discopt.solvers.mip_nlp import solve_mip_nlp
+
+    calls = {}
+
+    def fake_solve_lp_nlp_bb(model, **kwargs):
+        calls.update(kwargs)
+        return SolveResult(status="optimal", objective=0.0, bound=0.0, gap=0.0)
+
+    monkeypatch.setattr(oa_module, "solve_lp_nlp_bb", fake_solve_lp_nlp_bb)
+
+    result = solve_mip_nlp(
+        _binary_model("shot_single_tree_route"),
+        method="oa",
+        mip_nlp_options={
+            "mip_nlp_profile": "shot",
+            "tree_strategy": "single_tree",
+        },
+    )
+
+    assert result.status == "optimal"
+    assert calls["milp_solver"] == "gurobi"
+    assert calls["mip_nlp_profile"] == "shot"
+    assert calls["mip_nlp_shot_config"].tree_strategy == "single_tree"
+    assert calls["add_no_good_cuts"] is True
+    assert result.mip_nlp_trace["method"] == "lp_nlp_bb"
+
+
+def test_mip_nlp_shot_single_tree_rejects_non_gurobi_backend():
+    from discopt.solvers.mip_nlp import solve_mip_nlp
+
+    with pytest.raises(RuntimeError, match="tree_strategy='single_tree'.*milp_solver='gurobi'"):
+        solve_mip_nlp(
+            _binary_model("shot_single_tree_highs"),
+            method="oa",
+            mip_nlp_options={
+                "mip_nlp_profile": "shot",
+                "tree_strategy": "single_tree",
+                "milp_solver": "highs",
+            },
+        )
 
 
 @pytest.mark.parametrize(
@@ -2349,6 +2393,7 @@ def test_lp_nlp_bb_lazy_callback_solves_fixed_integer_nlp(monkeypatch):
         _objective_is_convex,
         equality_relaxation=False,
         oa_cut_relaxable=None,
+        cut_provenance=None,
     ):
         calls["oa"] += 1
         assert constraint_convex_mask is None or all(
@@ -2394,6 +2439,137 @@ def test_lp_nlp_bb_lazy_callback_solves_fixed_integer_nlp(monkeypatch):
     assert calls["lazy"] == 1
     assert calls["subproblem"] == 1
     assert calls["oa"] >= 2
+
+
+def test_lp_nlp_bb_shot_callback_trace_records_node_and_incumbent_cuts(monkeypatch):
+    import discopt.solvers.gurobi as gurobi_module
+    import discopt.solvers.oa as oa_module
+    from discopt.solvers import MILPResult, SolveStatus
+    from discopt.solvers.mip_nlp import solve_mip_nlp
+
+    calls = {"lazy": 0, "node": 0, "subproblem": 0}
+
+    def fake_relaxation(*_args, **_kwargs):
+        return None, None
+
+    def fake_subproblem(
+        _evaluator,
+        _lb,
+        _ub,
+        _int_indices,
+        x_master,
+        _nlp_solver,
+        initial_point=None,
+        return_attempt=False,
+    ):
+        assert initial_point is not None
+        calls["subproblem"] += 1
+        return np.asarray(x_master, dtype=np.float64), 0.0
+
+    def fake_add_oa_cuts(
+        _evaluator,
+        _x_star,
+        n_vars,
+        _n_cons,
+        _constraint_senses,
+        oa_A_rows,
+        oa_b_rows,
+        *_args,
+        oa_cut_relaxable=None,
+        cut_provenance=None,
+        **_kwargs,
+    ):
+        row = np.zeros(n_vars, dtype=np.float64)
+        row[0] = 1.0
+        oa_module._append_master_cut(
+            oa_A_rows,
+            oa_b_rows,
+            row,
+            -0.5,
+            oa_cut_relaxable,
+            cut_provenance=cut_provenance,
+            source="oa",
+            global_valid=True,
+            supporting_point=np.zeros(n_vars, dtype=np.float64),
+        )
+
+    def fake_add_ecp_cuts(
+        _evaluator,
+        _x_master,
+        n_vars,
+        _constraint_senses,
+        oa_A_rows,
+        oa_b_rows,
+        *_args,
+        oa_cut_relaxable=None,
+        cut_provenance=None,
+        **_kwargs,
+    ):
+        row = np.zeros(n_vars, dtype=np.float64)
+        row[0] = 1.0
+        oa_module._append_master_cut(
+            oa_A_rows,
+            oa_b_rows,
+            row,
+            -0.25,
+            oa_cut_relaxable,
+            cut_provenance=cut_provenance,
+            source="ecp",
+            global_valid=True,
+            supporting_point=np.zeros(n_vars, dtype=np.float64),
+        )
+        return 1
+
+    def fake_lazy_milp(**kwargs):
+        candidate = np.zeros_like(kwargs["c"], dtype=np.float64)
+        node_cuts = kwargs["node_callback"](candidate)
+        calls["node"] += 1
+        lazy_cuts = kwargs["lazy_callback"](candidate)
+        calls["lazy"] += 1
+        assert node_cuts
+        assert lazy_cuts
+        return MILPResult(
+            status=SolveStatus.OPTIMAL,
+            x=candidate,
+            objective=0.0,
+            bound=0.0,
+            gap=0.0,
+            node_count=2,
+            callback_stats={
+                "mipsol_calls": 1,
+                "mipnode_calls": 1,
+                "lazy_cuts": len(lazy_cuts),
+                "node_cuts": len(node_cuts),
+            },
+        )
+
+    monkeypatch.setattr(oa_module, "_solve_nlp_relaxation", fake_relaxation)
+    monkeypatch.setattr(oa_module, "_solve_nlp_subproblem", fake_subproblem)
+    monkeypatch.setattr(oa_module, "_add_oa_cuts", fake_add_oa_cuts)
+    monkeypatch.setattr(oa_module, "_add_ecp_cuts", fake_add_ecp_cuts)
+    monkeypatch.setattr(gurobi_module, "solve_milp_with_lazy_cuts", fake_lazy_milp)
+
+    result = solve_mip_nlp(
+        _binary_model("lp_nlp_bb_shot_callback_trace"),
+        method="lp_nlp_bb",
+        mip_nlp_options={
+            "mip_nlp_profile": "shot",
+            "tree_strategy": "single_tree",
+            "cut_strategy": "oa",
+        },
+        milp_solver="gurobi",
+    )
+
+    assert result.status == "optimal"
+    assert calls == {"lazy": 1, "node": 1, "subproblem": 1}
+    trace = result.mip_nlp_trace
+    assert trace["profile"] == "shot"
+    assert trace["summary"]["callback_stats"]["mipnode_calls"] == 1
+    assert trace["summary"]["callback_stats"]["mipsol_calls"] == 1
+    assert trace["summary"]["cut_source_counts"]["oa"] >= 1
+    assert trace["summary"]["cut_source_counts"]["ecp"] >= 1
+    contexts = [event["context"] for event in trace["iterations"][0]["callback_events"]]
+    assert contexts == ["mipnode", "mipsol"]
 
 
 def test_lp_nlp_bb_no_good_cut_skips_mixed_integer_model(monkeypatch):

--- a/python/tests/test_mip_nlp.py
+++ b/python/tests/test_mip_nlp.py
@@ -2572,6 +2572,48 @@ def test_lp_nlp_bb_shot_callback_trace_records_node_and_incumbent_cuts(monkeypat
     assert contexts == ["mipnode", "mipsol"]
 
 
+def test_lp_nlp_bb_callback_termination_reports_time_limit(monkeypatch):
+    import discopt.solvers.gurobi as gurobi_module
+    import discopt.solvers.oa as oa_module
+    from discopt.solvers import MILPResult, SolveStatus
+    from discopt.solvers.mip_nlp import solve_mip_nlp
+
+    monkeypatch.setattr(oa_module, "_solve_nlp_relaxation", lambda *args, **kwargs: (None, None))
+    monkeypatch.setattr(oa_module, "_add_oa_cuts", lambda *args, **kwargs: None)
+
+    def fake_lazy_milp(**kwargs):
+        assert kwargs["terminate_callback"]({}) is True
+        return MILPResult(
+            status=SolveStatus.ERROR,
+            x=None,
+            objective=None,
+            bound=None,
+            gap=None,
+            node_count=0,
+            callback_stats={
+                "terminated": True,
+                "terminate_context": "callback",
+                "mipsol_calls": 0,
+                "mipnode_calls": 0,
+                "lazy_cuts": 0,
+                "node_cuts": 0,
+            },
+        )
+
+    monkeypatch.setattr(gurobi_module, "solve_milp_with_lazy_cuts", fake_lazy_milp)
+
+    result = solve_mip_nlp(
+        _binary_model("lp_nlp_bb_callback_timeout"),
+        method="lp_nlp_bb",
+        milp_solver="gurobi",
+        time_limit=0.0,
+    )
+
+    assert result.status == "time_limit"
+    assert result.mip_nlp_trace["termination_reason"] == "time_limit"
+    assert result.mip_nlp_trace["summary"]["callback_stats"]["terminated"] is True
+
+
 def test_lp_nlp_bb_no_good_cut_skips_mixed_integer_model(monkeypatch):
     import discopt.solvers.gurobi as gurobi_module
     import discopt.solvers.oa as oa_module


### PR DESCRIPTION
Closes #150.

## Summary

- Route SHOT-profile `tree_strategy="single_tree"` OA/ECP requests to the Gurobi LP/NLP-BB callback solver, with a clear non-Gurobi backend error.
- Extend the Gurobi lazy-cut wrapper with MIPNODE user-cut callbacks, callback stats, termination checks, and MIP starts.
- Feed LP/NLP-BB callback-generated OA/ECP/feasibility/integer cuts into the unified MIP-NLP cut provenance ledger and expose callback events in `mip_nlp_trace`.
- Add mocked callback coverage for MIPSOL and MIPNODE state transitions, SHOT single-tree routing, provenance counts, and backend rejection.
- Document the SHOT single-tree callback behavior and backend limitation.

## Tests

- `PYTHONPATH=python pytest python/tests/test_mip_nlp.py -q`
- `PYTHONPATH=python pytest python/tests/test_gurobi_backend.py -q`
- `PYTHONPATH=python python -m ruff check python/discopt/solvers/gurobi.py python/discopt/solvers/oa.py python/discopt/solvers/mip_nlp.py python/tests/test_gurobi_backend.py python/tests/test_mip_nlp.py`
- `PYTHONPATH=python python -m ruff format --check python/discopt/solvers/gurobi.py python/discopt/solvers/oa.py python/discopt/solvers/mip_nlp.py python/tests/test_gurobi_backend.py python/tests/test_mip_nlp.py`
- `make lint`
- Commit hook: ruff, ruff format, mypy; cargo fmt skipped because no Rust files changed.

Local pytest passed with existing JAX persistent-cache warnings caused by the read-only home cache under `~/.cache/discopt/jax-cache`. Optional licensed Gurobi tests remain guarded by license availability.

## Branch Hygiene

- Base branch: `feature/mip-nlp-solver` (non-default SHOT roadmap integration branch).
- Source branch point: `origin/feature/mip-nlp-solver` at `410d85bcd20fc0d0b421e62298564887183c746e`, the issue #149 merge commit.
- Head branch: `fix/issue-150-single-tree-callbacks`.
- Stacked status: follows issue #149 / PR #167, already merged into `feature/mip-nlp-solver`.
- Upstream sync: `origin/feature/mip-nlp-solver` does not include current `upstream/main` `849ad01cb2a304b2d9f9771cc96f66f74ee73f58`; this PR intentionally stays on the active SHOT integration branch.

Because this targets non-default branch `feature/mip-nlp-solver`, GitHub may not auto-close #150 until that branch reaches the default branch; manual closure may be needed by the issue-series policy.
