### PR TITLE
Add SHOT direct strategy routing

### DIFF
--- a/docs/mip_nlp.md
+++ b/docs/mip_nlp.md
@@ -126,7 +126,7 @@ Accepted SHOT-profile controls are:
 | `integer_bilinear_strategy` | `"auto"`, `"off"`, `"binary_expansion"`, `"mccormick"` |
 | `integer_bilinear_max_bits` | Positive integer or `None` |
 | `quadratic_extraction` | `"auto"`, `"off"`, `"native"`, `"relaxation"` |
-| `direct_quadratic_routing` | `"auto"`, `"off"`, `"safe"` |
+| `direct_quadratic_routing` | `"auto"`, `"off"` |
 | `rootsearch_strategy` | `"auto"`, `"none"`, `"bisection"`, `"toms748"` |
 | `fixed_nlp_strategy` | `"auto"`, `"none"`, `"always"`, `"adaptive"`, `"iteration"`, `"time"`, `"solution_pool"` |
 | `solution_pool_capacity`, `hyperplane_max_per_iter` | Positive integer or `None` |
@@ -152,6 +152,18 @@ solves an integrality-relaxed master before each integer master iteration and
 records the phase state under each iteration's `relaxation_phase` trace entry.
 Failures fall back to the existing OA/ECP path with details in the iteration
 trace.
+
+`direct_quadratic_routing="auto"` enables SHOT-profile direct strategy routing
+before the multi-tree OA/GOA fallback. Despite the historical option name, this
+gate covers every currently implemented direct class: continuous convex NLP,
+LP/MILP, convex QP/MIQP, and convex QCP/QCQP/MIQCP/MIQCQP. Convexity-sensitive
+classes route directly only when the classifier proves known convexity; unknown
+or nonconvex models fall back to OA/GOA and record the fallback reason in
+`result.mip_nlp_trace["strategy_selection"]["direct_attempt"]`.
+`direct_quadratic_routing="off"` disables these direct routes. QCP-class direct
+routing currently requires an explicit `milp_solver="gurobi"` request; with
+`milp_solver="auto"` those models fall back to the normal MIP-NLP path instead
+of probing an optional commercial backend.
 
 SHOT-profile runs also maintain an internal provenance-aware interior-point
 store for feasible relaxation, incumbent, and initial-POA points. Reusable

--- a/python/discopt/solvers/mip_nlp.py
+++ b/python/discopt/solvers/mip_nlp.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import time
 from typing import Any, Optional, cast
 
 from discopt.modeling.core import Model, ObjectiveSense, SolveResult
@@ -70,6 +71,8 @@ _LP_NLP_BB_OPTION_KEYS = frozenset(
         "milp_solver",
     }
 )
+_DIRECT_ROUTABLE_METHODS = frozenset({"oa", "ecp", "goa"})
+_DIRECT_BACKENDS = frozenset({"auto", "gurobi", "highs", "pounce", "simplex"})
 
 
 def _apply_shot_profile_reformulations(
@@ -92,6 +95,541 @@ def _apply_shot_profile_reformulations(
 
     reformulated, _changed = relax_objective_defining_equality(model)
     return cast(Model, reformulated)
+
+
+def _normalize_direct_backend(options: dict[str, Any]) -> str:
+    backend = str(options.get("milp_solver", "auto")).strip().lower().replace("-", "_")
+    return backend or "auto"
+
+
+def _annotate_strategy_trace(
+    result: SolveResult,
+    *,
+    method: str,
+    profile: str,
+    shot_config: MIPNLPShotConfig | None,
+    selected_strategy: str,
+    problem_class: str | None = None,
+    backend: str | None = None,
+    direct_attempt: dict[str, object] | None = None,
+) -> SolveResult:
+    ensure_mip_nlp_trace(
+        result,
+        method=method,
+        profile=profile,
+        shot_config=shot_config,
+    )
+    selection: dict[str, object] = {"selected_strategy": selected_strategy}
+    if problem_class is not None:
+        selection["problem_class"] = problem_class
+    if backend is not None:
+        selection["backend"] = backend
+    if direct_attempt is not None:
+        selection["direct_attempt"] = direct_attempt
+
+    trace = result.mip_nlp_trace
+    if trace is not None:
+        trace["selected_strategy"] = selected_strategy
+        trace["strategy_selection"] = selection
+        summary = trace.setdefault("summary", {})
+        if isinstance(summary, dict):
+            summary["selected_strategy"] = selected_strategy
+            if backend is not None:
+                summary["selected_backend"] = backend
+            if direct_attempt is not None:
+                summary["direct_routing"] = direct_attempt
+    return result
+
+
+def _direct_attempt(
+    *,
+    problem_class: str,
+    candidate_strategy: str,
+    backend: str,
+    fallback_reason: str,
+) -> dict[str, object]:
+    return {
+        "candidate_strategy": candidate_strategy,
+        "problem_class": problem_class,
+        "backend": backend,
+        "fallback_reason": fallback_reason,
+    }
+
+
+def _requires_known_convexity(
+    model: Model,
+    *,
+    problem_class: str,
+    candidate_strategy: str,
+    backend: str,
+    failure_label: str,
+) -> dict[str, object] | None:
+    import discopt.solver as solver_module
+
+    known, is_convex, _constraint_mask = solver_module._classify_model_convexity(
+        model,
+        failure_label=failure_label,
+        log_nonconvex_continuous=problem_class == "nlp",
+    )
+    if not known:
+        return _direct_attempt(
+            problem_class=problem_class,
+            candidate_strategy=candidate_strategy,
+            backend=backend,
+            fallback_reason="convexity_unknown",
+        )
+    if not is_convex:
+        return _direct_attempt(
+            problem_class=problem_class,
+            candidate_strategy=candidate_strategy,
+            backend=backend,
+            fallback_reason="nonconvex_model",
+        )
+    return None
+
+
+def _annotate_direct_result(
+    result: SolveResult,
+    *,
+    profile: str,
+    shot_config: MIPNLPShotConfig,
+    selected_strategy: str,
+    problem_class: str,
+    backend: str,
+) -> SolveResult:
+    return _annotate_strategy_trace(
+        result,
+        method="direct",
+        profile=profile,
+        shot_config=shot_config,
+        selected_strategy=selected_strategy,
+        problem_class=problem_class,
+        backend=backend,
+    )
+
+
+def _try_direct_nlp(
+    model: Model,
+    *,
+    profile: str,
+    shot_config: MIPNLPShotConfig,
+    problem_class: str,
+    time_limit: float,
+    nlp_solver: str,
+    initial_point: Any,
+    solver_module: Any,
+) -> tuple[SolveResult | None, dict[str, object] | None]:
+    strategy = "direct_nlp"
+    fallback = _requires_known_convexity(
+        model,
+        problem_class=problem_class,
+        candidate_strategy=strategy,
+        backend=nlp_solver,
+        failure_label="SHOT direct NLP convexity detection failed",
+    )
+    if fallback is not None:
+        return None, fallback
+    result = solver_module._solve_continuous(
+        model,
+        time_limit,
+        None,
+        time.perf_counter(),
+        nlp_solver,
+        initial_point=initial_point,
+    )
+    result.convex_fast_path = True
+    return (
+        _annotate_direct_result(
+            result,
+            profile=profile,
+            shot_config=shot_config,
+            selected_strategy=strategy,
+            problem_class=problem_class,
+            backend=nlp_solver,
+        ),
+        None,
+    )
+
+
+def _try_direct_lp(
+    model: Model,
+    *,
+    profile: str,
+    shot_config: MIPNLPShotConfig,
+    problem_class: str,
+    backend: str,
+    time_limit: float,
+    nlp_solver: str,
+    solver_module: Any,
+) -> tuple[SolveResult | None, dict[str, object] | None]:
+    strategy = "direct_lp"
+    t_start = time.perf_counter()
+    if backend == "gurobi":
+        result = solver_module._solve_lp_gurobi(model, t_start, time_limit)
+    elif backend == "highs":
+        result = solver_module._solve_lp_highs(model, t_start, time_limit)
+    elif backend == "pounce":
+        result = solver_module._solve_lp_pounce(model, t_start, time_limit)
+    elif backend == "simplex":
+        result = None
+    else:
+        result = solver_module._solve_lp(
+            model,
+            t_start,
+            time_limit,
+            prefer_pounce=nlp_solver == "pounce",
+        )
+    if result is None:
+        return None, _direct_attempt(
+            problem_class=problem_class,
+            candidate_strategy=strategy,
+            backend=backend,
+            fallback_reason="direct_backend_unavailable",
+        )
+    return (
+        _annotate_direct_result(
+            result,
+            profile=profile,
+            shot_config=shot_config,
+            selected_strategy=strategy,
+            problem_class=problem_class,
+            backend=backend,
+        ),
+        None,
+    )
+
+
+def _try_direct_milp(
+    model: Model,
+    *,
+    profile: str,
+    shot_config: MIPNLPShotConfig,
+    problem_class: str,
+    backend: str,
+    time_limit: float,
+    gap_tolerance: float,
+    max_iterations: int,
+    nlp_solver: str,
+    solver_module: Any,
+) -> tuple[SolveResult | None, dict[str, object] | None]:
+    strategy = "direct_milp"
+    t_start = time.perf_counter()
+    result = None
+    if backend == "gurobi":
+        result = solver_module._solve_milp_gurobi(model, t_start, time_limit, gap_tolerance)
+    elif backend == "highs":
+        result = solver_module._solve_milp_highs(model, t_start, time_limit, gap_tolerance)
+    elif backend == "simplex":
+        result = solver_module._solve_milp_simplex(
+            model,
+            time_limit,
+            gap_tolerance,
+            max_iterations,
+            t_start,
+        )
+    elif backend == "pounce":
+        result = solver_module._solve_milp_bb(
+            model,
+            time_limit,
+            gap_tolerance,
+            16,
+            "best_first",
+            max_iterations,
+            t_start,
+            prefer_pounce=True,
+            node_engine="simplex",
+        )
+    else:
+        if nlp_solver != "pounce":
+            result = solver_module._solve_milp_highs(model, t_start, time_limit, gap_tolerance)
+        if result is None:
+            result = solver_module._solve_milp_bb(
+                model,
+                time_limit,
+                gap_tolerance,
+                16,
+                "best_first",
+                max_iterations,
+                t_start,
+                prefer_pounce=nlp_solver == "pounce",
+                node_engine="simplex" if nlp_solver == "pounce" else "pounce",
+            )
+    if result is None:
+        return None, _direct_attempt(
+            problem_class=problem_class,
+            candidate_strategy=strategy,
+            backend=backend,
+            fallback_reason="direct_backend_unavailable",
+        )
+    return (
+        _annotate_direct_result(
+            result,
+            profile=profile,
+            shot_config=shot_config,
+            selected_strategy=strategy,
+            problem_class=problem_class,
+            backend=backend,
+        ),
+        None,
+    )
+
+
+def _try_direct_qp(
+    model: Model,
+    *,
+    profile: str,
+    shot_config: MIPNLPShotConfig,
+    problem_class: str,
+    is_miqp: bool,
+    backend: str,
+    time_limit: float,
+    gap_tolerance: float,
+    max_iterations: int,
+    nlp_solver: str,
+    solver_module: Any,
+) -> tuple[SolveResult | None, dict[str, object] | None]:
+    strategy = "direct_miqp" if is_miqp else "direct_qp"
+    if backend == "simplex":
+        return None, _direct_attempt(
+            problem_class=problem_class,
+            candidate_strategy=strategy,
+            backend=backend,
+            fallback_reason="direct_backend_unavailable",
+        )
+    fallback = _requires_known_convexity(
+        model,
+        problem_class=problem_class,
+        candidate_strategy=strategy,
+        backend=backend,
+        failure_label="SHOT direct quadratic convexity detection failed",
+    )
+    if fallback is not None:
+        return None, fallback
+
+    t_start = time.perf_counter()
+    result = None
+    if backend == "gurobi":
+        result = solver_module._solve_qp_gurobi(model, t_start, time_limit, gap_tolerance)
+    elif backend == "highs":
+        result = solver_module._solve_qp_highs(model, t_start, time_limit)
+        if result is None:
+            return None, _direct_attempt(
+                problem_class=problem_class,
+                candidate_strategy=strategy,
+                backend=backend,
+                fallback_reason="direct_backend_unavailable",
+            )
+    elif backend == "pounce" and not is_miqp:
+        result = solver_module._solve_qp_pounce(model, t_start, time_limit)
+        if result is None:
+            return None, _direct_attempt(
+                problem_class=problem_class,
+                candidate_strategy=strategy,
+                backend=backend,
+                fallback_reason="direct_backend_unavailable",
+            )
+    elif is_miqp:
+        if backend == "auto" and nlp_solver != "pounce":
+            result = solver_module._solve_qp_highs(model, t_start, time_limit)
+        if result is None:
+            result = solver_module._solve_miqp_bb(
+                model,
+                time_limit,
+                gap_tolerance,
+                16,
+                "best_first",
+                max_iterations,
+                t_start,
+                prefer_pounce=nlp_solver == "pounce" or backend == "pounce",
+            )
+    else:
+        result = solver_module._solve_qp(
+            model,
+            t_start,
+            prefer_pounce=nlp_solver == "pounce",
+        )
+
+    if result is None:
+        return None, _direct_attempt(
+            problem_class=problem_class,
+            candidate_strategy=strategy,
+            backend=backend,
+            fallback_reason="direct_backend_unavailable",
+        )
+    return (
+        _annotate_direct_result(
+            result,
+            profile=profile,
+            shot_config=shot_config,
+            selected_strategy=strategy,
+            problem_class=problem_class,
+            backend=backend,
+        ),
+        None,
+    )
+
+
+def _try_direct_qcp(
+    model: Model,
+    *,
+    profile: str,
+    shot_config: MIPNLPShotConfig,
+    problem_class: str,
+    backend: str,
+    time_limit: float,
+    gap_tolerance: float,
+    solver_module: Any,
+) -> tuple[SolveResult | None, dict[str, object] | None]:
+    strategy = {
+        "qcp": "direct_qcp",
+        "qcqp": "direct_qcqp",
+        "miqcp": "direct_miqcp",
+        "miqcqp": "direct_miqcqp",
+    }[problem_class]
+    if backend != "gurobi":
+        return None, _direct_attempt(
+            problem_class=problem_class,
+            candidate_strategy=strategy,
+            backend=backend,
+            fallback_reason="requires_milp_solver_gurobi",
+        )
+    fallback = _requires_known_convexity(
+        model,
+        problem_class=problem_class,
+        candidate_strategy=strategy,
+        backend=backend,
+        failure_label="SHOT direct QCP convexity detection failed",
+    )
+    if fallback is not None:
+        return None, fallback
+    result = solver_module._solve_qcp_gurobi(
+        model,
+        time.perf_counter(),
+        time_limit,
+        gap_tolerance,
+    )
+    return (
+        _annotate_direct_result(
+            result,
+            profile=profile,
+            shot_config=shot_config,
+            selected_strategy=strategy,
+            problem_class=problem_class,
+            backend=backend,
+        ),
+        None,
+    )
+
+
+def _try_solve_shot_direct_strategy(
+    model: Model,
+    *,
+    method: str,
+    profile: str,
+    shot_config: MIPNLPShotConfig | None,
+    options: dict[str, Any],
+    time_limit: float,
+    gap_tolerance: float,
+    max_iterations: int,
+    nlp_solver: str,
+    initial_point: Any,
+) -> tuple[SolveResult | None, dict[str, object] | None]:
+    if (
+        profile != "shot"
+        or shot_config is None
+        or method not in _DIRECT_ROUTABLE_METHODS
+        or shot_config.direct_quadratic_routing == "off"
+    ):
+        return None, None
+
+    import discopt.solver as solver_module
+    from discopt._jax.problem_classifier import ProblemClass, classify_problem
+
+    backend = _normalize_direct_backend(options)
+    try:
+        problem_class = classify_problem(model)
+    except Exception as exc:
+        return None, {
+            "candidate_strategy": "direct",
+            "backend": backend,
+            "fallback_reason": f"classification_failed: {type(exc).__name__}",
+        }
+
+    problem_value = problem_class.value
+    if backend not in _DIRECT_BACKENDS:
+        return None, {
+            "candidate_strategy": "direct",
+            "problem_class": problem_value,
+            "backend": backend,
+            "fallback_reason": "unsupported_direct_backend",
+        }
+
+    if problem_class == ProblemClass.NLP:
+        return _try_direct_nlp(
+            model,
+            profile=profile,
+            shot_config=shot_config,
+            problem_class=problem_value,
+            solver_module=solver_module,
+            time_limit=time_limit,
+            nlp_solver=nlp_solver,
+            initial_point=initial_point,
+        )
+    if problem_class == ProblemClass.LP:
+        return _try_direct_lp(
+            model,
+            profile=profile,
+            shot_config=shot_config,
+            problem_class=problem_value,
+            solver_module=solver_module,
+            backend=backend,
+            time_limit=time_limit,
+            nlp_solver=nlp_solver,
+        )
+    if problem_class == ProblemClass.MILP:
+        return _try_direct_milp(
+            model,
+            profile=profile,
+            shot_config=shot_config,
+            problem_class=problem_value,
+            solver_module=solver_module,
+            backend=backend,
+            time_limit=time_limit,
+            gap_tolerance=gap_tolerance,
+            max_iterations=max_iterations,
+            nlp_solver=nlp_solver,
+        )
+    if problem_class in (ProblemClass.QP, ProblemClass.MIQP):
+        return _try_direct_qp(
+            model,
+            profile=profile,
+            shot_config=shot_config,
+            problem_class=problem_value,
+            solver_module=solver_module,
+            is_miqp=problem_class == ProblemClass.MIQP,
+            backend=backend,
+            time_limit=time_limit,
+            gap_tolerance=gap_tolerance,
+            max_iterations=max_iterations,
+            nlp_solver=nlp_solver,
+        )
+    if problem_class in (
+        ProblemClass.QCP,
+        ProblemClass.QCQP,
+        ProblemClass.MIQCP,
+        ProblemClass.MIQCQP,
+    ):
+        return _try_direct_qcp(
+            model,
+            profile=profile,
+            shot_config=shot_config,
+            problem_class=problem_value,
+            solver_module=solver_module,
+            backend=backend,
+            time_limit=time_limit,
+            gap_tolerance=gap_tolerance,
+        )
+    return None, None
 
 
 def _normalize_method(method: Any) -> str:
@@ -216,7 +754,29 @@ def solve_mip_nlp(
                 profile=profile,
                 shot_config=shot_config,
             )
-            return result
+            return _annotate_strategy_trace(
+                result,
+                method="lp_nlp_bb",
+                profile=profile,
+                shot_config=shot_config,
+                selected_strategy="lp_nlp_bb",
+                backend="gurobi",
+            )
+
+        direct_result, direct_attempt = _try_solve_shot_direct_strategy(
+            model,
+            method=method,
+            profile=profile,
+            shot_config=shot_config,
+            options=options,
+            time_limit=time_limit,
+            gap_tolerance=gap_tolerance,
+            max_iterations=max_iterations,
+            nlp_solver=nlp_solver,
+            initial_point=initial_point,
+        )
+        if direct_result is not None:
+            return direct_result
 
         if method == "fp":
             from discopt.solvers.oa import _normalize_init_strategy, solve_feasibility_pump
@@ -255,7 +815,13 @@ def solve_mip_nlp(
                 profile=profile,
                 shot_config=shot_config,
             )
-            return result
+            return _annotate_strategy_trace(
+                result,
+                method=method,
+                profile=profile,
+                shot_config=shot_config,
+                selected_strategy=method,
+            )
 
         if method == "goa":
             from discopt.solvers.oa import solve_goa
@@ -276,7 +842,14 @@ def solve_mip_nlp(
                 profile=profile,
                 shot_config=shot_config,
             )
-            return result
+            return _annotate_strategy_trace(
+                result,
+                method=method,
+                profile=profile,
+                shot_config=shot_config,
+                selected_strategy=method,
+                direct_attempt=direct_attempt,
+            )
 
         if method == "lp_nlp_bb":
             from discopt.solvers.oa import _normalize_init_strategy, solve_lp_nlp_bb
@@ -305,7 +878,14 @@ def solve_mip_nlp(
                 profile=profile,
                 shot_config=shot_config,
             )
-            return result
+            return _annotate_strategy_trace(
+                result,
+                method=method,
+                profile=profile,
+                shot_config=shot_config,
+                selected_strategy=method,
+                backend=str(options.get("milp_solver", "gurobi")).strip().lower(),
+            )
 
         from discopt.solvers.oa import _normalize_init_strategy, solve_oa
 
@@ -336,7 +916,15 @@ def solve_mip_nlp(
             profile=profile,
             shot_config=shot_config,
         )
-        return result
+        return _annotate_strategy_trace(
+            result,
+            method=method,
+            profile=profile,
+            shot_config=shot_config,
+            selected_strategy=method,
+            backend=str(options.get("milp_solver", "auto")).strip().lower(),
+            direct_attempt=direct_attempt,
+        )
 
     raise NotImplementedError(
         f"mip_nlp_method={method!r} is reserved for a future MIP-NLP "

--- a/python/discopt/solvers/mip_nlp_options.py
+++ b/python/discopt/solvers/mip_nlp_options.py
@@ -100,7 +100,7 @@ _AUTO_OFF_ON = frozenset({"auto", "off", "on"})
 _PARTITION_STRATEGIES = frozenset({"auto", "off", "static", "adaptive"})
 _INTEGER_BILINEAR_STRATEGIES = frozenset({"auto", "off", "binary_expansion", "mccormick"})
 _QUADRATIC_EXTRACTION_STRATEGIES = frozenset({"auto", "off", "native", "relaxation"})
-_DIRECT_QUADRATIC_ROUTING = frozenset({"auto", "off", "safe"})
+_DIRECT_QUADRATIC_ROUTING = frozenset({"auto", "off"})
 _ROOTSEARCH_STRATEGIES = frozenset({"auto", "none", "bisection", "toms748"})
 _FIXED_NLP_STRATEGIES = frozenset(
     {"auto", "none", "always", "adaptive", "iteration", "time", "solution_pool"}

--- a/python/tests/test_mip_nlp.py
+++ b/python/tests/test_mip_nlp.py
@@ -1958,7 +1958,7 @@ def test_mip_nlp_shot_profile_options_validate_and_attach_trace(monkeypatch):
             "integer_bilinear_strategy": "binary-expansion",
             "integer_bilinear_max_bits": 8,
             "quadratic_extraction": "native",
-            "direct_quadratic_routing": "safe",
+            "direct_quadratic_routing": "auto",
             "rootsearch_strategy": "toms748",
             "fixed_nlp_strategy": "solution-pool",
             "solution_pool_capacity": 5,
@@ -1986,7 +1986,7 @@ def test_mip_nlp_shot_profile_options_validate_and_attach_trace(monkeypatch):
     assert cfg.integer_bilinear_strategy == "binary_expansion"
     assert cfg.integer_bilinear_max_bits == 8
     assert cfg.quadratic_extraction == "native"
-    assert cfg.direct_quadratic_routing == "safe"
+    assert cfg.direct_quadratic_routing == "auto"
     assert cfg.rootsearch_strategy == "toms748"
     assert cfg.fixed_nlp_strategy == "solution_pool"
     assert cfg.solution_pool_capacity == 5
@@ -2243,6 +2243,68 @@ def test_mip_nlp_shot_direct_qcp_falls_back_without_gurobi(monkeypatch):
     attempt = result.mip_nlp_trace["strategy_selection"]["direct_attempt"]
     assert attempt["candidate_strategy"] == "direct_qcp"
     assert attempt["fallback_reason"] == "requires_milp_solver_gurobi"
+
+
+@pytest.mark.parametrize(
+    ("convexity_result", "fallback_reason"),
+    [
+        ((True, False, []), "nonconvex_model"),
+        ((False, False, None), "convexity_unknown"),
+    ],
+)
+def test_mip_nlp_shot_direct_miqp_falls_back_when_convexity_not_certified(
+    monkeypatch,
+    convexity_result,
+    fallback_reason,
+):
+    import discopt.solver as solver_module
+    import discopt.solvers.oa as oa_module
+    from discopt.solvers.mip_nlp import solve_mip_nlp
+
+    calls = {}
+
+    monkeypatch.setattr(
+        solver_module,
+        "_classify_model_convexity",
+        lambda *args, **kwargs: convexity_result,
+    )
+
+    def fail_direct(*args, **kwargs):
+        raise AssertionError("direct QP backend should not run without convexity proof")
+
+    def fake_solve_oa(model, **kwargs):
+        del model
+        calls.update(kwargs)
+        return SolveResult(status="optimal", objective=0.0, bound=0.0, gap=0.0)
+
+    monkeypatch.setattr(solver_module, "_solve_qp_highs", fail_direct)
+    monkeypatch.setattr(oa_module, "solve_oa", fake_solve_oa)
+
+    result = solve_mip_nlp(
+        _miqp_style_model("shot_direct_miqp_convexity_fallback"),
+        method="oa",
+        mip_nlp_options={"mip_nlp_profile": "shot", "milp_solver": "highs"},
+    )
+
+    assert calls["milp_solver"] == "highs"
+    assert result.mip_nlp_trace["selected_strategy"] == "oa"
+    attempt = result.mip_nlp_trace["strategy_selection"]["direct_attempt"]
+    assert attempt["candidate_strategy"] == "direct_miqp"
+    assert attempt["fallback_reason"] == fallback_reason
+
+
+def test_mip_nlp_shot_rejects_unimplemented_safe_direct_routing_mode():
+    from discopt.solvers.mip_nlp import solve_mip_nlp
+
+    with pytest.raises(ValueError, match="direct_quadratic_routing"):
+        solve_mip_nlp(
+            _miqp_style_model("shot_direct_safe_rejected"),
+            method="oa",
+            mip_nlp_options={
+                "mip_nlp_profile": "shot",
+                "direct_quadratic_routing": "safe",
+            },
+        )
 
 
 @pytest.mark.parametrize(

--- a/python/tests/test_mip_nlp.py
+++ b/python/tests/test_mip_nlp.py
@@ -38,6 +38,13 @@ def _continuous_model(name="mip_nlp_continuous"):
     return m
 
 
+def _convex_general_nlp_model(name="shot_direct_nlp"):
+    m = dm.Model(name)
+    x = m.continuous("x", lb=0.0, ub=2.0)
+    m.minimize(dm.exp(x))
+    return m
+
+
 def _gdp_model(name="mip_nlp_gdp_route"):
     m = dm.Model(name)
     x = m.continuous("x", lb=0, ub=10)
@@ -139,6 +146,15 @@ def _miqp_style_model(name="shot_miqp_style"):
     m = dm.Model(name)
     x = m.continuous("x", lb=-2, ub=2)
     y = m.binary("y")
+    m.minimize((x - 1) ** 2 + y)
+    return m
+
+
+def _miqcqp_style_model(name="shot_miqcqp_style"):
+    m = dm.Model(name)
+    x = m.continuous("x", lb=-2, ub=2)
+    y = m.binary("y")
+    m.subject_to(x**2 + y <= 3.0)
     m.minimize((x - 1) ** 2 + y)
     return m
 
@@ -1926,7 +1942,7 @@ def test_mip_nlp_shot_profile_options_validate_and_attach_trace(monkeypatch):
     monkeypatch.setattr(oa_module, "solve_oa", fake_solve_oa)
 
     result = solve_mip_nlp(
-        _binary_model("shot_profile_options"),
+        _convex_binary_nonlinear_model("shot_profile_options"),
         method="oa",
         mip_nlp_options={
             "mip_nlp_profile": "shot",
@@ -2032,6 +2048,203 @@ def test_mip_nlp_shot_single_tree_rejects_non_gurobi_backend():
         )
 
 
+def test_mip_nlp_shot_direct_nlp_routes_to_continuous_solver(monkeypatch):
+    import discopt.solver as solver_module
+    from discopt.solvers.mip_nlp import solve_mip_nlp
+
+    calls = {}
+
+    monkeypatch.setattr(
+        solver_module,
+        "_classify_model_convexity",
+        lambda *args, **kwargs: (True, True, []),
+    )
+
+    def fake_solve_continuous(
+        model,
+        time_limit,
+        ipopt_options,
+        t_start,
+        nlp_solver,
+        initial_point=None,
+    ):
+        del model, ipopt_options, t_start, initial_point
+        calls["time_limit"] = time_limit
+        calls["nlp_solver"] = nlp_solver
+        return SolveResult(status="optimal", objective=1.0, bound=1.0, gap=0.0)
+
+    monkeypatch.setattr(solver_module, "_solve_continuous", fake_solve_continuous)
+
+    result = solve_mip_nlp(
+        _convex_general_nlp_model("shot_direct_nlp_route"),
+        method="oa",
+        mip_nlp_options={"mip_nlp_profile": "shot"},
+        time_limit=12.0,
+        nlp_solver="pounce",
+    )
+
+    assert calls == {"time_limit": 12.0, "nlp_solver": "pounce"}
+    assert result.convex_fast_path is True
+    assert result.mip_nlp_trace["method"] == "direct"
+    assert result.mip_nlp_trace["selected_strategy"] == "direct_nlp"
+    assert result.mip_nlp_trace["strategy_selection"]["problem_class"] == "nlp"
+
+
+def test_mip_nlp_shot_direct_milp_routes_to_requested_backend(monkeypatch):
+    import discopt.solver as solver_module
+    from discopt.solvers.mip_nlp import solve_mip_nlp
+
+    calls = {}
+
+    def fake_solve_milp_highs(model, t_start, time_limit=None, gap_tolerance=1e-4):
+        del model, t_start
+        calls["backend"] = "highs"
+        calls["time_limit"] = time_limit
+        calls["gap_tolerance"] = gap_tolerance
+        return SolveResult(status="optimal", objective=0.0, bound=0.0, gap=0.0)
+
+    monkeypatch.setattr(solver_module, "_solve_milp_highs", fake_solve_milp_highs)
+
+    result = solve_mip_nlp(
+        _binary_model("shot_direct_milp_route"),
+        method="oa",
+        mip_nlp_options={"mip_nlp_profile": "shot", "milp_solver": "highs"},
+        time_limit=7.0,
+        gap_tolerance=5e-5,
+    )
+
+    assert calls == {"backend": "highs", "time_limit": 7.0, "gap_tolerance": 5e-5}
+    assert result.mip_nlp_trace["selected_strategy"] == "direct_milp"
+    assert result.mip_nlp_trace["strategy_selection"]["backend"] == "highs"
+    assert result.mip_nlp_trace["summary"]["selected_strategy"] == "direct_milp"
+
+
+def test_mip_nlp_shot_direct_miqp_routes_when_convex(monkeypatch):
+    import discopt.solver as solver_module
+    from discopt.solvers.mip_nlp import solve_mip_nlp
+
+    calls = {}
+
+    monkeypatch.setattr(
+        solver_module,
+        "_classify_model_convexity",
+        lambda *args, **kwargs: (True, True, []),
+    )
+
+    def fake_solve_qp_highs(model, t_start, time_limit=None):
+        del model, t_start
+        calls["backend"] = "highs"
+        calls["time_limit"] = time_limit
+        return SolveResult(status="optimal", objective=1.0, bound=1.0, gap=0.0)
+
+    monkeypatch.setattr(solver_module, "_solve_qp_highs", fake_solve_qp_highs)
+
+    result = solve_mip_nlp(
+        _miqp_style_model("shot_direct_miqp_route"),
+        method="oa",
+        mip_nlp_options={"mip_nlp_profile": "shot", "milp_solver": "highs"},
+        time_limit=9.0,
+    )
+
+    assert calls == {"backend": "highs", "time_limit": 9.0}
+    assert result.mip_nlp_trace["selected_strategy"] == "direct_miqp"
+    assert result.mip_nlp_trace["strategy_selection"]["problem_class"] == "miqp"
+
+
+def test_mip_nlp_shot_direct_qcp_routes_to_gurobi_when_requested(monkeypatch):
+    import discopt.solver as solver_module
+    from discopt.solvers.mip_nlp import solve_mip_nlp
+
+    calls = {}
+
+    monkeypatch.setattr(
+        solver_module,
+        "_classify_model_convexity",
+        lambda *args, **kwargs: (True, True, []),
+    )
+
+    def fake_solve_qcp_gurobi(model, t_start, time_limit=None, gap_tolerance=1e-4):
+        del model, t_start
+        calls["backend"] = "gurobi"
+        calls["time_limit"] = time_limit
+        calls["gap_tolerance"] = gap_tolerance
+        return SolveResult(status="optimal", objective=0.0, bound=0.0, gap=0.0)
+
+    monkeypatch.setattr(solver_module, "_solve_qcp_gurobi", fake_solve_qcp_gurobi)
+
+    result = solve_mip_nlp(
+        _quadratic_partition_model("shot_direct_qcp_route"),
+        method="oa",
+        mip_nlp_options={"mip_nlp_profile": "shot", "milp_solver": "gurobi"},
+        time_limit=8.0,
+        gap_tolerance=1e-5,
+    )
+
+    assert calls == {"backend": "gurobi", "time_limit": 8.0, "gap_tolerance": 1e-5}
+    assert result.mip_nlp_trace["selected_strategy"] == "direct_qcp"
+    assert result.mip_nlp_trace["strategy_selection"]["backend"] == "gurobi"
+
+
+def test_mip_nlp_shot_direct_miqcqp_routes_to_gurobi_when_requested(monkeypatch):
+    import discopt.solver as solver_module
+    from discopt.solvers.mip_nlp import solve_mip_nlp
+
+    calls = {}
+
+    monkeypatch.setattr(
+        solver_module,
+        "_classify_model_convexity",
+        lambda *args, **kwargs: (True, True, []),
+    )
+
+    def fake_solve_qcp_gurobi(model, t_start, time_limit=None, gap_tolerance=1e-4):
+        del model, t_start
+        calls["backend"] = "gurobi"
+        calls["time_limit"] = time_limit
+        calls["gap_tolerance"] = gap_tolerance
+        return SolveResult(status="optimal", objective=1.0, bound=1.0, gap=0.0)
+
+    monkeypatch.setattr(solver_module, "_solve_qcp_gurobi", fake_solve_qcp_gurobi)
+
+    result = solve_mip_nlp(
+        _miqcqp_style_model("shot_direct_miqcqp_route"),
+        method="oa",
+        mip_nlp_options={"mip_nlp_profile": "shot", "milp_solver": "gurobi"},
+        time_limit=8.0,
+        gap_tolerance=1e-5,
+    )
+
+    assert calls == {"backend": "gurobi", "time_limit": 8.0, "gap_tolerance": 1e-5}
+    assert result.mip_nlp_trace["selected_strategy"] == "direct_miqcqp"
+    assert result.mip_nlp_trace["strategy_selection"]["problem_class"] == "miqcqp"
+
+
+def test_mip_nlp_shot_direct_qcp_falls_back_without_gurobi(monkeypatch):
+    import discopt.solvers.oa as oa_module
+    from discopt.solvers.mip_nlp import solve_mip_nlp
+
+    calls = {}
+
+    def fake_solve_oa(model, **kwargs):
+        del model
+        calls.update(kwargs)
+        return SolveResult(status="optimal", objective=0.0, bound=0.0, gap=0.0)
+
+    monkeypatch.setattr(oa_module, "solve_oa", fake_solve_oa)
+
+    result = solve_mip_nlp(
+        _quadratic_partition_model("shot_direct_qcp_fallback"),
+        method="oa",
+        mip_nlp_options={"mip_nlp_profile": "shot", "milp_solver": "highs"},
+    )
+
+    assert calls["milp_solver"] == "highs"
+    assert result.mip_nlp_trace["selected_strategy"] == "oa"
+    attempt = result.mip_nlp_trace["strategy_selection"]["direct_attempt"]
+    assert attempt["candidate_strategy"] == "direct_qcp"
+    assert attempt["fallback_reason"] == "requires_milp_solver_gurobi"
+
+
 @pytest.mark.parametrize(
     ("model_factory", "options", "trace_key", "trace_value"),
     [
@@ -2066,9 +2279,9 @@ def test_mip_nlp_shot_single_tree_rejects_non_gurobi_backend():
         (_miqp_style_model, {"quadratic_extraction": "native"}, "quadratic_extraction", "native"),
         (
             _miqp_style_model,
-            {"direct_quadratic_routing": "safe"},
+            {"direct_quadratic_routing": "off"},
             "direct_quadratic_routing",
-            "safe",
+            "off",
         ),
     ],
 )


### PR DESCRIPTION
Closes #151.

## Summary

- Add SHOT-profile direct strategy selection for continuous convex NLP, LP/MILP, convex QP/MIQP, and Gurobi-backed convex QCP/QCQP/MIQCP/MIQCQP problem classes.
- Preserve the existing OA/GOA fallback paths when classification, convexity, or backend checks do not permit direct routing.
- Record `selected_strategy`, backend, problem class, and fallback diagnostics in `mip_nlp_trace.strategy_selection`.
- Add mock-backed tests for direct NLP, MILP, MIQP, QCP, MIQCQP, and QCP fallback routing.

## Tests

- `PYTHONPATH=/home/bernalde/repos/discopt/python pytest python/tests/test_mip_nlp.py -q`
  - `163 passed, 2 skipped, 7 deselected`
  - JAX emitted persistent-cache warnings because `/home/bernalde/.cache/discopt/jax-cache` is read-only in this environment.
- `PYTHONPATH=/home/bernalde/repos/discopt/python pytest python/tests/test_qp_highs.py python/tests/test_qp_backend_seam.py python/tests/test_gurobi_backend.py -q`
  - `62 passed, 10 skipped, 2 deselected`
- `python -m ruff check python/discopt/solvers/mip_nlp.py python/tests/test_mip_nlp.py`
- `python -m ruff format --check python/discopt/solvers/mip_nlp.py python/tests/test_mip_nlp.py`
- Commit hook: `ruff`, `ruff format`, and repo mypy passed; `cargo fmt` skipped because no Rust files were staged.

## Branch Hygiene

- Base: `feature/mip-nlp-solver` at `17b6f6375578d9eafaae4cce6e7a8f48981dddec`.
- Head: `fix/issue-151-direct-routing` at `3039d0704401b6e867e5d26bfd28055e38e86ea9`.
- This follows the SHOT stack after #150/#168, which has already merged into `feature/mip-nlp-solver`.
- `upstream/main` is currently `ba0668b87fab6be24ef4ffd8c451c1616449a6e9`; `feature/mip-nlp-solver` does not currently contain that commit, so this PR intentionally targets the integration branch rather than rebasing it onto default.
- Because the base is non-default, GitHub may not auto-close #151 until this integration branch reaches the default branch.
